### PR TITLE
Prevent index testnet currencies in currencies by ticker

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -1776,8 +1776,8 @@ for (let id in cryptocurrenciesById) {
   const c = cryptocurrenciesById[id];
   cryptocurrenciesById[c.id] = c;
   cryptocurrenciesByScheme[c.scheme] = c;
-  cryptocurrenciesByTicker[c.ticker] = c;
   if (!c.isTestnetFor) {
+    cryptocurrenciesByTicker[c.ticker] = c;
     prodCryptoArray.push(c);
   }
   cryptocurrenciesArray.push(c);


### PR DESCRIPTION
It was causing trouble when changing rate provider (e.g it was changing for eth_testnet instead of eth)

relatable: LL-483