### PR TITLE
LL-1549 Add checkCurrencyApp and checkAccountApp commands

### DIFF
--- a/src/hw/checkAccountApp.js
+++ b/src/hw/checkAccountApp.js
@@ -1,0 +1,30 @@
+// @flow
+import Transport from "@ledgerhq/hw-transport";
+import { WrongDeviceForAccount } from "@ledgerhq/errors";
+import getAddress from "./getAddress";
+import checkCurrencyApp from "./checkCurrencyApp";
+import type { Account, CryptoCurrency } from "../types";
+import { isSegwitDerivationMode } from "../derivation";
+
+export default async (
+  transport: Transport<*>,
+  account: Account,
+  currency: CryptoCurrency,
+  devicePath: string
+): Promise<void> => {
+  await checkCurrencyApp(transport, currency, devicePath);
+  const { address } = await getAddress(transport, {
+    derivationMode: account.derivationMode,
+    devicePath,
+    currency,
+    path: account.freshAddressPath,
+    segwit: isSegwitDerivationMode(account.derivationMode)
+  });
+
+  const { freshAddress } = account;
+  if (freshAddress !== address) {
+    throw new WrongDeviceForAccount(`WrongDeviceForAccount ${account.name}`, {
+      accountName: account.name
+    });
+  }
+};

--- a/src/hw/checkCurrencyApp.js
+++ b/src/hw/checkCurrencyApp.js
@@ -1,0 +1,47 @@
+// @flow
+import Transport from "@ledgerhq/hw-transport";
+import getAppAndVersion from "./getAppAndVersion";
+import {
+  DeviceOnDashboardUnexpected,
+  WrongAppForCurrency
+} from "@ledgerhq/errors";
+import getAddress from "./getAddress";
+import type { CryptoCurrency } from "../types";
+import { getDerivationScheme, runDerivationScheme } from "../derivation";
+
+const dashboardAppNames = ["BOLOS", "OLOS\u0000"]; // NB nano x 1.2.4-1 dashboard app name
+
+export default async (
+  transport: Transport<*>,
+  currency: CryptoCurrency,
+  devicePath: string
+): Promise<void> => {
+  const currentApp = await getAppAndVersion(transport).catch(e => {
+    if (e.status === 0x6e00) return null;
+    throw e;
+  });
+
+  if (currentApp) {
+    if (currentApp.name === currency.managerAppName) {
+      return;
+    } else if (dashboardAppNames.includes(currentApp.name)) {
+      throw new DeviceOnDashboardUnexpected();
+    }
+    throw new WrongAppForCurrency(
+      `wrong app ${currentApp.name}, expected ${currency.managerAppName}`,
+      { current: currentApp.name, expected: currency.managerAppName }
+    );
+  } else {
+    // NB fallback for devices not supporting getAppAndVersion
+    await getAddress(transport, {
+      derivationMode: "",
+      devicePath,
+      currency,
+      path: runDerivationScheme(
+        getDerivationScheme({ currency, derivationMode: "" }),
+        currency
+      ),
+      segwit: false
+    });
+  }
+};

--- a/src/hw/deviceAccess.js
+++ b/src/hw/deviceAccess.js
@@ -5,6 +5,7 @@ import { retryWhen, mergeMap, catchError } from "rxjs/operators";
 import type Transport from "@ledgerhq/hw-transport";
 import {
   WrongDeviceForAccount,
+  WrongAppForCurrency,
   CantOpenDevice,
   UpdateYourApp,
   BluetoothRequired,
@@ -150,6 +151,7 @@ export const withDevice = (deviceId: string) => <T>(
   });
 
 export const genericCanRetryOnError = (err: ?Error) => {
+  if (err instanceof WrongAppForCurrency) return false;
   if (err instanceof WrongDeviceForAccount) return false;
   if (err instanceof CantOpenDevice) return false;
   if (err instanceof BluetoothRequired) return false;

--- a/yarn.lock
+++ b/yarn.lock
@@ -5078,12 +5078,12 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.12.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.4:
+lodash@^4.12.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
   integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
-lodash@^4.17.12, lodash@^4.17.15:
+lodash@^4.17.12, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
Adds two commands to diferentiate between the open app and the correct device logic. Allowing us to see if the current open app is the one we are expecting. I'll need to ping @dasilvarosa to get the wording because obviously we can't go with what's in the screenshot :trollface: but for that, it's another pr on desktop.

<img width="1380" alt="Screenshot 2019-07-22 at 19 17 09" src="https://user-images.githubusercontent.com/4631227/61651870-0edf0400-acb7-11e9-8c37-893e82541b4f.png">
