### PR TITLE
WIP libcore encryption

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -29,7 +29,8 @@ const envParsers = {
   BASE_SOCKET_URL: stringParser,
   EXPLORER_V2: stringParser,
   EXPLORER_V3: stringParser,
-  EXPERIMENTAL_EXPLORERS: boolParser
+  EXPERIMENTAL_EXPLORERS: boolParser,
+  LIBCORE_PASSWORD: stringParser
 };
 
 // This define the default values
@@ -45,7 +46,8 @@ const defaults: $ObjMap<EnvParsers, ExtractEnvValue> = {
     "https://explorers.api.live.ledger.com/blockchain/v2/$ledgerExplorerId",
   EXPLORER_V3:
     "http://$ledgerExplorerId.explorers.prod.aws.ledger.fr/blockchain/v3",
-  EXPERIMENTAL_EXPLORERS: false
+  EXPERIMENTAL_EXPLORERS: false,
+  LIBCORE_PASSWORD: ""
 };
 
 // private local state

--- a/src/libcore/types.js
+++ b/src/libcore/types.js
@@ -21,6 +21,7 @@ declare class CoreWalletPool {
     config: CoreDynamicObject
   ): Promise<CoreWallet>;
   freshResetAll(): Promise<void>;
+  changePassword(oldPassword: string, newPassword: string): Promise<void>;
 }
 
 declare class CoreWallet {

--- a/test/package.json
+++ b/test/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@ledgerhq/hw-transport-node-hid": "^4.46.0",
-    "@ledgerhq/ledger-core": "2.1.0",
+    "@ledgerhq/ledger-core": "2.2.1-rc",
     "@ledgerhq/live-common": "file:..",
     "axios": "^0.18.0",
     "babel-polyfill": "^6.26.0",

--- a/test/src/examples/changePassword.js
+++ b/test/src/examples/changePassword.js
@@ -1,0 +1,24 @@
+// @flow
+/* eslint-disable no-console */
+
+import "babel-polyfill";
+import "../live-common-setup";
+import "../implement-libcore";
+
+import { withLibcore } from "@ledgerhq/live-common/lib/libcore/access";
+import { setEnv } from "@ledgerhq/live-common/lib/env";
+
+if (process.argv.length !== 4) {
+  console.error(
+    `Usage: ${process.argv[0]} ${process.argv[1]} <oldPassword> <newPassword>`
+  );
+  process.exit(1);
+}
+
+const oldPassword = process.argv[2];
+const newPassword = process.argv[3];
+
+setEnv("LIBCORE_PASSWORD", oldPassword);
+withLibcore(core =>
+  core.getPoolInstance().changePassword(oldPassword, newPassword)
+);

--- a/test/src/implement-libcore.js
+++ b/test/src/implement-libcore.js
@@ -3,6 +3,7 @@
 
 import invariant from "invariant";
 import network from "axios";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
 import { deserializeError, serializeError } from "@ledgerhq/errors/lib/helpers";
 import { setLoadCoreImplementation } from "@ledgerhq/live-common/lib/libcore/access";
 import type {
@@ -150,7 +151,8 @@ const NJSLogPrinter = new lib.NJSLogPrinter({
 });
 
 const NJSRandomNumberGenerator = new lib.NJSRandomNumberGenerator({
-  getRandomBytes: size => crypto.randomBytes(size),
+  getRandomBytes: size =>
+    Array.from(Buffer.from(crypto.randomBytes(size), "hex")),
   getRandomInt: () => Math.random() * MAX_RANDOM,
   getRandomLong: () => Math.random() * MAX_RANDOM * MAX_RANDOM
 });
@@ -186,7 +188,7 @@ const instanciateWalletPool = ({ dbPath }) => {
 
   walletPoolInstance = new lib.NJSWalletPool(
     "ledger_live_common",
-    "",
+    getEnv("LIBCORE_PASSWORD"),
     NJSHttpClient,
     NJSWebSocketClient,
     NJSPathResolver,

--- a/test/src/live-common-setup.js
+++ b/test/src/live-common-setup.js
@@ -1,9 +1,12 @@
 // @flow
 import axios from "axios";
+import { setEnvUnsafe } from "@ledgerhq/live-common/lib/env";
 import { setNetwork } from "@ledgerhq/live-common/lib/network";
 import TransportNodeHid from "@ledgerhq/hw-transport-node-hid";
 import { registerTransportModule } from "@ledgerhq/live-common/lib/hw";
 import { retry } from "@ledgerhq/live-common/lib/promise";
+
+for (const k in process.env) setEnvUnsafe(k, process.env[k]);
 
 setNetwork(axios);
 

--- a/test/yarn.lock
+++ b/test/yarn.lock
@@ -445,16 +445,16 @@
     "@ledgerhq/errors" "^4.48.0"
     events "^3.0.0"
 
-"@ledgerhq/ledger-core@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.1.0.tgz#9cd426b97423289fe775e625e2cd63e8fd5eed8a"
-  integrity sha512-SUEz4Rm6Pc6yD8z18JVRCbthV1e+26BlTu3ra8Q+30IwkL/JUfFEVGik+RXTSMbsRGRZUQYwPr0go533pNxLmQ==
+"@ledgerhq/ledger-core@2.2.1-rc":
+  version "2.2.1-rc"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.2.1-rc.tgz#fbf16c63a5d9aed5428997ed15825b5c0e96c6dd"
+  integrity sha512-2HBHz3IH21gGgc9ob9SwAXY5BPORrVjgmv+0QT8VtHyPN0P8CCu8EPV4j8iAM4I4J9hgPWU92k48ktUa0h4WzA==
   dependencies:
     bindings "^1.3.0"
     nan "^2.6.2"
 
 "@ledgerhq/live-common@file:..":
-  version "4.36.1"
+  version "4.39.0"
   dependencies:
     "@ledgerhq/errors" "^4.48.0"
     "@ledgerhq/hw-app-btc" "^4.48.0"


### PR DESCRIPTION
**To test things**

```
yarn
yarn build
cd test
yarn
yarn build
```

each time you want to reset libcore state:

```
rm -rf dbdata
```

**Status**

- ✅  I am able to scan accounts with a password. `LIBCORE_PASSWORD=toto node lib/examples/scanAccountsOnDevice.js` **works**. 
- ✅  I am able to scan AGAIN accounts with same password. `LIBCORE_PASSWORD=toto node lib/examples/scanAccountsOnDevice.js` **works again**. 
- 🔴  I am able to change the password. `LIBCORE_PASSWORD=toto node lib/examples/changePassword.js "toto" "foo"` => `segmentation fault`


**to be done on desktop**

- each time user input password to unlock the app. we hash this password in memory and use this hash to encrypt libcore by doing `setEnv("LIBCORE_PASSWORD", hash)`. With the new system we're working on with @valpinkman, this will reboot the internal process each time we change envs.
- we will add a new command `changeLibcorePassword(newPassword)` that, when call will basically do `libcore.getPool().changePassword`. when implementing the change password UI, we hash the new password to call that command with it. We wait it is successful and only then we can apply the encryption over user accounts data as well and only then we do a `setEnv("LIBCORE_PASSWORD", hash)`.
- as the previous work is not guarantee to be atomic, we need a way to reset the libcore when UI password matches but libcore password don't! It sounds like we need to rimraf sqlite like before.
- same goes when we "remove" the password. we will need to call `changeLibcorePassword("")` awaited and followed by a `setEnv("LIBCORE_PASSWORD","")`
