### PR TITLE
Fix Pirl coinType

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -704,7 +704,7 @@ const cryptocurrenciesById = {
   },
   pirl: {
     id: "pirl",
-    coinType: 3125659152,
+    coinType: 164,
     name: "Pirl",
     managerAppName: "Pirl",
     ticker: "PIRL",


### PR DESCRIPTION
Pirl coinType should be `164` based on slip44 rather than chain ID