### PR TITLE
Add importAccounts functions and add freshAddress to export

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "eslint-plugin-jsx-a11y": "^6.2.3",
     "flow-bin": "^0.102.0",
     "flow-copy-source": "^2.0.7",
-    "flow-typed": "^2.5.2",
+    "flow-typed": "^2.6.0",
     "glob": "^7.1.4",
     "jest": "23",
     "prettier": "^1.18.2",

--- a/src/__tests__/accounts/importAccounts.js
+++ b/src/__tests__/accounts/importAccounts.js
@@ -1,0 +1,172 @@
+// @flow
+
+import { setEnv } from "../../env";
+import {
+  importAccountsMakeItems,
+  importAccountsReduce,
+  fromAccountRaw
+} from "../../account";
+import { setSupportedCurrencies } from "../../currencies";
+
+setSupportedCurrencies(["ethereum"]);
+setEnv("EXPERIMENTAL_LIBCORE", true);
+
+test("importAccountsMakeItems", () => {
+  const result = {
+    meta: { exporterName: "desktop", exporterVersion: "1.12.0" },
+    accounts: [
+      {
+        id: "libcore:1:ethereum:xpub1:",
+        name: "Ethereum 1",
+        seedIdentifier: "seed",
+        derivationMode: "",
+        freshAddress: "0x01",
+        currencyId: "ethereum",
+        index: 0,
+        balance: "51281813126095913"
+      },
+      {
+        id: "libcore:1:ethereum:xpub2:",
+        name: "Ethereum 2",
+        seedIdentifier: "seed",
+        derivationMode: "",
+        freshAddress: "0x02",
+        currencyId: "ethereum",
+        index: 1,
+        balance: "1081392000000000"
+      },
+      {
+        id: "libcore:1:ethereum:xpub4:",
+        name: "Ethereum 4",
+        seedIdentifier: "seed",
+        derivationMode: "",
+        freshAddress: "0x04",
+        currencyId: "ethereum",
+        index: 3,
+        balance: "1000000000000000"
+      },
+      {
+        id: "libcore:1:ethereum:xpub3:",
+        name: "ETH3 name edited",
+        seedIdentifier: "seed",
+        derivationMode: "",
+        freshAddress: "0x03",
+        currencyId: "ethereum",
+        index: 2,
+        balance: "0"
+      },
+      {
+        id: "libcore:1:ethereum:xpub5:",
+        name: "Ethereum 5",
+        seedIdentifier: "seed",
+        derivationMode: "",
+        freshAddress: "0x05",
+        currencyId: "ethereum",
+        index: 4,
+        balance: "0"
+      }
+    ],
+    settings: {
+      counterValue: "USD",
+      currenciesSettings: {},
+      pairExchanges: {},
+      developerModeEnabled: false
+    }
+  };
+  const accounts = [
+    {
+      id: "ethereumjs:2:ethereum:0x01:",
+      seedIdentifier: "0x01",
+      name: "Ethereum 1",
+      derivationMode: "",
+      index: 0,
+      freshAddress: "0x01",
+      freshAddressPath: "44'/60'/0'/0/0",
+      blockHeight: 8168983,
+      operations: [],
+      pendingOperations: [],
+      currencyId: "ethereum",
+      unitMagnitude: 18,
+      lastSyncDate: "2019-07-17T15:13:30.318Z",
+      balance: "51281813126095910"
+    },
+    {
+      id: "ethereumjs:2:ethereum:0x02:",
+      seedIdentifier: "0x02",
+      name: "Ethereum 2",
+      derivationMode: "",
+      index: 1,
+      freshAddress: "0x02",
+      freshAddressPath: "44'/60'/1'/0/0",
+      blockHeight: 8168983,
+      operations: [],
+      pendingOperations: [],
+      currencyId: "ethereum",
+      unitMagnitude: 18,
+      lastSyncDate: "2019-07-17T15:13:29.306Z",
+      balance: "1081392000000000"
+    },
+    {
+      id: "libcore:1:ethereum:xpub3:",
+      seedIdentifier: "seed",
+      name: "Ethereum 3",
+      derivationMode: "",
+      index: 2,
+      freshAddress: "0x03",
+      freshAddressPath: "44'/60'/2'/0/0",
+      blockHeight: 8168983,
+      operations: [],
+      pendingOperations: [],
+      currencyId: "ethereum",
+      unitMagnitude: 18,
+      lastSyncDate: "2019-07-17T15:13:29.306Z",
+      balance: "1081392000000000"
+    }
+  ].map(fromAccountRaw);
+
+  const items = importAccountsMakeItems({ result, accounts });
+
+  expect(items).toMatchObject([
+    {
+      initialAccountId: "libcore:1:ethereum:xpub4:",
+      account: { id: "libcore:1:ethereum:xpub4:", name: "Ethereum 4" },
+      mode: "create"
+    },
+    {
+      initialAccountId: "libcore:1:ethereum:xpub5:",
+      account: { id: "libcore:1:ethereum:xpub5:", name: "Ethereum 5" },
+      mode: "create"
+    },
+    {
+      initialAccountId: "ethereumjs:2:ethereum:0x01:",
+      account: { id: "libcore:1:ethereum:xpub1:", name: "Ethereum 1" },
+      mode: "update"
+    },
+    {
+      initialAccountId: "ethereumjs:2:ethereum:0x02:",
+      account: { id: "libcore:1:ethereum:xpub2:", name: "Ethereum 2" },
+      mode: "update"
+    },
+    {
+      initialAccountId: "libcore:1:ethereum:xpub3:",
+      account: { id: "libcore:1:ethereum:xpub3:", name: "ETH3 name edited" },
+      mode: "update"
+    }
+  ]);
+
+  const reduced = importAccountsReduce(accounts, {
+    items,
+    selectedAccounts: [
+      "libcore:1:ethereum:xpub3:",
+      "libcore:1:ethereum:xpub2:",
+      "libcore:1:ethereum:xpub5:"
+    ]
+  });
+
+  expect(reduced).toMatchObject([
+    { id: "ethereumjs:2:ethereum:0x01:", name: "Ethereum 1" },
+    { id: "libcore:1:ethereum:xpub2:", name: "Ethereum 2" },
+    { id: "libcore:1:ethereum:xpub3:", name: "ETH3 name edited" },
+    { id: "libcore:1:ethereum:xpub5:", name: "Ethereum 5" }
+  ]);
+});

--- a/src/__tests__/bridgestream/__snapshots__/index.js.snap
+++ b/src/__tests__/bridgestream/__snapshots__/index.js.snap
@@ -7,6 +7,7 @@ Object {
       "balance": "15710290533550751349",
       "currencyId": "ethereum",
       "derivationMode": "",
+      "freshAddress": "0x8C5FE6AF52E79EC4361B7A12B53356EF5D37C765",
       "id": "mock:1:ethereum:export_0:",
       "index": 1,
       "name": "qfLJHUiyMqUUN",
@@ -16,6 +17,7 @@ Object {
       "balance": "53736258",
       "currencyId": "bitcoin_cash",
       "derivationMode": "",
+      "freshAddress": "1x7aLVWzaGVH8AWQ4aaD2hdcmJW",
       "id": "mock:1:bitcoin_cash:export_1:",
       "index": 1,
       "name": "Y4SYkWgSWIIZptphvAu",
@@ -25,6 +27,7 @@ Object {
       "balance": "128088571428550",
       "currencyId": "dogecoin",
       "derivationMode": "",
+      "freshAddress": "1CWNKLfcukxxXRNRK1DpYwPA6Hb1h",
       "id": "mock:1:dogecoin:export_2:",
       "index": 1,
       "name": "s9dZEiOrwfEPOXbKgNKq88aQZ",
@@ -37,11 +40,13 @@ Object {
   },
   "settings": Object {
     "counterValue": "USD",
-    "counterValueExchange": "KRAKEN",
     "currenciesSettings": Object {
       "bitcoin": Object {
-        "exchange": "KRAKEN",
+        "confirmationsNb": 3,
       },
+    },
+    "pairExchanges": Object {
+      "BTC_USD": "KRAKEN",
     },
   },
 }

--- a/src/__tests__/bridgestream/index.js
+++ b/src/__tests__/bridgestream/index.js
@@ -11,10 +11,12 @@ test("encode/decode", () => {
     accounts,
     settings: {
       counterValue: "USD",
-      counterValueExchange: "KRAKEN",
+      pairExchanges: {
+        BTC_USD: "KRAKEN"
+      },
       currenciesSettings: {
         bitcoin: {
-          exchange: "KRAKEN"
+          confirmationsNb: 3
         }
       }
     },
@@ -35,10 +37,12 @@ test("encode/decode", () => {
   );
   expect(res.settings).toMatchObject({
     counterValue: "USD",
-    counterValueExchange: "KRAKEN",
+    pairExchanges: {
+      BTC_USD: "KRAKEN"
+    },
     currenciesSettings: {
       bitcoin: {
-        exchange: "KRAKEN"
+        confirmationsNb: 3
       }
     }
   });

--- a/src/__tests__/cross.js
+++ b/src/__tests__/cross.js
@@ -42,7 +42,8 @@ test("encode/decode", () => {
   const data = {
     accounts,
     settings: {
-      currenciesSettings: {}
+      currenciesSettings: {},
+      pairExchanges: {}
     },
     exporterName: "test你好👋",
     exporterVersion: "0.0.0"

--- a/src/account/importAccounts.js
+++ b/src/account/importAccounts.js
@@ -1,0 +1,111 @@
+// @flow
+import type { Account } from "../types";
+import { log } from "@ledgerhq/logs";
+import type { Result } from "../cross";
+import { accountDataToAccount } from "../cross";
+import { findAccountMigration } from "./addAccounts";
+import { isCurrencySupported } from "../currencies";
+
+const itemModeDisplaySort = {
+  create: 1,
+  update: 2,
+  id: 3,
+  unsupported: 4
+};
+
+export type ImportItemMode = $Keys<typeof itemModeDisplaySort>;
+export type ImportItem = {
+  initialAccountId: string,
+  account: Account,
+  mode: ImportItemMode
+};
+
+export const importAccountsMakeItems = ({
+  result,
+  accounts,
+  items
+}: {
+  result: Result,
+  accounts: Account[],
+  items?: ImportItem[]
+}): ImportItem[] =>
+  result.accounts
+    .map(accInput => {
+      const prevItem = (items || []).find(
+        item => item.account.id === accInput.id
+      );
+      if (prevItem) return prevItem;
+
+      try {
+        const account = accountDataToAccount(accInput);
+        const migratableAccount = accounts.find(a =>
+          findAccountMigration(a, [account])
+        );
+        if (migratableAccount) {
+          // in migration case, we completely replace the older account
+          return {
+            initialAccountId: migratableAccount.id,
+            account,
+            mode: "update"
+          };
+        }
+        const existingAccount = accounts.find(a => a.id === accInput.id);
+        if (existingAccount) {
+          // only the name is supposed to change. rest is never changing
+          if (existingAccount.name === accInput.name) {
+            return {
+              initialAccountId: existingAccount.id,
+              account: existingAccount,
+              mode: "id"
+            };
+          }
+          return {
+            initialAccountId: existingAccount.id,
+            account: { ...existingAccount, name: accInput.name },
+            mode: "update"
+          };
+        }
+
+        return {
+          initialAccountId: account.id,
+          account,
+          mode: isCurrencySupported(account.currency) ? "create" : "unsupported"
+        };
+      } catch (e) {
+        log("error", String(e));
+        return null;
+      }
+    })
+    .filter(Boolean)
+    .sort((a, b) => itemModeDisplaySort[a.mode] - itemModeDisplaySort[b.mode]);
+
+export const importAccountsReduce = (
+  existingAccounts: Account[],
+  {
+    items,
+    selectedAccounts
+  }: {
+    items: ImportItem[],
+    selectedAccounts: string[]
+  }
+): Account[] => {
+  const accounts = existingAccounts.slice(0);
+  const selectedItems = items.filter(item =>
+    selectedAccounts.includes(item.account.id)
+  );
+  for (const { mode, account, initialAccountId } of selectedItems) {
+    switch (mode) {
+      case "create":
+        accounts.push(account);
+        break;
+      case "update": {
+        const item = accounts.find(a => a.id === initialAccountId);
+        const i = accounts.indexOf(item);
+        accounts[i] = account;
+        break;
+      }
+      default:
+    }
+  }
+  return accounts;
+};

--- a/src/account/index.js
+++ b/src/account/index.js
@@ -22,6 +22,12 @@ import {
   migrateAccounts
 } from "./addAccounts";
 import {
+  importAccountsMakeItems,
+  importAccountsReduce,
+  type ImportItem,
+  type ImportItemMode
+} from "./importAccounts";
+import {
   inferSubOperations,
   toOperationRaw,
   fromOperationRaw,
@@ -47,7 +53,12 @@ import {
   groupAccountOperationsByDay
 } from "./groupOperations";
 
-export type { AddAccountsSection, AddAccountsSectionResult };
+export type {
+  AddAccountsSection,
+  AddAccountsSectionResult,
+  ImportItem,
+  ImportItemMode
+};
 
 export {
   getMainAccount,
@@ -82,5 +93,7 @@ export {
   groupAccountsOperationsByDay,
   groupAccountOperationsByDay,
   addPendingOperation,
-  shortAddressPreview
+  shortAddressPreview,
+  importAccountsMakeItems,
+  importAccountsReduce
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,19 +3447,21 @@ flow-copy-source@^2.0.7:
     kefir "^3.7.3"
     yargs "^13.1.0"
 
-flow-typed@^2.5.2:
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/flow-typed/-/flow-typed-2.5.2.tgz#967e83c762a1cbfcd52eebaece1ade77944f1714"
-  integrity sha512-RrHRmp/Bof1vDG1AqBcwuyxMMoezkl7TxvimA5c6GKZOOb1fkkRZ81S+1qAuvb4rUka5fLlFomKCnpMnCsgP+g==
+flow-typed@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/flow-typed/-/flow-typed-2.6.0.tgz#504e6a7e7312ab31adc1717e6527b94014a459a6"
+  integrity sha512-aTd2ygnb9e0/O4Rskzh/zYMU0NJR3PygoheTfiDEOCbEVdXS6mpX/TfcpcbpPVcJpqqV44+pjhOt36VXlYkLRA==
   dependencies:
     "@babel/polyfill" "^7.0.0"
     "@octokit/rest" "^15.12.1"
     colors "^1.3.2"
+    flowgen "^1.9.0"
     fs-extra "^7.0.0"
     glob "^7.1.3"
     got "^8.3.2"
     md5 "^2.2.1"
     mkdirp "^0.5.1"
+    prettier "^1.18.2"
     rimraf "^2.6.2"
     semver "^5.5.1"
     table "^5.0.2"
@@ -3467,6 +3469,21 @@ flow-typed@^2.5.2:
     unzipper "^0.9.3"
     which "^1.3.1"
     yargs "^12.0.2"
+
+flowgen@^1.9.0:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/flowgen/-/flowgen-1.9.2.tgz#bf4b6319b5455e8724094ab1d8ba2a3b6f3c3a13"
+  integrity sha512-YKKNGUqLX/J8nNClaaoaAmICZVVUACRERbyuZPSLN/sDEK5DWRStvV+cUG/QL2ZCLRc1obZgHvkF2LR5CEK2oQ==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/highlight" "^7.0.0"
+    commander "^2.11.0"
+    lodash "^4.17.4"
+    paralleljs "^0.2.1"
+    prettier "^1.16.4"
+    shelljs "^0.8.3"
+    typescript "^3.3.3333"
+    typescript-compiler "^1.4.1-2"
 
 follow-redirects@1.5.10:
   version "1.5.10"
@@ -4024,6 +4041,11 @@ inquirer@^6.2.2:
     string-width "^2.1.0"
     strip-ansi "^5.1.0"
     through "^2.3.6"
+
+interpret@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/interpret/-/interpret-1.2.0.tgz#d5061a6224be58e8083985f5014d844359576296"
+  integrity sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==
 
 into-stream@^3.1.0:
   version "3.1.0"
@@ -5777,6 +5799,11 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
+paralleljs@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/paralleljs/-/paralleljs-0.2.1.tgz#ebca745d3e09c01e2bebcc14858891ff4510e926"
+  integrity sha1-68p0XT4JwB4r68wUhYiR/0UQ6SY=
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -5933,7 +5960,7 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.13.0, prettier@^1.18.2:
+prettier@^1.13.0, prettier@^1.16.4, prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
@@ -6146,6 +6173,13 @@ realpath-native@^1.0.0:
   integrity sha512-wlgPA6cCIIg9gKz0fgAPjnzh4yR/LnXovwuo9hvyGvx3h8nX4+/iLZplfUWasXpqD8BdnGnP5njOFjkUwPzvjA==
   dependencies:
     util.promisify "^1.0.0"
+
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
 
 recursive-readdir@^2.2.2:
   version "2.2.2"
@@ -6385,6 +6419,13 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
+
+resolve@^1.1.6:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.11.1.tgz#ea10d8110376982fef578df8fc30b9ac30a07a3e"
+  integrity sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==
+  dependencies:
+    path-parse "^1.0.6"
 
 resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.5.0:
   version "1.11.0"
@@ -6683,6 +6724,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shelljs@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -7223,6 +7273,16 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+typescript-compiler@^1.4.1-2:
+  version "1.4.1-2"
+  resolved "https://registry.yarnpkg.com/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz#ba4f7db22d91534a1929d90009dce161eb72fd3f"
+  integrity sha1-uk99si2RU0oZKdkACdzhYety/T8=
+
+typescript@^3.3.3333:
+  version "3.5.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.3.tgz#c830f657f93f1ea846819e929092f5fe5983e977"
+  integrity sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g==
 
 uglify-js@^3.1.4:
   version "3.5.4"


### PR DESCRIPTION
add two methods to be used by mobile for the "import from desktop" logic:

- importAccountsMakeItems
- importAccountsReduce

Fixes:

- fix the LiveQR to export the pairs again
- LiveQR also need to export freshAddress in order for a "migration" to be seen. mobile will still have to enable LIBCORE_EXPERIMENTAL