### PR TITLE
Add 'hasFailed' field in operation that is set to true for FAIL txs

### DIFF
--- a/src/libcore/buildAccount/buildOperation.js
+++ b/src/libcore/buildAccount/buildOperation.js
@@ -12,8 +12,13 @@ const OperationTypeMap = {
 async function ethereum({ coreOperation }) {
   const ethereumLikeOperation = await coreOperation.asEthereumLikeOperation();
   const ethereumLikeTransaction = await ethereumLikeOperation.getTransaction();
+  const status = await ethereumLikeTransaction.getStatus();
   const hash = await ethereumLikeTransaction.getHash();
-  return { hash };
+  const out: $Shape<Operation> = { hash };
+  if (status === 0) {
+    out.hasFailed = true;
+  }
+  return out;
 }
 
 async function bitcoin({ coreOperation }) {

--- a/src/libcore/types.js
+++ b/src/libcore/types.js
@@ -162,6 +162,7 @@ declare class CoreEthereumLikeTransaction {
   getSender(): Promise<CoreEthereumLikeAddress>;
   serialize(): Promise<string>;
   setSignature(string, string, string): Promise<void>;
+  getStatus(): Promise<number>;
 }
 
 declare class CoreBitcoinLikeOperation {
@@ -676,7 +677,8 @@ export const reflect = (declare: (string, Spec) => void) => {
       serialize: { returns: "hex" },
       setSignature: {
         params: ["hex", "hex", "hex"]
-      }
+      },
+      getStatus: {}
     }
   });
 

--- a/src/types/operation.js
+++ b/src/types/operation.js
@@ -46,7 +46,10 @@ export type Operation = {
   date: Date,
 
   // Extra crypto specific fields
-  extra: Object
+  extra: Object,
+
+  // Has the transaction actually failed? (some blockchain like ethereum will have failed tx appearing)
+  hasFailed?: boolean
 };
 
 export type OperationRaw = {
@@ -61,6 +64,7 @@ export type OperationRaw = {
   blockHash: ?string,
   transactionSequenceNumber?: number,
   accountId: string,
+  hasFailed?: boolean,
   // --------------------------------------------- specific operation raw fields
   date: string,
   extra: Object // would be a serializable version of the extra


### PR DESCRIPTION
in case of ethereum you can have txs that are FAIL, typically because out of gas.

To test:

```
EXPERIMENTAL_EXPLORERS=1 ledger-live sync -c ethereum -s "" --format json | less
```

you can see some ops to be hasFailed:true