### PR TITLE
Share more API code and also getting ready for v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/live-common",
-  "version": "5.0.0-beta.0",
+  "version": "5.0.0-beta.1",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/live-common",
-  "version": "4.14.1",
+  "version": "5.0.0-beta.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ledgerhq/live-common",
-  "version": "5.0.0-beta.1",
+  "version": "4.15.0-beta.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/src/api/Ethereum.js
+++ b/src/api/Ethereum.js
@@ -1,0 +1,114 @@
+// @flow
+import { BigNumber } from "bignumber.js";
+import type { CryptoCurrency } from "../types";
+import { LedgerAPINotAvailable } from "../errors";
+import network from "../network";
+import { blockchainBaseURL } from "./Ledger";
+
+export type Block = { height: number }; // TODO more fields actually
+
+export type Tx = {
+  hash: string,
+  received_at: string,
+  nonce: string,
+  value: number,
+  gas: number,
+  gas_price: number,
+  cumulative_gas_used: number,
+  gas_used: number,
+  from: string,
+  to: string,
+  input: string,
+  index: number,
+  block?: {
+    hash: string,
+    height: number,
+    time: string
+  },
+  confirmations: number
+};
+
+export type API = {
+  getTransactions: (
+    address: string,
+    blockHash: ?string
+  ) => Promise<{
+    truncated: boolean,
+    txs: Tx[]
+  }>,
+  getCurrentBlock: () => Promise<Block>,
+  getAccountNonce: (address: string) => Promise<number>,
+  broadcastTransaction: (signedTransaction: string) => Promise<string>,
+  getAccountBalance: (address: string) => Promise<BigNumber>
+};
+
+export const apiForCurrency = (currency: CryptoCurrency): API => {
+  const baseURL = blockchainBaseURL(currency);
+  if (!baseURL) {
+    throw new LedgerAPINotAvailable(`LedgerAPINotAvailable ${currency.id}`, {
+      currencyName: currency.name
+    });
+  }
+  return {
+    async getTransactions(address, blockHash) {
+      let { data } = await network({
+        method: "GET",
+        url: `${baseURL}/addresses/${address}/transactions`,
+        params:
+          currency.ledgerExplorerVersion === "v2"
+            ? {
+                blockHash,
+                noToken: 1
+              }
+            : {
+                batch_size: 2000,
+                no_token: true,
+                block_hash: blockHash,
+                partial: true
+              }
+      });
+      // v3 have a bug that still includes the tx of the paginated block_hash, we're cleaning it up
+      if (blockHash && currency.ledgerExplorerVersion === "v3") {
+        data = {
+          ...data,
+          txs: data.txs.filter(tx => !tx.block || tx.block.hash !== blockHash)
+        };
+      }
+      return data;
+    },
+
+    async getCurrentBlock() {
+      const { data } = await network({
+        method: "GET",
+        url: `${baseURL}/blocks/current`
+      });
+      return data;
+    },
+
+    async getAccountNonce(address) {
+      const { data } = await network({
+        method: "GET",
+        url: `${baseURL}/addresses/${address}/nonce`
+      });
+      return data[0].nonce;
+    },
+
+    async broadcastTransaction(tx) {
+      const { data } = await network({
+        method: "POST",
+        url: `${baseURL}/transactions/send`,
+        data: { tx }
+      });
+      return data.result;
+    },
+
+    async getAccountBalance(address) {
+      const { data } = await network({
+        method: "GET",
+        url: `${baseURL}/addresses/${address}/balance`
+      });
+      // FIXME precision lost here. nothing we can do easily
+      return BigNumber(data[0].balance);
+    }
+  };
+};

--- a/src/api/Fees.js
+++ b/src/api/Fees.js
@@ -1,0 +1,29 @@
+// @flow
+import invariant from "invariant";
+import type { CryptoCurrency } from "../types";
+import { FeeEstimationFailed } from "../errors";
+import { makeLRUCache } from "../cache";
+import { blockchainBaseURL } from "./Ledger";
+import network from "../network";
+
+export type Fees = {
+  [_: string]: number
+};
+
+export const getEstimatedFees = makeLRUCache(
+  async (currency: CryptoCurrency): Promise<Fees> => {
+    const baseURL = blockchainBaseURL(currency);
+    invariant(baseURL, `Fees for ${currency.id} are not supported`);
+    const { data, status } = await network({
+      method: "GET",
+      url: `${baseURL}/fees`
+    });
+    if (data) {
+      return data;
+    }
+    throw new FeeEstimationFailed(`FeeEstimationFailed ${status}`, {
+      httpStatus: status
+    });
+  },
+  c => c.id
+);

--- a/src/api/FeesBitcoin.js
+++ b/src/api/FeesBitcoin.js
@@ -1,0 +1,51 @@
+// @flow
+import React from "react";
+import { BigNumber } from "bignumber.js";
+import { Trans } from "react-i18next";
+import type { CryptoCurrency } from "../types";
+import { getEstimatedFees } from "./Fees";
+
+export type FeeItem = {
+  key: string,
+  label: React$Node,
+  blockCount: number,
+  feePerByte: BigNumber
+};
+
+export type FeeItems = {
+  items: FeeItem[],
+  defaultFeePerByte: BigNumber
+};
+
+export const labels = {
+  "1": <Trans i18nKey="fees.speed.high" />,
+  "3": <Trans i18nKey="fees.speed.standard" />,
+  "6": <Trans i18nKey="fees.speed.low" />
+};
+
+export const defaultBlockCount = 3;
+
+export const getFeeItems = async (
+  currency: CryptoCurrency
+): Promise<FeeItems> => {
+  let items = [];
+  const fees = await getEstimatedFees(currency);
+  let defaultFeePerByte = BigNumber(0);
+  for (const key of Object.keys(fees)) {
+    const feePerByte = BigNumber(Math.ceil(fees[key] / 1000));
+    const blockCount = parseInt(key, 10);
+    if (blockCount === defaultBlockCount) defaultFeePerByte = feePerByte;
+    if (!isNaN(blockCount) && !feePerByte.isNaN()) {
+      items.push({
+        key,
+        label: labels[blockCount] || (
+          <Trans i18nKey="fees.speed.blocks" values={{ blockCount }} />
+        ),
+        blockCount,
+        feePerByte
+      });
+    }
+  }
+  items = items.sort((a, b) => a.blockCount - b.blockCount);
+  return { items, defaultFeePerByte };
+};

--- a/src/api/Ledger.js
+++ b/src/api/Ledger.js
@@ -1,0 +1,18 @@
+// @flow
+import type { Currency } from "../types";
+
+const ledgerExplorersByVersion = {
+  v2: "https://explorers.api.live.ledger.com/blockchain/v2/$ledgerExplorerId",
+  v3: "https://$ledgerExplorerId.explorers.prod.aws.ledger.fr/blockchain/v3"
+};
+
+export const blockchainBaseURL = ({
+  ledgerExplorerId,
+  ledgerExplorerVersion
+}: Currency): ?string =>
+  ledgerExplorerId && ledgerExplorerVersion
+    ? (ledgerExplorersByVersion[ledgerExplorerVersion] || "").replace(
+        "$ledgerExplorerId",
+        ledgerExplorerId
+      )
+    : null;

--- a/src/api/Ledger.js
+++ b/src/api/Ledger.js
@@ -3,7 +3,7 @@ import type { Currency } from "../types";
 
 const ledgerExplorersByVersion = {
   v2: "https://explorers.api.live.ledger.com/blockchain/v2/$ledgerExplorerId",
-  v3: "https://$ledgerExplorerId.explorers.prod.aws.ledger.fr/blockchain/v3"
+  v3: "http://$ledgerExplorerId.explorers.prod.aws.ledger.fr/blockchain/v3"
 };
 
 export const blockchainBaseURL = ({

--- a/src/api/Ripple.js
+++ b/src/api/Ripple.js
@@ -1,0 +1,49 @@
+// @flow
+import { BigNumber } from "bignumber.js";
+import {
+  parseCurrencyUnit,
+  getCryptoCurrencyById,
+  formatCurrencyUnit
+} from "../currencies";
+
+const rippleUnit = getCryptoCurrencyById("ripple").units[0];
+
+export const defaultEndpoint = "wss://s2.ripple.com";
+
+export const apiForEndpointConfig = (
+  RippleAPI: *, // you must provide {RippleAPI} from "ripple-lib"
+  endpointConfig: ?string = null
+) => {
+  const server = endpointConfig || defaultEndpoint;
+  const api = new RippleAPI({ server });
+  api.on("error", (errorCode, errorMessage) => {
+    console.warn(`Ripple API error: ${errorCode}: ${errorMessage}`);
+  });
+  return api;
+};
+
+export const parseAPIValue = (value: string) =>
+  parseCurrencyUnit(rippleUnit, value);
+
+export const parseAPICurrencyObject = ({
+  currency,
+  value
+}: {
+  currency: string,
+  value: string
+}) => {
+  if (currency !== "XRP") {
+    console.warn(`RippleJS: attempt to parse unknown currency ${currency}`);
+    return BigNumber(0);
+  }
+  return parseAPIValue(value);
+};
+
+export const formatAPICurrencyXRP = (amount: BigNumber) => {
+  const value = formatCurrencyUnit(rippleUnit, amount, {
+    showAllDigits: true,
+    disableRounding: true,
+    useGrouping: false
+  });
+  return { currency: "XRP", value };
+};

--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -722,8 +722,10 @@ const cryptocurrenciesById = {
     color: "#0ebdcd",
     units: ethereumUnits("ether", "ETH"),
     family: "ethereum",
-    ledgerExplorerId: "eth-mainnet",
-    ledgerExplorerVersion: "v3",
+    // ledgerExplorerId: "eth-mainnet",
+    // ledgerExplorerVersion: "v3",
+    ledgerExplorerId: "eth",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 15,
     ethereumLikeInfo: {
       chainId: 1

--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -11,7 +11,7 @@
  * ticker: check this is the one used in exchanges (BTW our countervalues api will only support the new coin until we do a redeployment to support it (whitelist))
  * scheme is generally the id
  * color: is the dominant color of the currency logo, we will color the logo svg with it.
- * ledgerExplorerId: if any, is Ledger's internal explorer id (backend explorer team).
+ * ledgerExplorerId and ledgerExplorerVersion: only set it if it exists, is Ledger's internal explorer id (backend explorer team).
  * managerAppName: if any, is the exact name of the related Ledger's app in LL Manager.
  * blockAvgTime: the average time between 2 blocks. (check online / on explorers)
  * scheme: the well accepted unique id to use in uri scheme (e.g. bitcoin:...)
@@ -262,6 +262,7 @@ const cryptocurrenciesById = {
     supportsSegwit: true,
     family: "bitcoin",
     ledgerExplorerId: "btc",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 15 * 60,
     bitcoinLikeInfo: {
       P2PKH: 0,
@@ -280,6 +281,7 @@ const cryptocurrenciesById = {
     color: "#3ca569",
     family: "bitcoin",
     ledgerExplorerId: "abc",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 15 * 60,
     bitcoinLikeInfo: {
       P2PKH: 0,
@@ -325,6 +327,7 @@ const cryptocurrenciesById = {
     supportsSegwit: true,
     family: "bitcoin",
     ledgerExplorerId: "btg",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 15 * 60,
     bitcoinLikeInfo: {
       P2PKH: 38,
@@ -506,6 +509,7 @@ const cryptocurrenciesById = {
     color: "#000000", // FIXME
     family: "bitcoin",
     ledgerExplorerId: "club",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 140,
     bitcoinLikeInfo: {
       P2PKH: 28,
@@ -535,6 +539,7 @@ const cryptocurrenciesById = {
     color: "#0e76aa",
     family: "bitcoin",
     ledgerExplorerId: "dash",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 76,
@@ -583,6 +588,7 @@ const cryptocurrenciesById = {
     ],
     family: "bitcoin",
     ledgerExplorerId: "dcr",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 15 * 60,
     bitcoinLikeInfo: {
       P2PKH: 0x073f,
@@ -601,6 +607,7 @@ const cryptocurrenciesById = {
     family: "bitcoin",
     supportsSegwit: true,
     ledgerExplorerId: "dgb",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 60,
     bitcoinLikeInfo: {
       P2PKH: 30,
@@ -630,6 +637,7 @@ const cryptocurrenciesById = {
     color: "#65d196",
     family: "bitcoin",
     ledgerExplorerId: "doge",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 60,
     bitcoinLikeInfo: {
       P2PKH: 30,
@@ -714,7 +722,8 @@ const cryptocurrenciesById = {
     color: "#0ebdcd",
     units: ethereumUnits("ether", "ETH"),
     family: "ethereum",
-    ledgerExplorerId: "eth",
+    ledgerExplorerId: "eth-mainnet",
+    ledgerExplorerVersion: "v3",
     blockAvgTime: 15,
     ethereumLikeInfo: {
       chainId: 1
@@ -732,6 +741,7 @@ const cryptocurrenciesById = {
     units: ethereumUnits("ETC", "ETC"),
     family: "ethereum",
     ledgerExplorerId: "ethc",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 15,
     ethereumLikeInfo: {
       chainId: 61
@@ -872,6 +882,7 @@ const cryptocurrenciesById = {
     color: "#56438c",
     family: "bitcoin",
     ledgerExplorerId: "hsr",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 40,
@@ -937,6 +948,7 @@ const cryptocurrenciesById = {
     color: "#326464",
     family: "bitcoin",
     ledgerExplorerId: "kmd",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 60,
     bitcoinLikeInfo: {
       P2PKH: 60,
@@ -967,6 +979,7 @@ const cryptocurrenciesById = {
     supportsSegwit: true,
     family: "bitcoin",
     ledgerExplorerId: "ltc",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 5 * 60,
     bitcoinLikeInfo: {
       P2PKH: 48,
@@ -1230,6 +1243,7 @@ const cryptocurrenciesById = {
     color: "#3cb054",
     family: "bitcoin",
     ledgerExplorerId: "ppc",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 450,
     bitcoinLikeInfo: {
       P2PKH: 55,
@@ -1277,6 +1291,7 @@ const cryptocurrenciesById = {
     color: "#46385d",
     family: "bitcoin",
     ledgerExplorerId: "pivx",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 30,
@@ -1324,6 +1339,7 @@ const cryptocurrenciesById = {
     color: "#000000", // FIXME
     family: "bitcoin",
     ledgerExplorerId: "posw",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 60,
     bitcoinLikeInfo: {
       P2PKH: 55,
@@ -1353,6 +1369,7 @@ const cryptocurrenciesById = {
     color: "#2e9ad0",
     family: "bitcoin",
     ledgerExplorerId: "qtum",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 2 * 60,
     bitcoinLikeInfo: {
       P2PKH: 58,
@@ -1408,6 +1425,7 @@ const cryptocurrenciesById = {
     supportsSegwit: true,
     family: "bitcoin",
     ledgerExplorerId: "xsn",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 60,
     bitcoinLikeInfo: {
       P2PKH: 76,
@@ -1437,6 +1455,7 @@ const cryptocurrenciesById = {
     color: "#1382c6",
     family: "bitcoin",
     ledgerExplorerId: "strat",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 63,
@@ -1466,6 +1485,7 @@ const cryptocurrenciesById = {
     color: "#000000",
     family: "bitcoin",
     ledgerExplorerId: "xst",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 62,
@@ -1621,6 +1641,7 @@ const cryptocurrenciesById = {
     supportsSegwit: true,
     family: "bitcoin",
     ledgerExplorerId: "vtc",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 71,
@@ -1651,6 +1672,7 @@ const cryptocurrenciesById = {
     supportsSegwit: true,
     family: "bitcoin",
     ledgerExplorerId: "via",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 24,
     bitcoinLikeInfo: {
       P2PKH: 71,
@@ -1716,6 +1738,7 @@ const cryptocurrenciesById = {
     color: "#3790ca",
     family: "bitcoin",
     ledgerExplorerId: "zec",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 0x1cb8,
@@ -1763,6 +1786,7 @@ const cryptocurrenciesById = {
     color: "#152f5c",
     family: "bitcoin",
     ledgerExplorerId: "zen",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 150,
     bitcoinLikeInfo: {
       P2PKH: 0x2089,
@@ -1797,6 +1821,7 @@ const cryptocurrenciesById = {
     isTestnetFor: "bitcoin",
     family: "bitcoin",
     ledgerExplorerId: "btc_testnet",
+    ledgerExplorerVersion: "v2",
     blockAvgTime: 15 * 60,
     bitcoinLikeInfo: {
       P2PKH: 111,
@@ -1815,7 +1840,8 @@ const cryptocurrenciesById = {
     units: ethereumUnits("ether", "ETH").map(makeTestnetUnit),
     isTestnetFor: "ethereum",
     family: "ethereum",
-    ledgerExplorerId: "eth_ropsten",
+    ledgerExplorerId: "eth-ropsten",
+    ledgerExplorerVersion: "v3",
     blockAvgTime: 15,
     ethereumLikeInfo: {
       chainId: 3 // ropsten

--- a/src/types/currencies.js
+++ b/src/types/currencies.js
@@ -40,6 +40,7 @@ export type CryptoCurrency = CurrencyCommon & {
   color: string,
   family: string,
   ledgerExplorerId?: string,
+  ledgerExplorerVersion?: string,
   blockAvgTime?: number, // in seconds
   supportsSegwit?: boolean,
   // if defined this coin is a testnet for another crypto (id)};


### PR DESCRIPTION
- introduce ledgerExplorerVersion in currency we'll use later to migrate Ethereum API to v3.
- all src/api code that exists on mobile & desktop will now use the new files imported.