### PR TITLE
countervalues: explicitely provide the network func (e.g. axios)

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@ledgerhq/live-common": "^3.8.0",
+    "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",
     "bignumber.js": "^7.2.1",
     "flow-bin": "^0.73.0",

--- a/demo/src/demos/Currencies/countervalues.js
+++ b/demo/src/demos/Currencies/countervalues.js
@@ -1,8 +1,10 @@
 // @flow
 
+import axios from "axios";
 import createCounterValues from "@ledgerhq/live-common/lib/countervalues";
 
 export default createCounterValues({
+  network: axios,
   log: (...args) => console.log(...args), // eslint-disable-line no-console
   getAPIBaseURL: () => window.LEDGER_CV_API,
   storeSelector: state => state.countervalues,

--- a/demo/src/demos/countervalue-direct/countervalues.js
+++ b/demo/src/demos/countervalue-direct/countervalues.js
@@ -1,5 +1,6 @@
 // @flow
 
+import axios from "axios";
 import createCounterValues from "@ledgerhq/live-common/lib/countervalues";
 import { pairsSelector } from "./reducers/markets";
 import { setExchangePairsAction } from "./actions/markets";
@@ -22,6 +23,7 @@ const addExtraPollingHooks = (schedulePoll, cancelPoll) => {
 };
 
 export default createCounterValues({
+  network: axios,
   log: (...args) => console.log(...args), // eslint-disable-line no-console
   getAPIBaseURL: () => window.LEDGER_CV_API,
   storeSelector: state => state.countervalues,

--- a/demo/src/demos/countervalue-intermediary/countervalues.js
+++ b/demo/src/demos/countervalue-intermediary/countervalues.js
@@ -1,5 +1,6 @@
 // @flow
 
+import axios from "axios";
 import createCounterValues from "@ledgerhq/live-common/lib/countervalues";
 import { pairsSelector } from "./reducers/app";
 import { setExchangePairsAction } from "./actions/app";
@@ -22,6 +23,7 @@ const addExtraPollingHooks = (schedulePoll, cancelPoll) => {
 };
 
 export default createCounterValues({
+  network: axios,
   log: (...args) => console.log(...args), // eslint-disable-line no-console
   getAPIBaseURL: () => window.LEDGER_CV_API,
   storeSelector: state => state.countervalues,

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "testURL": "http://localhost"
   },
   "dependencies": {
-    "axios": "^0.18.0",
     "bignumber.js": "^7.2.1",
     "invariant": "^2.2.2",
     "lodash": "^4.17.4",

--- a/scripts/listMarketPriceFor1USD.js
+++ b/scripts/listMarketPriceFor1USD.js
@@ -1,6 +1,7 @@
 // @flow
 /* eslint-disable no-console */
 
+// $FlowFixMe install axios yourself :D
 const axios = require("axios");
 const {
   listCryptoCurrencies,
@@ -46,7 +47,7 @@ function main() {
       currencies.forEach(c => {
         const rate =
           getRate(c.ticker, "USD") || btcRate * getRate(c.ticker, "BTC");
-        const price = formatCurrencyUnit(c.units[0], amount * 100 / rate);
+        const price = formatCurrencyUnit(c.units[0], (amount * 100) / rate);
         console.log(c.ticker + "\t" + price);
       });
     })

--- a/src/countervalues/types.js
+++ b/src/countervalues/types.js
@@ -50,6 +50,16 @@ export type CounterValuesState = {
 };
 
 export type Input<State> = {
+  // Provide a fetch-like (or axios like) method
+  // you can literally just give axios or fetch
+  network: ({
+    method: string,
+    url: string,
+    data?: any,
+    timeout?: number,
+    headers?: Object
+  }) => Promise<{ data: any }>,
+
   log?: (...args: *) => void,
 
   // example: () => "http://localhost:8088"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1039,14 +1039,6 @@ aws4@^1.6.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.7.0.tgz#d4d0e9b9dbfca77bf08eeb0a8a471550fe39e289"
   integrity sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==
 
-axios@^0.18.0:
-  version "0.18.0"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.18.0.tgz#32d53e4851efdc0a11993b6cd000789d70c05102"
-  integrity sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=
-  dependencies:
-    follow-redirects "^1.3.0"
-    is-buffer "^1.1.5"
-
 babel-cli@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-cli/-/babel-cli-6.26.0.tgz#502ab54874d7db88ad00b887a06383ce03d002f1"
@@ -3419,13 +3411,6 @@ flush-write-stream@^1.0.2:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
-
-follow-redirects@^1.3.0:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.5.0.tgz#234f49cf770b7f35b40e790f636ceba0c3a0ab77"
-  integrity sha512-fdrt472/9qQ6Kgjvb935ig6vJCuofpBUD14f9Vb+SLlm7xIe4Qva5gey8EKtv8lp7ahE1wilg3xL1znpVGtZIA==
-  dependencies:
-    debug "^3.1.0"
 
 for-in@^1.0.1, for-in@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
this allows to:
- remove axios dependency
- fit more in different projects (for instance Live desktop might want to add some version headers, mobile might use different timeouts, uniformization of network errors, fetch implementation instead of axios,...)


We'll do a major after this since it's a breaking change to provide the network.