### PR TITLE
Provide a fallback for accountsBtcBalance - Allows fix for LL-766 and LL-767

### DIFF
--- a/src/account.js
+++ b/src/account.js
@@ -258,7 +258,7 @@ type SortMethod = "name" | "balance";
 const sortMethod: { [_: SortMethod]: (SortAccountsParam) => string[] } = {
   balance: ({ accounts, accountsBtcBalance }) =>
     accounts
-      .map((a, i) => [a.id, accountsBtcBalance[i], a.name])
+      .map((a, i) => [a.id, accountsBtcBalance[i] || BigNumber(-1), a.name])
       .sort((a, b) => {
         const numOrder = a[1].minus(b[1]).toNumber();
         if (numOrder === 0) {


### PR DESCRIPTION
When we are unable to resolve a BTC value for ordering an account, think Posw, HCash, that inability breaks the ordering since we have a condition before the sorting stating `if (allRatesAvailable)`. Removing that condition causes a crash since the map in common relies on that value existing. Setting a fallback value fixes the sort again and places those accounts as if they had -1 balance.