### PR TITLE
Bootstrap fees utility to have a dynamic slider with one value

### DIFF
--- a/src/__tests__/__snapshots__/range.js.snap
+++ b/src/__tests__/__snapshots__/range.js.snap
@@ -2,62 +2,62 @@
 
 exports[`inferDynamicRange 1`] = `
 Object {
-  "initial": 0.4,
-  "max": 0.8,
-  "min": 0.1,
-  "step": 0.05,
+  "initial": "0.4",
+  "max": "0.8",
+  "min": "0.1",
+  "step": "0.05",
   "steps": 15,
 }
 `;
 
 exports[`inferDynamicRange 2`] = `
 Object {
-  "initial": 1,
-  "max": 2,
-  "min": 0.2,
-  "step": 0.1,
-  "steps": 19,
+  "initial": "1",
+  "max": "2",
+  "min": "0.3",
+  "step": "0.1",
+  "steps": 18,
 }
 `;
 
 exports[`inferDynamicRange 3`] = `
 Object {
-  "initial": 1,
-  "max": 2.1,
-  "min": 0.30000000000000004,
-  "step": 0.1,
+  "initial": "1",
+  "max": "2.1",
+  "min": "0.3",
+  "step": "0.1",
   "steps": 19,
 }
 `;
 
 exports[`inferDynamicRange 4`] = `
 Object {
-  "initial": 10,
-  "max": 20,
-  "min": 3,
-  "step": 1,
+  "initial": "10",
+  "max": "20",
+  "min": "3",
+  "step": "1",
   "steps": 18,
 }
 `;
 
 exports[`inferDynamicRange 5`] = `
 Object {
-  "initial": 100,
-  "max": 200,
-  "min": 30,
-  "step": 10,
+  "initial": "100",
+  "max": "200",
+  "min": "30",
+  "step": "10",
   "steps": 18,
 }
 `;
 
 exports[`inferDynamicRange 6`] = `
 Object {
-  "initial": 100,
-  "max": 200,
-  "min": 20,
-  "step": 10,
+  "initial": "100",
+  "max": "200",
+  "min": "20",
+  "step": "10",
   "steps": 19,
 }
 `;
 
-exports[`projectRangeIndex 1`] = `0.2`;
+exports[`projectRangeIndex 1`] = `"0.2"`;

--- a/src/__tests__/__snapshots__/range.js.snap
+++ b/src/__tests__/__snapshots__/range.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`inferDynamicRange 1`] = `
+Object {
+  "initial": 0.4,
+  "max": 0.8,
+  "min": 0.1,
+  "step": 0.05,
+  "steps": 15,
+}
+`;
+
+exports[`inferDynamicRange 2`] = `
+Object {
+  "initial": 1,
+  "max": 2,
+  "min": 0.2,
+  "step": 0.1,
+  "steps": 19,
+}
+`;
+
+exports[`inferDynamicRange 3`] = `
+Object {
+  "initial": 1,
+  "max": 2.1,
+  "min": 0.30000000000000004,
+  "step": 0.1,
+  "steps": 19,
+}
+`;
+
+exports[`inferDynamicRange 4`] = `
+Object {
+  "initial": 10,
+  "max": 20,
+  "min": 3,
+  "step": 1,
+  "steps": 18,
+}
+`;
+
+exports[`inferDynamicRange 5`] = `
+Object {
+  "initial": 100,
+  "max": 200,
+  "min": 30,
+  "step": 10,
+  "steps": 18,
+}
+`;
+
+exports[`inferDynamicRange 6`] = `
+Object {
+  "initial": 100,
+  "max": 200,
+  "min": 20,
+  "step": 10,
+  "steps": 19,
+}
+`;
+
+exports[`projectRangeIndex 1`] = `0.2`;

--- a/src/__tests__/range.js
+++ b/src/__tests__/range.js
@@ -1,25 +1,40 @@
 // @flow
+import { BigNumber } from "bignumber.js";
 import {
   inferDynamicRange,
   projectRangeIndex,
   reverseRangeIndex
 } from "../range";
 
+function asString(bn) {
+  if (BigNumber.isBigNumber(bn)) return bn.toString();
+  if (typeof bn === "object" && bn) {
+    const obj = {};
+    for (let k in bn) {
+      obj[k] = asString(bn[k]);
+    }
+    return obj;
+  }
+  return bn;
+}
+
 test("inferDynamicRange", () => {
-  expect(inferDynamicRange(0.4)).toMatchSnapshot();
-  expect(inferDynamicRange(1)).toMatchSnapshot();
-  expect(inferDynamicRange(1.01)).toMatchSnapshot();
-  expect(inferDynamicRange(10)).toMatchSnapshot();
-  expect(inferDynamicRange(100)).toMatchSnapshot();
-  expect(inferDynamicRange(99)).toMatchSnapshot();
+  expect(asString(inferDynamicRange(BigNumber(0.4)))).toMatchSnapshot();
+  expect(asString(inferDynamicRange(BigNumber(1)))).toMatchSnapshot();
+  expect(asString(inferDynamicRange(BigNumber(1.01)))).toMatchSnapshot();
+  expect(asString(inferDynamicRange(BigNumber(10)))).toMatchSnapshot();
+  expect(asString(inferDynamicRange(BigNumber(100)))).toMatchSnapshot();
+  expect(asString(inferDynamicRange(BigNumber(99)))).toMatchSnapshot();
 });
 
 test("projectRangeIndex", () => {
-  expect(projectRangeIndex(inferDynamicRange(0.4), 2)).toMatchSnapshot();
+  expect(
+    asString(projectRangeIndex(inferDynamicRange(BigNumber(0.4)), BigNumber(2)))
+  ).toMatchSnapshot();
 });
 
 test("reverseRangeIndex", () => {
-  const range = inferDynamicRange(0.4);
+  const range = inferDynamicRange(BigNumber(0.4));
   for (let i = 0; i < range.steps; i++) {
     const n = projectRangeIndex(range, i);
     expect(reverseRangeIndex(range, n)).toBe(i);

--- a/src/__tests__/range.js
+++ b/src/__tests__/range.js
@@ -1,0 +1,27 @@
+// @flow
+import {
+  inferDynamicRange,
+  projectRangeIndex,
+  reverseRangeIndex
+} from "../range";
+
+test("inferDynamicRange", () => {
+  expect(inferDynamicRange(0.4)).toMatchSnapshot();
+  expect(inferDynamicRange(1)).toMatchSnapshot();
+  expect(inferDynamicRange(1.01)).toMatchSnapshot();
+  expect(inferDynamicRange(10)).toMatchSnapshot();
+  expect(inferDynamicRange(100)).toMatchSnapshot();
+  expect(inferDynamicRange(99)).toMatchSnapshot();
+});
+
+test("projectRangeIndex", () => {
+  expect(projectRangeIndex(inferDynamicRange(0.4), 2)).toMatchSnapshot();
+});
+
+test("reverseRangeIndex", () => {
+  const range = inferDynamicRange(0.4);
+  for (let i = 0; i < range.steps; i++) {
+    const n = projectRangeIndex(range, i);
+    expect(reverseRangeIndex(range, n)).toBe(i);
+  }
+});

--- a/src/range.js
+++ b/src/range.js
@@ -1,0 +1,77 @@
+// @flow
+// Utility to deal with ranges
+
+export type Range = {
+  initial: number,
+  min: number,
+  max: number,
+  step: number,
+  steps: number
+};
+
+const defaultOpts: InferDynamicRangeOpts = {
+  minMult: 0.3,
+  maxMult: 2,
+  targetSteps: 20
+};
+
+export type InferDynamicRangeOpts = typeof defaultOpts;
+
+// infer a range from ONE estimated fees value.
+// e.g. we just have a "gasPrice" and we want a slider to move a gas value around it.
+// to test this:
+// for (let i = 0.1; i < 10; i += 0.1) console.log(i, inferDynamicRange(i));
+export function inferDynamicRange(
+  amount: number,
+  opts: $Shape<InferDynamicRangeOpts> = {}
+): Range {
+  const { minMult, maxMult, targetSteps } = { ...defaultOpts, ...opts };
+  const targetMin = amount * minMult;
+  const targetMax = amount * maxMult;
+  const step = findBestRangeStep(targetMin, targetMax, targetSteps);
+  if (Number.isNaN(step) || step <= 0) {
+    throw new Error("inferDynamicRange: invalid parameters");
+  }
+  const initial = round(amount, step);
+  const min = floor(targetMin, step);
+  const max = ceil(targetMax, step);
+  const steps = 1 + (max - min) / step;
+  return { initial, min, max, step, steps };
+}
+
+export function projectRangeIndex(range: Range, index: number): number {
+  return range.min + index * range.step;
+}
+
+export function reverseRangeIndex(range: Range, n: number): number {
+  const x = (n - range.min) / (range.max - range.min);
+  const i = Math.floor(range.steps * x);
+  return Math.max(0, Math.min(i, range.steps - 1));
+}
+
+function floor(n, step) {
+  return Math.floor(n / step) * step;
+}
+
+function ceil(n, step) {
+  return Math.ceil(n / step) * step;
+}
+
+function round(n, step) {
+  return Math.round(n / step) * step;
+}
+
+const log10 = Math.log(10);
+
+// return step to use for a [min,max] with a planned number of steps (will approx).
+function findBestRangeStep(min, max, steps) {
+  const nonRoundedStep = (max - min) / steps;
+  const mag = Math.log(nonRoundedStep) / log10;
+  const magInt = Math.floor(mag);
+  const remain = mag - magInt;
+  let step = 10 ** (magInt + 1);
+  // heuristics
+  if (remain < 0.3) step /= 5;
+  else if (remain < 0.7) step /= 2;
+  return step;
+}

--- a/src/range.js
+++ b/src/range.js
@@ -1,11 +1,12 @@
 // @flow
 // Utility to deal with ranges
+import { BigNumber } from "bignumber.js";
 
 export type Range = {
-  initial: number,
-  min: number,
-  max: number,
-  step: number,
+  initial: BigNumber,
+  min: BigNumber,
+  max: BigNumber,
+  step: BigNumber,
   steps: number
 };
 
@@ -22,56 +23,58 @@ export type InferDynamicRangeOpts = typeof defaultOpts;
 // to test this:
 // for (let i = 0.1; i < 10; i += 0.1) console.log(i, inferDynamicRange(i));
 export function inferDynamicRange(
-  amount: number,
+  amount: BigNumber,
   opts: $Shape<InferDynamicRangeOpts> = {}
 ): Range {
   const { minMult, maxMult, targetSteps } = { ...defaultOpts, ...opts };
-  const targetMin = amount * minMult;
-  const targetMax = amount * maxMult;
+  const targetMin = amount.times(minMult);
+  const targetMax = amount.times(maxMult);
   const step = findBestRangeStep(targetMin, targetMax, targetSteps);
   if (Number.isNaN(step) || step <= 0) {
     throw new Error("inferDynamicRange: invalid parameters");
   }
-  const initial = round(amount, step);
-  const min = floor(targetMin, step);
-  const max = ceil(targetMax, step);
-  const steps = 1 + (max - min) / step;
+  const initial = stepping(amount, step, BigNumber.ROUND_HALF_UP);
+  const min = stepping(targetMin, step, BigNumber.ROUND_FLOOR);
+  const max = stepping(targetMax, step, BigNumber.ROUND_CEIL);
+  const steps = max
+    .minus(min)
+    .div(step)
+    .plus(1)
+    .toNumber();
   return { initial, min, max, step, steps };
 }
 
-export function projectRangeIndex(range: Range, index: number): number {
-  return range.min + index * range.step;
+export function projectRangeIndex(range: Range, index: number): BigNumber {
+  return range.min.plus(range.step.times(index));
 }
 
-export function reverseRangeIndex(range: Range, n: number): number {
-  const x = (n - range.min) / (range.max - range.min);
-  const i = Math.floor(range.steps * x);
+export function reverseRangeIndex(range: Range, n: BigNumber): number {
+  const x = n.minus(range.min).div(range.max.minus(range.min));
+  const i = x
+    .times(range.steps)
+    .integerValue(BigNumber.ROUND_FLOOR)
+    .toNumber();
   return Math.max(0, Math.min(i, range.steps - 1));
 }
 
-function floor(n, step) {
-  return Math.floor(n / step) * step;
-}
-
-function ceil(n, step) {
-  return Math.ceil(n / step) * step;
-}
-
-function round(n, step) {
-  return Math.round(n / step) * step;
+function stepping(n, step, roundingMode) {
+  return n
+    .div(step)
+    .integerValue(roundingMode)
+    .times(step);
 }
 
 const log10 = Math.log(10);
 
 // return step to use for a [min,max] with a planned number of steps (will approx).
 function findBestRangeStep(min, max, steps) {
-  const nonRoundedStep = (max - min) / steps;
+  const nonRoundedStep = (max.toNumber() - min.toNumber()) / steps;
   const mag = Math.log(nonRoundedStep) / log10;
   const magInt = Math.floor(mag);
   const remain = mag - magInt;
-  let step = 10 ** (magInt + 1);
+  let step = BigNumber(10).pow(magInt + 1);
   // heuristics
-  if (remain < 0.3) step /= 5;
-  else if (remain < 0.7) step /= 2;
+  if (remain < 0.3) step = step.div(5);
+  else if (remain < 0.7) step = step.div(2);
   return step;
 }

--- a/tool/yarn.lock
+++ b/tool/yarn.lock
@@ -329,9 +329,9 @@
     events "^3.0.0"
 
 "@ledgerhq/ledger-core@^2.3.0-beta.5":
-  version "2.3.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.3.0-beta.5.tgz#e2b301ae2900462807be94e69d3c496ffb24e7c0"
-  integrity sha512-TnHVz6k8JoAZrOoCOGE5z4nFXmujeGpJV+tT83nOpmCZphwgCKTq1uGZE8Y4+sy0iigubzBRQQwccLj7V5/g7Q==
+  version "2.3.0-beta.6"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.3.0-beta.6.tgz#38d64910eb9a3cfad457d1169345740d12c67a97"
+  integrity sha512-xvuc80A/zvgy0+OMzumN7toOAvaQlHGJUD3F/72vO8H+l8pNGm9IZuhaMa4qJb4hv3YZCo6d0ZZywk/+2mm1mQ==
   dependencies:
     bindings "^1.3.0"
     nan "^2.6.2"


### PR DESCRIPTION
This is a basic algorithm to infer a nice dynamic range, from one fees value and some settings (a min and max multiplicator + a desired (max capped) number of steps).

The plan is to have this working for ETH's Gas Price. In future, we could even imagine doing the same for all kind of fees (meaning those who have 3 values, not just one value estimation).

Despite the hairy code, the algorithm is pretty simple: we use multiplicator to find a min and max range. Then we infer what a nice step can be, looking for either a 0.1, 0.2 or 0.5 increment. we map that to the proper range (e.g. can be 1,2,5 or 100,200,500,...) to make it approach the desired number of steps.


example:

```js

> inferDynamicRange(1)
{ initial: 1, min: 0.2, max: 2, step: 0.1, steps: 19 }
> inferDynamicRange(2)
{ initial: 2, min: 0.4, max: 4, step: 0.2, steps: 19 }
> inferDynamicRange(4)
{ initial: 4, min: 1, max: 8, step: 0.5, steps: 15 }
> inferDynamicRange(8)
{ initial: 8, min: 2, max: 16, step: 1, steps: 15 }
>
>  inferDynamicRange(0.1)
{ initial: 0.1, min: 0.03, max: 0.2, step: 0.01, steps: 18 }
>  inferDynamicRange(0.2)
{ initial: 0.2, min: 0.06, max: 0.4, step: 0.02, steps: 18 }
>  inferDynamicRange(0.3)
{ initial: 0.30000000000000004,
  min: 0.05,
  max: 0.6000000000000001,
  step: 0.05,
  steps: 12 }
>  inferDynamicRange(0.4)
{ initial: 0.4, min: 0.1, max: 0.8, step: 0.05, steps: 15 }
>  inferDynamicRange(0.5)
{ initial: 0.5, min: 0.1, max: 1, step: 0.05, steps: 19 }
>  inferDynamicRange(0.6)
{ initial: 0.6000000000000001,
  min: 0.1,
  max: 1.2000000000000002,
  step: 0.1,
  steps: 12 }
>  inferDynamicRange(0.7)
{ initial: 0.7000000000000001,
  min: 0.2,
  max: 1.4000000000000001,
  step: 0.1,
  steps: 13.000000000000002 }
>
> inferDynamicRange(100)
{ initial: 100, min: 30, max: 200, step: 10, steps: 18 }
> inferDynamicRange(200)
{ initial: 200, min: 60, max: 400, step: 20, steps: 18 }
> inferDynamicRange(300)
{ initial: 300, min: 50, max: 600, step: 50, steps: 12 }
> inferDynamicRange(400)
{ initial: 400, min: 100, max: 800, step: 50, steps: 15 }
> inferDynamicRange(500)
{ initial: 500, min: 150, max: 1000, step: 50, steps: 18 }
> inferDynamicRange(600)
{ initial: 600, min: 100, max: 1200, step: 100, steps: 12 }
> inferDynamicRange(700)
{ initial: 700, min: 200, max: 1400, step: 100, steps: 13 }
```


you can see in this log that we have some JS number imprecision glitch so we can refactor this to BigNumber if it is a problem.

another thing that is solved is that if the estimation gas have insignificant part, it's ignored:

```
console.log(inferDynamicRange(1.012345));

      { initial: 1,
        min: 0.30000000000000004,
        max: 2.1,
        step: 0.1,
        steps: 19 }
```