### PR TITLE
Fix build not being pushed on yarn publish

### DIFF
--- a/tool/package.json
+++ b/tool/package.json
@@ -25,8 +25,12 @@
   "bin": {
     "ledger-live": "./cli.js"
   },
+  "files": [
+    "lib"
+  ],
   "scripts": {
     "build": "babel --ignore __tests__ -sd lib src",
+    "prepublish": "yarn build",
     "watch": "babel -wsd lib src",
     "test": "./scripts/tests.sh",
     "testOne": "./scripts/testOne.sh",


### PR DESCRIPTION
`ledger-live` cli package published on https://www.npmjs.com/package/ledger-live was missing the actual build.
This should fix that.