### PR TITLE
Split one countervalue call per rate to fetch

### DIFF
--- a/demo/src/demos/countervalue-direct/reducers/markets.js
+++ b/demo/src/demos/countervalue-direct/reducers/markets.js
@@ -1,7 +1,8 @@
 // @flow
 import {
   getCryptoCurrencyById,
-  getFiatCurrencyByTicker
+  getFiatCurrencyByTicker,
+  listCryptoCurrencies
 } from "@ledgerhq/live-common/lib/currencies";
 import type { Currency } from "@ledgerhq/live-common/lib/types";
 import { createSelector } from "reselect";
@@ -12,14 +13,16 @@ export type State = Array<{
   exchange: ?string
 }>;
 
+const bitcoin = getCryptoCurrencyById("bitcoin");
+
 const initialState: State = [
   {
-    from: getCryptoCurrencyById("bitcoin"),
+    from: bitcoin,
     to: getFiatCurrencyByTicker("USD"),
     exchange: "KRAKEN"
   },
   {
-    from: getCryptoCurrencyById("bitcoin"),
+    from: bitcoin,
     to: getFiatCurrencyByTicker("EUR"),
     exchange: null
   },
@@ -32,7 +35,12 @@ const initialState: State = [
     from: getCryptoCurrencyById("litecoin"),
     to: getCryptoCurrencyById("bitcoin"),
     exchange: null
-  }
+  },
+  ...listCryptoCurrencies().map(from => ({
+    from,
+    to: bitcoin,
+    exchange: null
+  }))
 ];
 
 const reducers = {
@@ -64,12 +72,15 @@ export default (state: State = initialState, action: *) => {
 
 export const marketsSelector = (state: *): State => state.markets;
 
-export const pairsSelector = createSelector(marketsSelector, (state: State) => {
-  const array = [];
-  for (const { from, to, exchange } of state) {
-    if (from && to) {
-      array.push({ from, to, exchange });
+export const pairsSelector = createSelector(
+  marketsSelector,
+  (state: State) => {
+    const array = [];
+    for (const { from, to, exchange } of state) {
+      if (from && to) {
+        array.push({ from, to, exchange });
+      }
     }
+    return array;
   }
-  return array;
-});
+);

--- a/src/countervalues/index.js
+++ b/src/countervalues/index.js
@@ -20,6 +20,7 @@ import type {
   RatesMap,
   PollAPIPair
 } from "./types";
+import network from "../network";
 
 type PollingProviderOwnProps = {
   children: React$Element<*>,
@@ -56,7 +57,6 @@ export const formatCounterValueDay = (d: Date) =>
 
 // This do one big query to fetch everything
 export const getDailyRatesAllInOnce = async (
-  network: *,
   getAPIBaseURL: () => string,
   pairs: PollAPIPair[]
 ) => {
@@ -72,7 +72,6 @@ export const getDailyRatesAllInOnce = async (
 
 // This do one query per rate (lighter query)
 export const getDailyRatesSplitPerRate = async (
-  network: *,
   getAPIBaseURL: () => string,
   pairs: PollAPIPair[]
 ) => {
@@ -102,7 +101,6 @@ function createCounterValues<State>({
   maximumDays,
   addExtraPollingHooks,
   log,
-  network,
   getDailyRatesImplementation
 }: Input<State>): Module<State> {
   type Poll = () => (Dispatch<*>, () => State) => Promise<*>;
@@ -386,7 +384,7 @@ function createCounterValues<State>({
       pairs.push(pair);
     });
     if (pairs.length === 0) return;
-    const data = await getDailyRates(network, getAPIBaseURL, pairs);
+    const data = await getDailyRates(getAPIBaseURL, pairs);
     if (data && typeof data === "object") {
       const ev: PollAction = { type: POLL, data };
       dispatch(ev);

--- a/src/countervalues/types.js
+++ b/src/countervalues/types.js
@@ -49,19 +49,7 @@ export type CounterValuesState = {
   rates: RatesMap
 };
 
-export type Network = ({
-  method: string,
-  url: string,
-  data?: any,
-  timeout?: number,
-  headers?: Object
-}) => Promise<{ data: any }>;
-
 export type Input<State> = {
-  // Provide a fetch-like (or axios like) method
-  // you can literally just give axios or fetch
-  network: Network,
-
   log?: (...args: *) => void,
 
   // example: () => "http://localhost:8088"
@@ -103,7 +91,6 @@ export type Input<State> = {
   ) => () => void,
 
   getDailyRatesImplementation?: (
-    network: Network,
     getAPIBaseURL: () => string,
     pairs: PollAPIPair[]
   ) => Promise<mixed>

--- a/src/countervalues/types.js
+++ b/src/countervalues/types.js
@@ -49,16 +49,18 @@ export type CounterValuesState = {
   rates: RatesMap
 };
 
+export type Network = ({
+  method: string,
+  url: string,
+  data?: any,
+  timeout?: number,
+  headers?: Object
+}) => Promise<{ data: any }>;
+
 export type Input<State> = {
   // Provide a fetch-like (or axios like) method
   // you can literally just give axios or fetch
-  network: ({
-    method: string,
-    url: string,
-    data?: any,
-    timeout?: number,
-    headers?: Object
-  }) => Promise<{ data: any }>,
+  network: Network,
 
   log?: (...args: *) => void,
 
@@ -98,7 +100,20 @@ export type Input<State> = {
   addExtraPollingHooks?: (
     schedulePoll: (ms: number) => void,
     cancelPoll: () => void
-  ) => () => void
+  ) => () => void,
+
+  getDailyRatesImplementation?: (
+    network: Network,
+    getAPIBaseURL: () => string,
+    pairs: PollAPIPair[]
+  ) => Promise<mixed>
+};
+
+export type PollAPIPair = {
+  from: string,
+  to: string,
+  exchange?: string,
+  afterDay?: string
 };
 
 export type Exchange = {


### PR DESCRIPTION
This should address current issues with countervalues API.
Ledger Live do one too big query that fetches all rates in once. The query is sometimes too big and the API returns a HTTP 500 in that case, making the live displaying a non available countervalues and placeholder graphs.

In this implementation, one HTTP query will be done for each rate to fetch. It will be more scalable in the future (erc20, hourly rate,...)