### PR TITLE
Use blockcypher as testnet explorer

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -2393,8 +2393,8 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
     },
     explorerViews: [
       {
-        tx: "https://testnet.blockchain.info/tx/$hash",
-        address: "https://testnet.blockchain.info/address/$address"
+        tx: "https://live.blockcypher.com/btc-testnet/tx/$hash",
+        address: "https://live.blockcypher.com/btc-testnet/address/$address"
       }
     ]
   },


### PR DESCRIPTION
Seems that the blockchain.info testnet explorer has issues, couldn't find a way to browse tx/address.

e.g:

- tx `08abd8d1e14442a0fea655085ff1864d40871cac27941f8de8f774e56697b526`
[blockcypher link](https://live.blockcypher.com/btc-testnet/tx/08abd8d1e14442a0fea655085ff1864d40871cac27941f8de8f774e56697b526/) / [blockchain link](https://testnet.blockchain.info/tx/08abd8d1e14442a0fea655085ff1864d40871cac27941f8de8f774e56697b526)
- address `2NEfsR6yeuF8tusetj5jhPz7LizY7frRfqu`
[blockcypher link](https://live.blockcypher.com/btc-testnet/address/2NEfsR6yeuF8tusetj5jhPz7LizY7frRfqu) / [blockchain link](https://testnet.blockchain.info/address/2NEfsR6yeuF8tusetj5jhPz7LizY7frRfqu)