### PR TITLE
LL-1063 Currency termination

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -16,7 +16,7 @@
  * blockAvgTime: the average time between 2 blocks. (check online / on explorers)
  * scheme: the well accepted unique id to use in uri scheme (e.g. bitcoin:...)
  * units: specify the coin different units. There MUST be at least one. convention: it is desc ordered by magnitude, the last unit is the most divisible unit (e.g. satoshi)
- *
+ * terminated: Present when we no longer support this specific coin.
  * Specific cases:
  *
  * if it's a testnet coin, use isTestnetFor field. testnet MUST only be added if we actually support it at ledger (in our explorer api)
@@ -877,10 +877,7 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
         magnitude: 0
       }
     ],
-    txExplorers: ["http://explorer.h.cash/tx/$hash"],
-    terminated: {
-      url: "#"
-    }
+    txExplorers: ["http://explorer.h.cash/tx/$hash"]
   },
   icon: {
     id: "icon",
@@ -1335,10 +1332,7 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
         magnitude: 0
       }
     ],
-    txExplorers: [],
-    terminated: {
-      url: "#"
-    }
+    txExplorers: []
   },
   qtum: {
     id: "qtum",

--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -94,7 +94,7 @@ const ethereumUnits = (name, code) => [
   }
 ];
 
-const cryptocurrenciesById = {
+const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
   aeternity: {
     id: "aeternity",
     coinType: 457,
@@ -877,7 +877,10 @@ const cryptocurrenciesById = {
         magnitude: 0
       }
     ],
-    txExplorers: ["http://explorer.h.cash/tx/$hash"]
+    txExplorers: ["http://explorer.h.cash/tx/$hash"],
+    terminated: {
+      url: "#"
+    }
   },
   icon: {
     id: "icon",
@@ -1332,7 +1335,10 @@ const cryptocurrenciesById = {
         magnitude: 0
       }
     ],
-    txExplorers: []
+    txExplorers: [],
+    terminated: {
+      url: "#"
+    }
   },
   qtum: {
     id: "qtum",

--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -877,7 +877,11 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
         magnitude: 0
       }
     ],
-    txExplorers: ["http://explorer.h.cash/tx/$hash"]
+    txExplorers: ["http://explorer.h.cash/tx/$hash"],
+    terminated: {
+      link:
+        "https://support.ledger.com/hc/en-us/articles/115003917133"
+    }
   },
   icon: {
     id: "icon",
@@ -1332,7 +1336,11 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
         magnitude: 0
       }
     ],
-    txExplorers: []
+    txExplorers: [],
+    terminated: {
+      link:
+        "https://support.ledger.com/hc/en-us/articles/115005175309"
+    }
   },
   qtum: {
     id: "qtum",

--- a/src/types/currencies.js
+++ b/src/types/currencies.js
@@ -63,7 +63,10 @@ export type CryptoCurrency = CurrencyCommon & {
   ethereumLikeInfo?: {
     chainId: number
   },
-  txExplorers: string[]
+  txExplorers: string[],
+  terminated?: {
+    url: string
+  }
 };
 
 export type Currency = FiatCurrency | CryptoCurrency | TokenCurrency;

--- a/src/types/currencies.js
+++ b/src/types/currencies.js
@@ -65,7 +65,7 @@ export type CryptoCurrency = CurrencyCommon & {
   },
   txExplorers: string[],
   terminated?: {
-    url: string
+    link: string
   }
 };
 


### PR DESCRIPTION
Added the preliminary version of changes to `CryptoCurrency` type, used to determine whether a currency is to be disabled for install, show a warning, etc. When we want to mark a crypto as terminated we need to modify `cryptocurrencies.js` and add the appropriate `terminated` field.