### PR TITLE
Introduced disableCountervalue on all Currency types

### DIFF
--- a/src/data/tokens.js
+++ b/src/data/tokens.js
@@ -1,6 +1,9 @@
 // @flow
 import type { TokenCurrency, CryptoCurrency } from "../types";
-import { getCryptoCurrencyById } from "../currencies";
+import {
+  getCryptoCurrencyById,
+  findCryptoCurrencyByTicker
+} from "./cryptocurrencies";
 
 const convertERC20 = ([
   parentCurrencyId,
@@ -19,6 +22,7 @@ const convertERC20 = ([
   tokenType: "erc20",
   name,
   ticker,
+  disableCountervalue: !!findCryptoCurrencyByTicker(ticker), // if it collides, disable
   units: [
     {
       name,

--- a/src/types/currencies.js
+++ b/src/types/currencies.js
@@ -20,7 +20,9 @@ type CurrencyCommon = {
   // by convention, [0] is the default and have "highest" magnitude
   units: Unit[],
   // a shorter version of code using the symbol of the currency. like Ƀ . not all cryptocurrencies have a symbol
-  symbol?: string
+  symbol?: string,
+  // tells if countervalue need to be disabled (typically because colliding with other coins)
+  disableCountervalue?: boolean
 };
 
 export type TokenCurrency = CurrencyCommon & {


### PR DESCRIPTION
this is to address the fact that countervalue of some token needs to be disabled.

typically because they collide

<img width="1081" alt="Capture d’écran 2019-06-07 à 14 02 44" src="https://user-images.githubusercontent.com/211411/59118315-1721f080-8950-11e9-9169-86fa16c9c56d.png">

will now show as

<img width="779" alt="Capture d’écran 2019-06-07 à 16 58 16" src="https://user-images.githubusercontent.com/211411/59118316-1721f080-8950-11e9-9960-9c35157feab9.png">


because it's not EOS the currency, it's EOS the token.