### PR TITLE
Add updateWalletConfig to make sure libcore is in sync with live

### DIFF
--- a/src/libcore/getOrCreateWallet.js
+++ b/src/libcore/getOrCreateWallet.js
@@ -18,43 +18,46 @@ export const getOrCreateWallet: F = atomicQueue(
   async ({ core, walletName, currency, derivationMode }) => {
     const poolInstance = core.getPoolInstance();
     let wallet;
+
+    const ledgerExplorer = getCurrencyExplorer(currency);
+    const endpoint = blockchainExplorerEndpoint(currency);
+    const derivationScheme = getDerivationScheme({
+      currency,
+      derivationMode
+    });
+    const keychainEngine = getKeychainEngine(derivationMode);
+
+    const config = await core.DynamicObject.newInstance();
+    if (keychainEngine) {
+      await config.putString("KEYCHAIN_ENGINE", keychainEngine);
+    }
+    await config.putString("KEYCHAIN_DERIVATION_SCHEME", derivationScheme);
+    if (endpoint) {
+      await config.putString("BLOCKCHAIN_EXPLORER_API_ENDPOINT", endpoint);
+    }
+    await config.putString(
+      "BLOCKCHAIN_EXPLORER_VERSION",
+      ledgerExplorer.version
+    );
+
     try {
+      // check if wallet exists yet
       wallet = await poolInstance.getWallet(walletName);
-      // TODO seen with khalil:
-      // TODO we need to check the explorer config set on that wallet have not changed! <- we miss this feature from libcore.
-      // TODO if it have, we need to call poolInstance.changeWalletConfig and then, getWallet again
     } catch (err) {
+      // create it with the config
       const currencyCore = await poolInstance.getCurrency(currency.id);
-      const config = await core.DynamicObject.newInstance();
-
-      const ledgerExplorer = getCurrencyExplorer(currency);
-      const endpoint = blockchainExplorerEndpoint(currency);
-
-      const derivationScheme = getDerivationScheme({
-        currency,
-        derivationMode
-      });
-
-      const keychainEngine = getKeychainEngine(derivationMode);
-      if (keychainEngine) {
-        await config.putString("KEYCHAIN_ENGINE", keychainEngine);
-      }
-      await config.putString("KEYCHAIN_DERIVATION_SCHEME", derivationScheme);
-
-      if (blockchainExplorerEndpoint) {
-        await config.putString("BLOCKCHAIN_EXPLORER_API_ENDPOINT", endpoint);
-      }
-      await config.putString(
-        "BLOCKCHAIN_EXPLORER_VERSION",
-        ledgerExplorer.version
-      );
-
       wallet = await poolInstance.createWallet(
         walletName,
         currencyCore,
         config
       );
+      return wallet;
     }
+
+    // if it existed, we still need to sync again the config in case it changed
+    await poolInstance.updateWalletConfig(walletName, config);
+    // and we need to get wallet again to have this config taken into account
+    wallet = await poolInstance.getWallet(walletName);
     return wallet;
   },
   ({ walletName }: { walletName: string }) => walletName

--- a/src/libcore/types.js
+++ b/src/libcore/types.js
@@ -18,6 +18,10 @@ declare class CoreWalletPool {
   ): Promise<CoreWalletPool>;
   getWallet(name: string): Promise<CoreWallet>;
   getCurrency(id: string): Promise<CoreCurrency>;
+  updateWalletConfig(
+    walletName: string,
+    config: CoreDynamicObject
+  ): Promise<void>;
   createWallet(
     walletName: string,
     currency: CoreCurrency,

--- a/src/libcore/types.js
+++ b/src/libcore/types.js
@@ -437,6 +437,9 @@ export const reflect = (declare: (string, Spec) => void) => {
       }
     },
     methods: {
+      updateWalletConfig: {
+        params: [null, "DynamicObject"],
+      },
       getWallet: {
         returns: "Wallet"
       },


### PR DESCRIPTION
fixes #212 

Before, the wallet config was only set once and in case something changes over time or because user change settings (e.g. if you use "experimental explorers" or if you change the XRP endpoint) it was not taken into account.

With that code, we are now always syncing again the wallet config.

## How to test

```
VERBOSE=1 ledger-live sync -c eth -s "" -i 0
```

you will see that v2 api is used

```
VERBOSE=1 EXPERIMENTAL_EXPLORERS=1 ledger-live sync -c eth -s "" -i 0
```

you will now see that v3 api is used