### PR TITLE
feat: LL-1264Testing for mock countervalue

### DIFF
--- a/src/countervalues/mock.js
+++ b/src/countervalues/mock.js
@@ -116,10 +116,16 @@ export const getDailyRatesImplementation = (
   }, rates);
 };
 
+/**
+ * [good]: Will return deterministic rates for the past 3 years for the pair
+ * [ugly]: Will respond, but return 0 as the latest rate.
+ * [bad]: Will not return anything for the pair.
+ */
 export const fetchExchangesForPairImplementation = async () => [
   { id: "good", name: "good", website: "#" },
   { id: "ugly", name: "ugly", website: "#" },
   { id: "bad", name: "bad", website: "#" }
 ];
-export const fetchTickersByMarketcapImplementation = async ():Promise<string[]> =>
-  listCryptoCurrencies().map(c => c.ticker);
+export const fetchTickersByMarketcapImplementation = async (): Promise<
+  string[]
+> => listCryptoCurrencies().map(c => c.ticker);

--- a/src/countervalues/mock.js
+++ b/src/countervalues/mock.js
@@ -1,7 +1,8 @@
 // @flow
-import type { CounterValuesState, Histodays } from "./types";
+import type { CounterValuesState, Histodays, PollAPIPair } from "./types";
 import type { Currency } from "../types";
 import { formatCounterValueDay } from ".";
+import { listCryptoCurrencies } from "../currencies";
 
 type Pair = {
   from: Currency,
@@ -32,3 +33,93 @@ export const genStoreState = (pairs: Pair[]): CounterValuesState => {
   });
   return state;
 };
+
+export const getDailyRatesImplementation = (
+  getAPIBaseURL: () => string,
+  pairs: PollAPIPair[]
+) => {
+  const rates = {
+    USD: { BTC: { SIMEX: { latest: 0.00521587214628 } } },
+    BTC: {}
+  };
+
+  // For pairs not reflected here we will be falling back on 1  ¯\_(ツ)_/¯
+  const baseMockBTCRates = {
+    BCH: 0.06102,
+    BTG: 0.003239,
+    DASH: 0.02314614,
+    DCR: 0.004706,
+    DGB: 0.00000249,
+    DOGE: 5.392e-7,
+    ETH: 3.1983e-12,
+    ETC: 1.203e-13,
+    ZEN: 0.00135623,
+    KMD: 0.0002006,
+    LTC: 0.015603,
+    PPC: 0.011236,
+    PIVX: 0.0001792,
+    QTUM: 0.00055208,
+    XSN: 0.0000241,
+    XST: 0.0021319999999999998,
+    STRAT: 0.0002083,
+    VTC: 0.00009569,
+    VIA: 0.0001065,
+    XRP: 0.006208,
+    ZEC: 0.0133534
+  };
+
+  const arbitraryRateEpoch = 1555452000000; // 17th April 2019 00:00
+  const todayTimestamp = new Date().setHours(0, 0, 0, 0);
+
+  const hms = date =>
+    new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+      .toISOString()
+      .split("T")[0];
+
+  const buildDays = from => {
+    const outputDays = {};
+    const baseRate = baseMockBTCRates[from] || 1;
+    const todayDate = new Date(todayTimestamp);
+    let date = new Date();
+
+    for (
+      date.setTime(todayTimestamp), date.setFullYear(date.getFullYear() - 3);
+      date.getTime() <= todayDate.getTime();
+      date.setDate(date.getDate() + 1)
+    ) {
+      const offset = (date.getTime() - arbitraryRateEpoch) / 864000000 / 180;
+      outputDays[todayDate - date ? hms(date) : "latest"] = Math.max(
+        baseRate * (1 + offset),
+        0
+      );
+    }
+    return outputDays;
+  };
+
+  return pairs.reduce((rates, pair) => {
+    if (pair.from === "BTC") return rates;
+    switch (pair.exchange) {
+      case "bad":
+        break;
+      case "ugly":
+        rates.BTC[pair.from] = { ugly: { latest: 0 } };
+        break;
+      default:
+        rates.BTC[pair.from] = {
+          [pair.exchange || "fallback"]: {
+            ...buildDays(pair.from)
+          }
+        };
+        break;
+    }
+    return rates;
+  }, rates);
+};
+
+export const fetchExchangesForPairImplementation = async () => [
+  { id: "good", name: "good", website: "#" },
+  { id: "ugly", name: "ugly", website: "#" },
+  { id: "bad", name: "bad", website: "#" }
+];
+export const fetchTickersByMarketcapImplementation = async ():Promise<string[]> =>
+  listCryptoCurrencies().map(c => c.ticker);

--- a/src/countervalues/types.js
+++ b/src/countervalues/types.js
@@ -94,8 +94,8 @@ export type Input<State> = {
     getAPIBaseURL: () => string,
     pairs: PollAPIPair[]
   ) => Promise<mixed>,
-  fetchExchangesForPairImplementation?: ()=>  Promise<Exchange[]>,
-  fetchTickersByMarketcapImplementation?: ()=> Promise<string[]>
+  fetchExchangesForPairImplementation?: () => Promise<Exchange[]>,
+  fetchTickersByMarketcapImplementation?: () => Promise<string[]>
 };
 
 export type PollAPIPair = {

--- a/src/countervalues/types.js
+++ b/src/countervalues/types.js
@@ -93,7 +93,9 @@ export type Input<State> = {
   getDailyRatesImplementation?: (
     getAPIBaseURL: () => string,
     pairs: PollAPIPair[]
-  ) => Promise<mixed>
+  ) => Promise<mixed>,
+  fetchExchangesForPairImplementation?: ()=>  Promise<Exchange[]>,
+  fetchTickersByMarketcapImplementation?: ()=> Promise<string[]>
 };
 
 export type PollAPIPair = {


### PR DESCRIPTION
This allows us to provide a custom `getDailyRatesImplementation`, `fetchExchangesForPairImplementation`, `fetchTickersByMarketcapImplementation`. They are present inside `countervalues/mock` that will fake the rates for a given pair and provide the rates for the past days too, accounting for a faked inflation for variance but keeping it consistent to allow Waldo or any other test suite to work with this.

I'll link a pr on mobile and desktop that will use the mock instead of the real ones.