### PR TITLE
NEW: Energi (NRG) support

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -650,6 +650,46 @@ const cryptocurrenciesById = {
     ],
     txExplorers: []
   },
+  energi: {
+    id: "energi",
+    coinType: 9797,
+    name: "Energi",
+    managerAppName: "Energi",
+    ticker: "NRG",
+    scheme: "energi",
+    color: "#0bc98d",
+    family: "bitcoin",
+    //ledgerExplorerId: "energi",
+    //ledgerExplorerVersion: "v2",
+    blockAvgTime: 60,
+    bitcoinLikeInfo: {
+      P2PKH: 33,
+      P2SH: 53
+    },
+    units: [
+      {
+        name: "energi",
+        code: "NRG",
+        magnitude: 8
+      },
+      {
+        name: "milli-energi",
+        code: "mNRG",
+        magnitude: 5
+      },
+      {
+        name: "micro-energi",
+        code: "μNRG",
+        magnitude: 2
+      },
+      {
+        name: "atoms",
+        code: "atom",
+        magnitude: 0
+      }
+    ],
+    txExplorers: ["https://explorer.energi.network/tx/$hash"]
+  },
   eos: {
     id: "eos",
     coinType: 194,

--- a/src/data/icons/react/energi.js
+++ b/src/data/icons/react/energi.js
@@ -1,0 +1,18 @@
+//@flow
+import React from "react";
+
+type Props = {
+  size: number,
+  color: string
+};
+
+export default function Energi({ size, color = "currentColor" }: Props) {
+  return (
+    <svg viewBox="0 0 256 256" width={size} height={size}>
+      <path
+        fill={color}
+        d="M128 21.934L21.934 128 128 234.066 234.066 128l-24.042-24.042-83.438 83.439L67.189 128l58.69-58.69 17.677 17.678-40.305 40.305 23.335 23.334 65.054-65.053z"
+      />
+    </svg>
+  );
+}

--- a/src/data/icons/react/index.js
+++ b/src/data/icons/react/index.js
@@ -10,6 +10,7 @@ export { default as dash } from "./dash";
 export { default as decred } from "./decred";
 export { default as digibyte } from "./digibyte";
 export { default as dogecoin } from "./dogecoin";
+export { default as energi } from "./energi";
 export { default as ethereumClassic } from "./ethereumClassic";
 export { default as expanse } from "./expanse";
 export { default as hcash } from "./hcash";

--- a/src/data/icons/reactNative/energi.js
+++ b/src/data/icons/reactNative/energi.js
@@ -1,0 +1,19 @@
+//@flow
+import React from "react";
+import Svg, { Path } from "react-native-svg";
+
+type Props = {
+  size: number,
+  color: string
+};
+
+export default function Energi({ size, color }: Props) {
+  return (
+    <Svg viewBox="0 0 256 256" width={size} height={size}>
+      <Path
+        fill={color}
+        d="M128 21.934L21.934 128 128 234.066 234.066 128l-24.042-24.042-83.438 83.439L67.189 128l58.69-58.69 17.677 17.678-40.305 40.305 23.335 23.334 65.054-65.053z"
+      />
+    </Svg>
+  );
+}

--- a/src/data/icons/reactNative/index.js
+++ b/src/data/icons/reactNative/index.js
@@ -10,6 +10,7 @@ export { default as dash } from "./dash";
 export { default as decred } from "./decred";
 export { default as digibyte } from "./digibyte";
 export { default as dogecoin } from "./dogecoin";
+export { default as energi } from "./energi";
 export { default as ethereumClassic } from "./ethereumClassic";
 export { default as expanse } from "./expanse";
 export { default as hcash } from "./hcash";

--- a/src/data/icons/svg/energi.svg
+++ b/src/data/icons/svg/energi.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="32" height="32">
+  <path
+    fill="#0bc98d"
+    d="M53 53 V203 H203 V53 H169 V171 H85 V88 H110 V145 H143 V53 Z"
+    transform="rotate(45 128 128)"
+    />
+</svg>


### PR DESCRIPTION
Performed yarn-based static analysis and tests.

Smoke tested with local Live Desktop: it's possible to select Energi for account creation.

However, full testing with Live Desktop was not possible due to unclear inability to synchronize accounts with device even for Bitcoin before all the changes.

Ledger's explorer configuration is temporary commented out.