### PR TITLE
Actually really fix cli tool npm package

### DIFF
--- a/tool/package.json
+++ b/tool/package.json
@@ -26,11 +26,12 @@
     "ledger-live": "./cli.js"
   },
   "files": [
+    "cli.js",
     "lib"
   ],
   "scripts": {
     "build": "babel --ignore __tests__ -sd lib src",
-    "prepublish": "yarn build",
+    "prepublishOnly": "rm -rf lib && babel --ignore __tests__ -d lib src",
     "watch": "babel -wsd lib src",
     "test": "./scripts/tests.sh",
     "testOne": "./scripts/testOne.sh",


### PR DESCRIPTION
Previous attempt to fix made `cli.js` to not be published anymore.
I also removed the babel maps while I was at it.

For review, this is the list of files that would be published with these changes:
```
$ npm publish --dry-run

> ledger-live@5.3.1 prepublishOnly .
> rm -rf lib && babel --ignore __tests__ -d lib src

src/accountFormatters.js -> lib/accountFormatters.js
src/cli.js -> lib/cli.js
src/commands.js -> lib/commands.js
src/live-common-setup.js -> lib/live-common-setup.js
src/scan.js -> lib/scan.js
src/stream.js -> lib/stream.js
src/transaction.js -> lib/transaction.js
npm notice 
npm notice 📦  ledger-live@5.3.1
npm notice === Tarball Contents === 
npm notice 1.3kB  package.json            
npm notice 42B    cli.js                  
npm notice 9.1kB  README.md               
npm notice 2.1kB  lib/accountFormatters.js
npm notice 3.5kB  lib/cli.js              
npm notice 14.7kB lib/commands.js         
npm notice 2.2kB  lib/live-common-setup.js
npm notice 4.8kB  lib/scan.js             
npm notice 2.4kB  lib/stream.js           
npm notice 4.4kB  lib/transaction.js      
npm notice === Tarball Details === 
npm notice name:          ledger-live                             
npm notice version:       5.3.1                                   
npm notice package size:  10.3 kB                                 
npm notice unpacked size: 44.8 kB                                 
npm notice shasum:        37e96c4cc48fcd52c67e2321fa28f111d914d387
npm notice integrity:     sha512-6Spj0JHRiOvHw[...]ZNJ+3Dqzb0HuQ==
npm notice total files:   10                                      
npm notice 
+ ledger-live@5.3.1
```