### PR TITLE
Build with Xcode 10.2.1

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ jobs:
   mac:
     working_directory: ~/live-common
     macos:
-      xcode: "9.1.0"
+      xcode: "10.2.1"
     steps:
       - run: brew unlink node && brew install node@8 jq && brew link --overwrite node@8 --force
       - checkout


### PR DESCRIPTION
At CircleCI we are going to be sun-setting the Xcode 9.1 image to make room for two new build images - Xcode 11 and Xcode 10.3.

This change updates the project to build on Xcode 10.2.1, the latest stable version.