### PR TITLE
Rework a bit bridge for ERC20

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "6.4.1",
+  "version": "6.5.0-alpha.4",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/src/account/helpers.js
+++ b/src/account/helpers.js
@@ -17,6 +17,9 @@ export const getMainAccount = (
 export const getAccountCurrency = (account: Account | TokenAccount) =>
   account.type === "Account" ? account.currency : account.token;
 
+export const getAccountUnit = (account: Account | TokenAccount) =>
+  account.type === "Account" ? account.unit : account.token.units[0];
+
 export const isAccountEmpty = (a: Account | TokenAccount): boolean =>
   a.operations.length === 0 && a.balance.isZero();
 

--- a/src/account/index.js
+++ b/src/account/index.js
@@ -6,6 +6,7 @@ import type {
 import {
   getMainAccount,
   getAccountCurrency,
+  getAccountUnit,
   isAccountEmpty,
   clearAccount,
   flattenAccounts
@@ -51,6 +52,7 @@ export type { AddAccountsSection, AddAccountsSectionResult };
 export {
   getMainAccount,
   getAccountCurrency,
+  getAccountUnit,
   isAccountEmpty,
   clearAccount,
   flattenAccounts,

--- a/src/bridge/EthereumJSBridge.js
+++ b/src/bridge/EthereumJSBridge.js
@@ -595,6 +595,8 @@ export const accountBridge: AccountBridge<Transaction> = {
     )
   }),
 
+  prepareTransaction: (account, transaction) => Promise.resolve(transaction),
+
   estimateGasLimit: (account, address) => {
     const api = apiForCurrency(account.currency);
     return api.estimateGasLimitForERC20(address);

--- a/src/bridge/LibcoreBitcoinAccountBridge.js
+++ b/src/bridge/LibcoreBitcoinAccountBridge.js
@@ -156,6 +156,9 @@ const getTotalSpent = async (a, t) =>
 const getMaxAmount = async (a, t) =>
   getFees(a, t).then(totalFees => a.balance.minus(totalFees || 0));
 
+const prepareTransaction = (account, transaction) =>
+  Promise.resolve(transaction);
+
 const bridge: AccountBridge<Transaction> = {
   startSync,
   checkValidRecipient,
@@ -172,6 +175,7 @@ const bridge: AccountBridge<Transaction> = {
   checkValidTransaction,
   getTotalSpent,
   getMaxAmount,
+  prepareTransaction,
   signAndBroadcast,
   addPendingOperation
 };

--- a/src/bridge/LibcoreEthereumAccountBridge.js
+++ b/src/bridge/LibcoreEthereumAccountBridge.js
@@ -6,7 +6,7 @@ import {
   InvalidAddress,
   NotEnoughBalance
 } from "@ledgerhq/errors";
-import type { Unit } from "../types";
+import type { Unit, TokenAccount, Account } from "../types";
 import type { AccountBridge } from "./types";
 import { getEstimatedFees } from "../api/Fees";
 import { syncAccount } from "../libcore/syncAccount";
@@ -22,14 +22,32 @@ export type Transaction = {
   gasPrice: ?BigNumber,
   gasLimit: BigNumber,
   feeCustomUnit: ?Unit,
+  tokenAccountId?: ?string,
+  useAllAmount?: boolean,
   networkInfo: ?{ serverFees: { gas_price: number } }
 };
 
-const asLibcoreTransaction = ({ amount, recipient, gasPrice, gasLimit }) => ({
+const getTransactionAccount = (a, t): Account | TokenAccount => {
+  const { tokenAccountId } = t;
+  return tokenAccountId
+    ? (a.tokenAccounts || []).find(ta => ta.id === tokenAccountId) || a
+    : a;
+};
+
+const asLibcoreTransaction = ({
   amount,
   recipient,
+  gasPrice,
+  tokenAccountId,
+  gasLimit,
+  useAllAmount
+}) => ({
+  amount,
+  recipient,
+  tokenAccountId,
   gasPrice: gasPrice || undefined,
-  gasLimit: gasLimit || undefined
+  gasLimit: gasLimit || undefined,
+  useAllAmount
 });
 
 const startSync = (initialAccount, _observation) => syncAccount(initialAccount);
@@ -51,7 +69,8 @@ const createTransaction = a => ({
   gasPrice: null,
   gasLimit: BigNumber(0x5208),
   networkInfo: null,
-  feeCustomUnit: a.currency.units[1] || a.currency.units[0]
+  feeCustomUnit: a.currency.units[1] || a.currency.units[0],
+  useAllAmount: false
 });
 
 const fetchTransactionNetworkInfo = async account => {
@@ -85,6 +104,10 @@ const editTransactionRecipient = (account, t, recipient) => ({
   ...t,
   recipient
 });
+
+const editTokenAccountId = (a, t, tokenAccountId) => ({ ...t, tokenAccountId });
+
+const getTokenAccountId = (a, t) => t.tokenAccountId;
 
 const getTransactionRecipient = (a, t) => t.recipient;
 
@@ -165,20 +188,46 @@ const checkValidTransaction = async (a, t) =>
     ? Promise.resolve(null)
     : Promise.reject(new NotEnoughBalance());
 
-const getTotalSpent = (a, t) =>
-  t.amount.isGreaterThan(0) &&
-  t.gasPrice &&
-  t.gasPrice.isGreaterThan(0) &&
-  t.gasLimit.isGreaterThan(0)
-    ? getFees(a, t).then(totalFees => BigNumber(t.amount).plus(totalFees || 0))
-    : Promise.resolve(BigNumber(0));
+const getTotalSpent = (a, t) => {
+  const tAccount = getTransactionAccount(a, t);
+
+  if (t.useAllAmount) {
+    return tAccount.balance;
+  }
+
+  const amount = BigNumber(t.amount || "0");
+  if (
+    amount.isZero() ||
+    !t.gasPrice ||
+    t.gasPrice.isZero() ||
+    t.gasLimit.isZero() ||
+    tAccount.type === "TokenAccount"
+  ) {
+    return Promise.resolve(amount);
+  }
+
+  return getFees(a, t).then(totalFees => amount.plus(totalFees || 0));
+};
 
 const getMaxAmount = async (a, t) =>
   getFees(a, t).then(totalFees => a.balance.minus(totalFees || 0));
 
 const estimateGasLimit = (account, address) => {
+  console.warn(
+    "bridge.estimateGasLimit DEPRECATED. use prepareTransaction instead"
+  );
   const api = apiForCurrency(account.currency);
   return api.estimateGasLimitForERC20(address);
+};
+
+const prepareTransaction = (a, t) => {
+  const api = apiForCurrency(a.currency);
+  const tAccount = getTransactionAccount(a, t);
+  const o =
+    tAccount.type === "TokenAccount"
+      ? api.estimateGasLimitForERC20(tAccount.token.contractAddress)
+      : api.estimateGasLimitForERC20(t.recipient);
+  return o.then(gasLimit => ({ ...t, gasLimit: BigNumber(gasLimit) }));
 };
 
 const bridge: AccountBridge<Transaction> = {
@@ -188,6 +237,8 @@ const bridge: AccountBridge<Transaction> = {
   fetchTransactionNetworkInfo,
   getTransactionNetworkInfo,
   applyTransactionNetworkInfo,
+  editTokenAccountId,
+  getTokenAccountId,
   editTransactionAmount,
   getTransactionAmount,
   editTransactionRecipient,
@@ -199,7 +250,8 @@ const bridge: AccountBridge<Transaction> = {
   getMaxAmount,
   signAndBroadcast,
   addPendingOperation,
-  estimateGasLimit
+  estimateGasLimit,
+  prepareTransaction
 };
 
 export default bridge;

--- a/src/bridge/RippleJSBridge.js
+++ b/src/bridge/RippleJSBridge.js
@@ -741,6 +741,8 @@ export const accountBridge: AccountBridge<Transaction> = {
     )
   }),
 
+  prepareTransaction: (account, transaction) => Promise.resolve(transaction),
+
   getDefaultEndpointConfig: () => defaultEndpoint,
 
   validateEndpointConfig: async endpointConfig => {

--- a/src/bridge/makeMockBridge.js
+++ b/src/bridge/makeMockBridge.js
@@ -179,6 +179,9 @@ export function makeMockAccountBridge(_opts?: Opts): AccountBridge<*> {
     pendingOperations: [...account.pendingOperations, optimisticOperation]
   });
 
+  const prepareTransaction = (account, transaction) =>
+    Promise.resolve(transaction);
+
   // TODO add optimistic update
   return {
     startSync,
@@ -197,7 +200,8 @@ export function makeMockAccountBridge(_opts?: Opts): AccountBridge<*> {
     getTotalSpent,
     getMaxAmount,
     signAndBroadcast,
-    addPendingOperation
+    addPendingOperation,
+    prepareTransaction
   };
 }
 

--- a/src/bridge/types.js
+++ b/src/bridge/types.js
@@ -9,12 +9,7 @@
 
 import type { Observable } from "rxjs";
 import type { BigNumber } from "bignumber.js";
-import type {
-  TokenAccount,
-  Account,
-  Operation,
-  CryptoCurrency
-} from "../types";
+import type { Account, Operation, CryptoCurrency } from "../types";
 
 // unique identifier of a device. it will depends on the underlying implementation.
 export type DeviceId = string;
@@ -73,11 +68,13 @@ export interface AccountBridge<Transaction> {
   // For doing token account transactions, everything remain the same except
   // you need to build Transaction with a contextual TokenAccount
   // otherwise, all reference to Account remains the mainAccount
-  setTokenAccount?: (
+  editTokenAccountId?: (
     account: Account,
     transaction: Transaction,
-    tokenAccount: ?TokenAccount
+    tokenAccountId: ?string
   ) => Transaction;
+
+  getTokenAccountId?: (account: Account, transaction: Transaction) => ?string;
 
   editTransactionAmount(
     account: Account,
@@ -159,8 +156,17 @@ export interface AccountBridge<Transaction> {
   validateEndpointConfig?: (endpointConfig: string) => Promise<void>;
 
   // TODO we need a better paradigm for this
+  // DEPRECATED for prepareTransaction
   estimateGasLimit?: (
     account: Account,
     address: string
   ) => Promise<number | BigNumber>; // TODO drop number support
+
+  // prepare the remaining missing part of a transaction and emit it
+  // Beware that transaction can be changed so the point is you can unsubscribe this
+  // typically we use it to fill up the gas limit but more ideas can be unified in this... (like the network info?)
+  prepareTransaction(
+    account: Account,
+    transaction: Transaction
+  ): Promise<Transaction>;
 }

--- a/src/families/ethereum/libcore-buildTransaction.js
+++ b/src/families/ethereum/libcore-buildTransaction.js
@@ -4,7 +4,7 @@ import invariant from "invariant";
 import { BigNumber } from "bignumber.js";
 import eip55 from "eip55";
 import { FeeNotLoaded } from "@ledgerhq/errors";
-import type { TokenAccount, Account, Transaction } from "../../types";
+import type { Account, Transaction } from "../../types";
 import { isValidRecipient } from "../../libcore/isValidRecipient";
 import { bigNumberToLibcoreAmount } from "../../libcore/buildBigNumber";
 import type { Core, CoreCurrency, CoreAccount } from "../../libcore/types";
@@ -14,7 +14,6 @@ const ethereumTransferMethodID = Buffer.from("a9059cbb", "hex");
 
 export async function ethereumBuildTransaction({
   account,
-  tokenAccount,
   core,
   coreAccount,
   coreCurrency,
@@ -22,7 +21,6 @@ export async function ethereumBuildTransaction({
   isCancelled
 }: {
   account: Account,
-  tokenAccount: ?TokenAccount,
   core: Core,
   coreAccount: CoreAccount,
   coreCurrency: CoreCurrency,
@@ -30,6 +28,11 @@ export async function ethereumBuildTransaction({
   isPartial: boolean,
   isCancelled: () => boolean
 }): Promise<?CoreEthereumLikeTransaction> {
+  const { tokenAccountId } = transaction;
+  const tokenAccount = tokenAccountId
+    ? account.tokenAccounts &&
+      account.tokenAccounts.find(t => t.id === tokenAccountId)
+    : null;
   const ethereumLikeAccount = await coreAccount.asEthereumLikeAccount();
 
   await isValidRecipient({

--- a/src/families/ethereum/libcore-hw-signTransaction.js
+++ b/src/families/ethereum/libcore-hw-signTransaction.js
@@ -4,25 +4,29 @@ import invariant from "invariant";
 import Eth from "@ledgerhq/hw-app-eth";
 import Transport from "@ledgerhq/hw-transport";
 import { byContractAddress } from "@ledgerhq/hw-app-eth/erc20";
-import type { CryptoCurrency, Account, TokenAccount } from "../../types";
+import type { CryptoCurrency, Account } from "../../types";
 import type { CoreCurrency } from "../../libcore/types";
 import type { CoreEthereumLikeTransaction } from "./types";
 
 export async function ethereumSignTransaction({
   transport,
   account,
-  tokenAccount,
-  coreTransaction
+  coreTransaction,
+  tokenAccountId
 }: {
   isCancelled: () => boolean,
   transport: Transport<*>,
   account: Account,
-  tokenAccount: ?TokenAccount,
   currency: CryptoCurrency,
+  tokenAccountId: ?string,
   coreCurrency: CoreCurrency,
   coreTransaction: CoreEthereumLikeTransaction
 }) {
   const hwApp = new Eth(transport);
+  const tokenAccount = tokenAccountId
+    ? account.tokenAccounts &&
+      account.tokenAccounts.find(t => t.id === tokenAccountId)
+    : null;
 
   if (tokenAccount) {
     const { token } = tokenAccount;

--- a/src/libcore/buildTransaction.js
+++ b/src/libcore/buildTransaction.js
@@ -1,11 +1,10 @@
 // @flow
-import type { TokenAccount, Account, Transaction } from "../types";
+import type { Account, Transaction } from "../types";
 import type { Core, CoreCurrency, CoreAccount } from "./types";
 import byFamily from "../generated/libcore-buildTransaction";
 
 export default (opts: {
   account: Account,
-  tokenAccount: ?TokenAccount,
   core: Core,
   coreAccount: CoreAccount,
   coreCurrency: CoreCurrency,

--- a/src/libcore/getFeesForTransaction.js
+++ b/src/libcore/getFeesForTransaction.js
@@ -2,7 +2,7 @@
 
 import { BigNumber } from "bignumber.js";
 import { getWalletName } from "../account";
-import type { Account, TokenAccount, Transaction } from "../types";
+import type { Account, Transaction } from "../types";
 import { withLibcoreF } from "./access";
 import { remapLibcoreErrors } from "./errors";
 import { getOrCreateWallet } from "./getOrCreateWallet";
@@ -11,14 +11,13 @@ import byFamily from "../generated/libcore-getFeesForTransaction";
 
 export type Input = {
   account: Account,
-  tokenAccount?: ?TokenAccount,
   transaction: Transaction
 };
 
 type F = Input => Promise<BigNumber>;
 
 export const getFeesForTransaction: F = withLibcoreF(
-  core => async ({ account, tokenAccount, transaction }) => {
+  core => async ({ account, transaction }) => {
     try {
       const { derivationMode, currency } = account;
       const walletName = getWalletName(account);
@@ -42,7 +41,6 @@ export const getFeesForTransaction: F = withLibcoreF(
       if (!f) throw new Error("currency " + currency.id + " not supported");
       let fees = await f({
         account,
-        tokenAccount,
         core,
         coreAccount,
         coreCurrency,

--- a/src/libcore/signAndBroadcast.js
+++ b/src/libcore/signAndBroadcast.js
@@ -4,7 +4,7 @@ import { Observable, from } from "rxjs";
 import { StatusCodes } from "@ledgerhq/hw-transport";
 import { UpdateYourApp } from "@ledgerhq/errors";
 import { log } from "@ledgerhq/logs";
-import type { Account, Operation, TokenAccount, Transaction } from "../types";
+import type { Account, Operation, Transaction } from "../types";
 import { getWalletName } from "../account";
 import { withDevice } from "../hw/deviceAccess";
 import type { SignAndBroadcastEvent } from "../bridge/types";
@@ -18,8 +18,6 @@ import byFamily from "../generated/libcore-signAndBroadcast";
 export type Input = {
   // the account to use for the transaction
   account: Account,
-  // tokenAccount if provided will use this account instead and account is just the parent
-  tokenAccount?: ?TokenAccount,
   // all data of the transaction
   transaction: Transaction,
   // device identified to sign the transaction with
@@ -29,7 +27,6 @@ export type Input = {
 const doSignAndBroadcast = withLibcoreF(
   core => async ({
     account,
-    tokenAccount,
     transaction,
     deviceId,
     isCancelled,
@@ -38,7 +35,6 @@ const doSignAndBroadcast = withLibcoreF(
     onOperationBroadcasted
   }: {
     account: Account,
-    tokenAccount: ?TokenAccount,
     transaction: Transaction,
     deviceId: string,
     isCancelled: () => boolean,
@@ -69,7 +65,6 @@ const doSignAndBroadcast = withLibcoreF(
 
     const builded = await buildTransaction({
       account,
-      tokenAccount,
       core,
       coreCurrency,
       coreAccount,
@@ -84,7 +79,7 @@ const doSignAndBroadcast = withLibcoreF(
       from(
         signTransaction({
           account,
-          tokenAccount,
+          tokenAccountId: transaction.tokenAccountId,
           isCancelled,
           transport,
           currency,
@@ -116,7 +111,6 @@ const doSignAndBroadcast = withLibcoreF(
 
     const op = await f({
       account,
-      tokenAccount,
       signedTransaction,
       builded,
       coreAccount,
@@ -131,7 +125,6 @@ const doSignAndBroadcast = withLibcoreF(
 
 export default ({
   account,
-  tokenAccount,
   transaction,
   deviceId
 }: Input): Observable<SignAndBroadcastEvent> =>
@@ -140,7 +133,6 @@ export default ({
     const isCancelled = () => unsubscribed;
     doSignAndBroadcast({
       account,
-      tokenAccount,
       transaction,
       deviceId,
       isCancelled,

--- a/src/libcore/signTransaction.js
+++ b/src/libcore/signTransaction.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Transport from "@ledgerhq/hw-transport";
-import type { CryptoCurrency, Account, TokenAccount } from "../types";
+import type { CryptoCurrency, Account } from "../types";
 import type { CoreCurrency } from "./types";
 import byFamily from "../generated/libcore-hw-signTransaction";
 
@@ -9,7 +9,7 @@ export default (opts: {
   isCancelled: () => boolean,
   transport: Transport<*>,
   account: Account,
-  tokenAccount: ?TokenAccount,
+  tokenAccountId: ?string,
   currency: CryptoCurrency,
   coreCurrency: CoreCurrency,
   coreTransaction: *

--- a/src/types/transaction.js
+++ b/src/types/transaction.js
@@ -6,6 +6,7 @@ export type Transaction = {
   recipient: string,
   amount: ?(BigNumber | string),
   useAllAmount?: boolean,
+  tokenAccountId?: ?string, // if provided, the transaction is done on a token instead
   // bitcoin
   feePerByte?: ?(BigNumber | string),
   // ethereum

--- a/tool/src/transaction.js
+++ b/tool/src/transaction.js
@@ -107,17 +107,18 @@ export async function inferTransaction(account, opts) {
   if (opts.token) {
     const tkn = opts.token.toLowerCase();
     const tokenAccounts = account.tokenAccounts || [];
-    res.tokenAccount = tokenAccounts.find(
+    const tokenAccount = tokenAccounts.find(
       t => tkn === t.token.ticker.toLowerCase() || tkn === t.token.id
     );
-    if (!res.tokenAccount) {
+    if (!tokenAccount) {
       throw new Error(
         "token account '" +
           opts.token +
           "' not found. Available: " +
-          tokenAccounts.map(t => t.token.ticket).join(", ")
+          tokenAccounts.map(t => t.token.ticker).join(", ")
       );
     }
+    res.transaction.tokenAccountId = tokenAccount.id;
   }
 
   if (!("gasLimit" in res.transaction)) {


### PR DESCRIPTION
- add getAccountUnit
- bridge introduces a method `prepareTransaction(account, transaction): Promise<Transaction>` that will complete information for the transaction to be ready. We will use that to fill the gasLimit info. In the future we can unify more stuff in that, like fetching the available fees. We will brainstorm more internally, how often we need to resync with such function / where to do it & do we need more precise lifecycles (before/after?). I think this is the most tricky UI part of our whole application because a lot of mutual dependencies between fields and behavior differences between coins.
- it also makes libcore bridge ready to use for ERC20 