### PR TITLE
Tool bump to v5.2.1

### DIFF
--- a/tool/package.json
+++ b/tool/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ledger-live",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "description": "ledger-live CLI version",
   "repository": {
     "type": "git",


### PR DESCRIPTION
I thought I could push that to upstream directly, but no.