### PR TITLE
[tests] fix tests by adding testURL to jest configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "jest": {
     "setupFiles": [
       "<rootDir>/jest/globals.js"
-    ]
+    ],
+    "testURL": "http://localhost"
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
If you attempt to run `yarn test` you will receive the following:
```
$ yarn test
yarn test v0.27.5
$ TZ=America/New_York jest src
 FAIL  src/__tests__/bridgestream/exporter.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

 FAIL  src/__tests__/mocks/account.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

 FAIL  src/__tests__/models/account.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

 FAIL  src/__tests__/helpers/currencies.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

 FAIL  src/__tests__/bridgestream/importer.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

 FAIL  src/__tests__/helpers/account.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

 FAIL  src/__tests__/helpers/BigNumberToLocaleString.js
  ● Test suite failed to run

    SecurityError: localStorage is not available for opaque origins

      at Window.get localStorage [as localStorage] (node_modules/jsdom/lib/jsdom/browser/Window.js:257:15)
          at Array.forEach (<anonymous>)

Test Suites: 7 failed, 7 total
Tests:       0 total
Snapshots:   0 total
Time:        2.368s
Ran all test suites matching /src/i.
error Command failed with exit code 1.
```

To resolve this, you can set a `testURL` in the `jest` configuration.

Detail as to why is located here:
* https://github.com/jsdom/jsdom/issues/2304
* https://github.com/jsdom/jsdom/wiki/Don't-stuff-jsdom-globals-onto-the-Node-global

Following `jest` documentation here:
* https://jestjs.io/docs/en/configuration.html#testurl-string

Tests are happy now:
```
$ yarn test
yarn test v0.27.5
$ TZ=America/New_York jest src
 PASS  src/__tests__/bridgestream/importer.js
 PASS  src/__tests__/bridgestream/exporter.js
 PASS  src/__tests__/helpers/currencies.js
 PASS  src/__tests__/models/account.js
 PASS  src/__tests__/helpers/BigNumberToLocaleString.js
 PASS  src/__tests__/helpers/account.js
 PASS  src/__tests__/mocks/account.js

Test Suites: 7 passed, 7 total
Tests:       43 passed, 43 total
Snapshots:   11 passed, 11 total
Time:        5.85s, estimated 8s
Ran all test suites matching /src/i.
Done in 7.13s.
```

Found because I am working on a couple other patches but wanted the current tests to pass first.  :)