### PR TITLE
LL to correctly uses Vertcoin coinType=28 for new accounts

### DIFF
--- a/tool/src/accountFormatters.js
+++ b/tool/src/accountFormatters.js
@@ -7,11 +7,8 @@ export default {
   json: account => JSON.stringify(toAccountRaw(account)),
 
   default: account =>
-    "(" +
-    (account.derivationMode || "bip44") +
-    "#" +
-    account.index +
-    ") " +
+    account.name +
+    ": " +
     formatCurrencyUnit(account.unit, account.balance, { showCode: true }) +
     " (" +
     account.operations.length +
@@ -19,6 +16,10 @@ export default {
     account.freshAddress +
     " on " +
     account.freshAddressPath +
+    ") (" +
+    (account.derivationMode || "bip44") +
+    "#" +
+    account.index +
     ")" +
     (account.tokenAccounts || [])
       .map(


### PR DESCRIPTION
- the previous coinType=128 is a mistake and it will now appear as "legacy" in LL
- user will have to clear cache before scanning again Vertcoin accounts otherwise he will see the account appearing twice (because we don't yet sync again the config in libcore wallet)

@Arnaud97234 to test this, you can use the `tool`