### PR TITLE
LL-1681 Throw a AccountNotSupported error if derivation mode is not supported

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 package.json
 src/load
 src/generated
+src/crypto/sha256.js

--- a/src/bridge/index.js
+++ b/src/bridge/index.js
@@ -1,5 +1,5 @@
 // @flow
-import { createCustomErrorClass } from "@ledgerhq/errors";
+import { AccountNotSupported, CurrencyNotSupported } from "@ledgerhq/errors";
 import type { CryptoCurrency, Account, TokenAccount } from "../types";
 import type { CurrencyBridge, AccountBridge } from "./types";
 import { decodeAccountId, getMainAccount } from "../account";
@@ -13,9 +13,7 @@ import {
   makeMockCurrencyBridge,
   makeMockAccountBridge
 } from "./makeMockBridge";
-
-// TODO as soon as it's in @ledgerhq/errors we can import it
-const CurrencyNotSupported = createCustomErrorClass("CurrencyNotSupported");
+import { getAllDerivationModes } from "../derivation";
 
 const mockCurrencyBridge = makeMockCurrencyBridge();
 const mockAccountBridge = makeMockAccountBridge();
@@ -44,6 +42,9 @@ export const getAccountBridge = (
 ): AccountBridge<any> => {
   const mainAccount = getMainAccount(account, parentAccount);
   const { type } = decodeAccountId(mainAccount.id);
+  if (!getAllDerivationModes().includes(mainAccount.derivationMode)) {
+    throw new AccountNotSupported({ reason: mainAccount.derivationMode });
+  }
   if (type === "mock") return mockAccountBridge;
   if (type === "libcore") {
     if (mainAccount.currency.family === "ethereum") {

--- a/src/derivation.js
+++ b/src/derivation.js
@@ -31,33 +31,11 @@ const modes = Object.freeze({
     overridesDerivation: "44'/60'/0'/<account>",
     tag: "legacy"
   },
-  // chrome wallet legacy derivation
-  ethW1: {
-    isNonIterable: true,
-    overridesDerivation: "44'/60'/0'/0'",
-    isInvalid: true
-  },
-  ethW2: {
-    isNonIterable: true,
-    overridesDerivation: "44'/60'/14'/5'/16",
-    isInvalid: true
-  },
   // MetaMask style
   ethMM: {
     overridesDerivation: "44'/60'/0'/0/<account>",
     skipFirst: true, // already included in the normal bip44,
     tag: "metamask"
-  },
-  // chrome ripple legacy derivations
-  rip: {
-    isNonIterable: true,
-    overridesDerivation: "44'/144'/0'/0'",
-    tag: "legacy"
-  },
-  rip2: {
-    isNonIterable: true,
-    overridesDerivation: "44'/144'/14'/5'/16",
-    isInvalid: true
   },
   // chrome app and LL wrongly used to derivate vertcoin on 128
   vertcoin_128: {
@@ -125,9 +103,8 @@ const modes = Object.freeze({
 
 const legacyDerivations: $Shape<CryptoCurrencyConfig<DerivationMode[]>> = {
   vertcoin: ["vertcoin_128", "vertcoin_128_segwit"],
-  ethereum: ["ethM", "ethW1", "ethW2", "ethMM"],
-  ethereum_classic: ["ethM", "etcM", "ethW1", "ethW2", "ethMM"],
-  ripple: ["rip", "rip2"]
+  ethereum: ["ethM", "ethMM"],
+  ethereum_classic: ["ethM", "etcM", "ethMM"]
 };
 
 export const asDerivationMode = (derivationMode: string): DerivationMode => {

--- a/src/explorers.js
+++ b/src/explorers.js
@@ -1,6 +1,11 @@
 // @flow
 
-import type { CryptoCurrency, ExplorerView, TokenAccount, Account } from "./types";
+import type {
+  CryptoCurrency,
+  ExplorerView,
+  TokenAccount,
+  Account
+} from "./types";
 
 export const getDefaultExplorerView = (
   currency: CryptoCurrency
@@ -24,6 +29,9 @@ export const getAccountContractExplorer = (
   explorerView: ?ExplorerView,
   account: TokenAccount,
   parentAccount: Account
-): ?string => explorerView &&
+): ?string =>
+  explorerView &&
   explorerView.token &&
-  explorerView.token.replace("$contractAddress", account.token.contractAddress).replace('$address', parentAccount.freshAddress);
+  explorerView.token
+    .replace("$contractAddress", account.token.contractAddress)
+    .replace("$address", parentAccount.freshAddress);

--- a/src/types/currencies.js
+++ b/src/types/currencies.js
@@ -43,7 +43,7 @@ export type FiatCurrency = CurrencyCommon & {
 export type ExplorerView = {
   tx?: string,
   address?: string,
-  token?: string,
+  token?: string
 };
 
 export type CryptoCurrency = CurrencyCommon & {


### PR DESCRIPTION
When trying to get an account's bridge, we will now throw an `AccountNotSupported` error if the derivation mode is not supported. This pr also drops ethW1, ethW2, rip and rip2 derivation modes.

Closes https://github.com/LedgerHQ/ledger-live-common/pull/304 because I messed it all up

### Type

Feature

### Context

https://ledgerhq.atlassian.net/browse/LL-1681