### PR TITLE
Bump libcore fix glibc

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,13 +24,6 @@ jobs:
     docker:
       - image: circleci/node:8-stretch-browsers
     steps:
-      - run:
-          name: Install GCC 7
-          command: |
-            echo "deb http://ftp.us.debian.org/debian testing main contrib non-free" | sudo tee /etc/apt/sources.list.d/gcc7.list ;
-            sudo apt-get update
-            sudo apt-get install -t testing g++-7
-            sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
       - run: sudo apt-get update
       - run: sudo apt-get install -y libudev-dev libusb-1.0-0-dev jq
       - run:

--- a/tool/package.json
+++ b/tool/package.json
@@ -12,7 +12,7 @@
     "@ledgerhq/hw-transport-mocker": "^4.61.0",
     "@ledgerhq/hw-transport-node-ble": "^4.61.0",
     "@ledgerhq/hw-transport-node-hid": "^4.61.1",
-    "@ledgerhq/ledger-core": "^2.3.0-beta.8",
+    "@ledgerhq/ledger-core": "^2.3.0-beta.9",
     "@ledgerhq/live-common": "^6.0.0",
     "@ledgerhq/logs": "^4.61.0",
     "axios": "^0.19.0",

--- a/tool/yarn.lock
+++ b/tool/yarn.lock
@@ -338,10 +338,10 @@
     "@ledgerhq/errors" "^4.61.0"
     events "^3.0.0"
 
-"@ledgerhq/ledger-core@^2.3.0-beta.8":
-  version "2.3.0-beta.8"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.3.0-beta.8.tgz#4b54b2858275a9b08b7c9e7e32d5635d5a28091e"
-  integrity sha512-sBkUrbWshh5enhbCINl1Q7yY7Tt9BpSqz7xSsB/uP9eympBfRspQLNIKL6nYd4WABCmdFdvVycndy2LhK5MgqQ==
+"@ledgerhq/ledger-core@^2.3.0-beta.9":
+  version "2.3.0-beta.9"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/ledger-core/-/ledger-core-2.3.0-beta.9.tgz#0f51bbcb898d365575a0f1a220308923c37cb294"
+  integrity sha512-R70o7ZMG7wUc3flk1jFH21jHxwbkPMwPij2IuLsk3GyigV/aU1MbzBscFOMop7LIDRdPkAV9bQjm7BDtKTNvdQ==
   dependencies:
     bindings "^1.3.0"
     nan "^2.6.2"


### PR DESCRIPTION
includes work of https://github.com/LedgerHQ/ledger-live-common/pull/261 and also bump libcore in tool to run the tests