### PR TITLE
add getAccountContractExplorer to explorers and token address for ethereum

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -855,7 +855,8 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
     explorerViews: [
       {
         tx: "https://etherscan.io/tx/$hash",
-        address: "https://etherscan.io/address/$address"
+        address: "https://etherscan.io/address/$address",
+        token: "https://etherscan.io/token/$contractAddress?a=$address"
       }
     ]
   },

--- a/src/explorers.js
+++ b/src/explorers.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { CryptoCurrency, ExplorerView } from "./types";
+import type { CryptoCurrency, ExplorerView, TokenAccount, Account } from "./types";
 
 export const getDefaultExplorerView = (
   currency: CryptoCurrency
@@ -19,3 +19,11 @@ export const getAddressExplorer = (
   explorerView &&
   explorerView.address &&
   explorerView.address.replace("$address", address);
+
+export const getAccountContractExplorer = (
+  explorerView: ?ExplorerView,
+  account: TokenAccount,
+  parentAccount: Account
+): ?string => explorerView &&
+  explorerView.token &&
+  explorerView.token.replace("$contractAddress", account.token.contractAddress).replace('$address', parentAccount.freshAddress);

--- a/src/types/currencies.js
+++ b/src/types/currencies.js
@@ -42,7 +42,8 @@ export type FiatCurrency = CurrencyCommon & {
 
 export type ExplorerView = {
   tx?: string,
-  address?: string
+  address?: string,
+  token?: string,
 };
 
 export type CryptoCurrency = CurrencyCommon & {


### PR DESCRIPTION
Adds a new field in Ethereum=>ExplorerViews to view tokens and added a * getAccountContractExplorer* helper function