### PR TITLE
Fixes BL 1.3.1 support

### DIFF
--- a/src/__tests__/hw/getDeviceInfo.js
+++ b/src/__tests__/hw/getDeviceInfo.js
@@ -147,6 +147,24 @@ test("0.9 bootloader", async () => {
   });
 });
 
+test("0.0 bootloader", async () => {
+  const Transport = createTransportReplayer(
+    RecordStore.fromString(`
+    => e001000000
+    <= 010000019000
+    `)
+  );
+  const t = await Transport.create();
+  const res = await getDeviceInfo(t);
+  expect(res).toMatchObject({
+    isBootloader: true,
+    isOSU: false,
+    majMin: "0.0",
+    version: "0.0.0",
+    mcuVersion: ""
+  });
+});
+
 test("OSU 1.4.2", async () => {
   const Transport = createTransportReplayer(
     RecordStore.fromString(`

--- a/src/hw/getDeviceInfo.js
+++ b/src/hw/getDeviceInfo.js
@@ -25,7 +25,7 @@ export default async function getDeviceInfo(
   const { targetId, mcuVersion, flags } = res;
   const isOSU = seVersion.includes("-osu");
   const version = seVersion.replace("-osu", "");
-  const m = seVersion.match(/([0-9]+.[0-9])+(.[0-9]+)?(-([a-zA-Z0-9]+))?/);
+  const m = seVersion.match(/([0-9]+.[0-9])+(.[0-9]+)?(-(.*))?/);
   const [, majMin, , providerName] = m || [];
   const providerId = getEnv("FORCE_PROVIDER") || PROVIDERS[providerName] || 1;
   const isBootloader = (targetId & 0xf0000000) !== 0x30000000;

--- a/src/hw/getVersion.js
+++ b/src/hw/getVersion.js
@@ -1,6 +1,5 @@
 // @flow
 
-import invariant from "invariant";
 import Transport from "@ledgerhq/hw-transport";
 
 export type FirmwareInfo = {
@@ -40,7 +39,15 @@ export default async function getVersion(
   }
   mcuVersion = mcuVersion.toString();
 
-  invariant(seVersionLength, "invalid getVersion payload");
+  if (!seVersionLength) {
+    // To support old firmware like bootloader of 1.3.1
+    return {
+      targetId,
+      seVersion: "0.0.0",
+      flags: Buffer.allocUnsafeSlow(0),
+      mcuVersion: ""
+    };
+  }
 
   return { targetId, seVersion, flags, mcuVersion };
 }


### PR DESCRIPTION
In recent refactoring of `getDeviceInfo` (and `getVersion`) to support more version patterns (1.6.0-rc1 kind of versionning), we've broken the support of 1.3.1 Bootloader that was not returning any seVersion at all (it was `""`) which means **users can't upgrade from 1.3.1 anymore exclusively when using Ledger Live 1.8.0**.

## Mitigation

Use Ledger Live 1.7.0 to upgrade from Nano S 1.3.1.

https://github.com/LedgerHQ/ledger-live-desktop/releases/tag/v1.7.0

## Solution

Provided in this PR, will be delivered in the next Ledger Live. We've rollbacked some previous code that was fallbacking on version `"0.0.0"` when `""`. It will make things like the repair tool to work again.

### Important note for devs

Added one more test so we are sure to never regress on this. that show us our lack of test in the past, important to continue adding more and more test in the future.
Everytime you have a new firmware version or a new pattern, please always add a test / tell the LL team what are the output of getVersion so we add this test in our side. thanks.

test plan: https://github.com/LedgerHQ/ledger-live-common/issues/235