### PR TITLE
 Ability to pass libcore db password as an argument

### DIFF
--- a/src/libcore/platforms/nodejs.js
+++ b/src/libcore/platforms/nodejs.js
@@ -21,7 +21,8 @@ const fs = require("fs");
 export default (arg: {
   // the actual @ledgerhq/ledger-core lib or a function that returns it
   lib: any,
-  dbPath: string
+  dbPath: string,
+  dbPassword?: string
 }) => {
   let lib;
   const lazyLoad = () => {
@@ -33,6 +34,10 @@ export default (arg: {
     }
   };
   const { dbPath } = arg;
+  const dbPassword =
+    typeof arg.dbPassword === "undefined"
+      ? getEnv("LIBCORE_PASSWORD")
+      : arg.dbPassword;
 
   const loadCore = (): Promise<Core> => {
     lazyLoad();
@@ -220,7 +225,7 @@ export default (arg: {
 
       walletPoolInstance = new lib.NJSWalletPool(
         "ledgerlive",
-        getEnv("LIBCORE_PASSWORD"),
+        dbPassword,
         NJSHttpClient,
         NJSWebSocketClient,
         NJSPathResolver,

--- a/src/libcore/platforms/nodejs.js
+++ b/src/libcore/platforms/nodejs.js
@@ -194,9 +194,9 @@ export default (arg: {
 
     let walletPoolInstance = null;
 
-    const instanciateWalletPool = o => {
+    const instanciateWalletPool = () => {
       try {
-        fs.mkdirSync(o.dbPath);
+        fs.mkdirSync(dbPath);
       } catch (err) {
         if (err.code !== "EEXIST") {
           throw err;
@@ -236,10 +236,7 @@ export default (arg: {
 
     const getPoolInstance = () => {
       if (!walletPoolInstance) {
-        instanciateWalletPool({
-          // sqlite files will be located in the app local data folder
-          dbPath
-        });
+        instanciateWalletPool();
       }
       invariant(walletPoolInstance, "can't initialize walletPoolInstance");
       return walletPoolInstance;

--- a/src/libcore/types/index.js
+++ b/src/libcore/types/index.js
@@ -37,6 +37,7 @@ declare class CoreWalletPool {
   ): Promise<CoreWallet>;
   freshResetAll(): Promise<void>;
   changePassword(oldPassword: string, newPassword: string): Promise<void>;
+  getName(): Promise<string>;
 }
 
 declare class CoreWallet {


### PR DESCRIPTION
New optional object member `dbPassword` to pass the password without relying on a env variable (as their values can be accessed trivially from outside).

If `dbPassword` is missing, `LIBCORE_PASSWORD` is used instead, so it should be painless for current implementations.