### PR TITLE
Update Bitcoin Cash scheme from `bch` to `bitcoincash`

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -191,7 +191,7 @@ const cryptocurrenciesById = {
     name: "Bitcoin Cash",
     managerAppName: "Bitcoin Cash",
     ticker: "BCH",
-    scheme: "bch",
+    scheme: "bitcoincash",
     color: "#3ca569",
     family: "bitcoin",
     ledgerExplorerId: "abc",


### PR DESCRIPTION
Following [Bitcoin Cash cashaddr specs](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md#prefix), the prefix for the currency is `bitcoincash`