### PR TITLE
Fixes QTUM to support segwit

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -1756,6 +1756,7 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
       P2PKH: 58,
       P2SH: 50
     },
+    supportsSegwit: true,
     units: [
       {
         name: "qtum",


### PR DESCRIPTION
this can only be merged when we have confirmation to have a new app that supports segwit.
in complement, we could look at having a backward compatibility or more explicit error when an app is asked to derive on segwit but it fails.