### PR TITLE
Fix over-truncating amounts 0.5 or less away from the next power of 10

### DIFF
--- a/src/__tests__/helpers/BigNumberToLocaleString.js
+++ b/src/__tests__/helpers/BigNumberToLocaleString.js
@@ -27,6 +27,14 @@ test("toLocaleString to default maximumFractionDigits to 3", () => {
   expect(toLocaleString(BigNumber(9.99999))).toBe("10");
   expect(toLocaleString(BigNumber(111111.111111111))).toBe("111,111.111");
   expect(toLocaleString(BigNumber(0.999999999))).toBe("1");
+  expect(toLocaleString(BigNumber(9.5))).toBe("9.5");
+  expect(toLocaleString(BigNumber(9.9))).toBe("9.9");
+  expect(toLocaleString(BigNumber(99.6))).toBe("99.6");
+  expect(toLocaleString(BigNumber(99.8))).toBe("99.8");
+  expect(toLocaleString(BigNumber(999.7))).toBe("999.7");
+  expect(toLocaleString(BigNumber(999.9))).toBe("999.9");
+  expect(toLocaleString(BigNumber(999999.7))).toBe("999,999.7");
+  expect(toLocaleString(BigNumber(999999.9))).toBe("999,999.9");
 });
 
 test("toLocaleString minimumFractionDigits", () => {
@@ -42,6 +50,12 @@ test("toLocaleString minimumFractionDigits", () => {
   expect(
     toLocaleString(BigNumber(0.001), "en", { minimumFractionDigits: 1 })
   ).toBe("0.001");
+  expect(
+    toLocaleString(BigNumber(9.5), "en", { minimumFractionDigits: 1 })
+  ).toBe("9.5");
+  expect(
+    toLocaleString(BigNumber(9.6), "en", { minimumFractionDigits: 2 })
+  ).toBe("9.60");
   expect(
     toLocaleString(BigNumber(13.1), "en", { minimumFractionDigits: 3 })
   ).toBe("13.100");
@@ -109,8 +123,16 @@ test("toLocaleString minimumFractionDigits and maximumFractionDigits", () => {
       maximumFractionDigits: 5
     })
   ).toBe("0.0");
+  expect(
+    toLocaleString(BigNumber(9.7), "en", {
+      minimumFractionDigits: 1,
+      maximumFractionDigits: 1
+    })
+  ).toBe("9.7");
 
   expect(
-    toLocaleString(BigNumber('4.4444444444444444444411111111111111'), "en", { maximumFractionDigits: 20 })
+    toLocaleString(BigNumber("4.4444444444444444444411111111111111"), "en", {
+      maximumFractionDigits: 20
+    })
   ).toBe("4.44444444444444444444");
 });

--- a/src/helpers/currencies/BigNumberToLocaleString.js
+++ b/src/helpers/currencies/BigNumberToLocaleString.js
@@ -53,18 +53,16 @@ export const toLocaleString = (
   const maxDecimals = bn.toFormat(maximumFractionDigits);
   if (maximumFractionDigits !== minimumFractionDigits) {
     const minDecimals = bn.toFormat(minimumFractionDigits);
-    let i = maxDecimals.length - 1;
+    let i = maxDecimals.length;
     // cleanup useless '0's from the right until the minimumFractionDigits
     while (i > minDecimals.length) {
-      if (maxDecimals[i] === "0") {
-        i--;
-      } else if (maxDecimals[i] === format.decimalSeparator) {
-        i--;
+      if (maxDecimals[i - 1] !== "0") {
+        if (maxDecimals[i - 1] === format.decimalSeparator) {
+          i--;
+        }
         break; // we reach decimal. stop now.
-      } else {
-        i++; // we eat one character that we shouldn't. we stop there and roll it back (nb slice won't overflow)
-        break;
       }
+      i--;
     }
     return maxDecimals.slice(0, i);
   } else {


### PR DESCRIPTION
### Type

Bugfix

### Description

Fix a bug where, for an `amount` with `d` digits and `n` a number between `0.5` and `0.1`, if `amount + n` has `d + 1` digit, the last decimal is cut off. eg `9.8` gets truncated to `9.`

### Demo

Before:
![9 5 buggy](https://user-images.githubusercontent.com/13920153/44394775-4fc71980-a538-11e8-9269-fd3ad24c814f.gif)

After:
![9 5 fixed](https://user-images.githubusercontent.com/13920153/44394795-5eadcc00-a538-11e8-916f-0b6a85d59199.gif)

### Affected Ledger Live versions
All versions since 1.1.0