### PR TITLE
Remove hardcoded version (was for NanoX initial protos)

### DIFF
--- a/src/hw/getDeviceInfo.js
+++ b/src/hw/getDeviceInfo.js
@@ -27,10 +27,9 @@ export default async (transport: Transport<*>): Promise<DeviceInfo> => {
   const isBootloader = (targetId & 0xf0000000) !== 0x30000000;
   const majMin = parsedVersion[1];
   const patch = parsedVersion[2] || ".0";
-  const fullVersion =
-    targetId === 0x33000004
-      ? "1.0"
-      : `${majMin}${patch}${providerName ? `-${providerName}` : ""}`;
+  const fullVersion = `${majMin}${patch}${
+    providerName ? `-${providerName}` : ""
+  }`;
   return {
     targetId,
     seVersion: majMin + patch,


### PR DESCRIPTION
Before the NanoX CES proto, the older protos used to not return proper versions, it was containing a git hash, and we had to do this hack of always returning `"1.0"`.
The new devices (the CES ones) are now at version `1.0.0` and this code change will make it properly returning this version.

**Important:** after this PR merged, we will need manager to support both the former 1.0 and the new 1.0.0.