### PR TITLE
Fixes invalid arithmetic operation on BigNumber

### DIFF
--- a/src/transaction.js
+++ b/src/transaction.js
@@ -26,7 +26,7 @@ export async function getTransactionStatus(
   let maxAmount;
   if (useAllAmount) maxAmount = await bridge.getMaxAmount(account, transaction);
 
-  const estimatedFees = totalSpent - (maxAmount || amount);
+  const estimatedFees = totalSpent.minus(maxAmount || amount);
 
   const showFeeWarning =
     (amount &&


### PR DESCRIPTION
I dont know why flow wasn't complaining in live-common but it is complaining about this on desktop. In any case, doing arithmetic operations on `BigNumber` is obviously wrong, so this is needed.