### PR TITLE
Introduce libcore getFees

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "7.10.0",
+  "version": "7.11.0-alpha.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/scripts/sync-families-dispatch.sh
+++ b/scripts/sync-families-dispatch.sh
@@ -3,7 +3,7 @@
 set -e
 cd $(dirname $0)
 
-targets="customAddressValidation hw-getAddress libcore-buildOperation libcore-buildTransaction libcore-hw-signTransaction libcore-signAndBroadcast libcore-buildTokenAccounts libcore-getFeesForTransaction libcore-postSyncPatch"
+targets="customAddressValidation hw-getAddress libcore-buildOperation libcore-buildTransaction libcore-hw-signTransaction libcore-signAndBroadcast libcore-buildTokenAccounts libcore-getFeesForTransaction libcore-postSyncPatch libcore-getFees"
 
 cd ../src
 

--- a/src/families/bitcoin/libcore-getFees.js
+++ b/src/families/bitcoin/libcore-getFees.js
@@ -5,7 +5,8 @@ import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
 async function bitcoin({ coreAccount }: { coreAccount: CoreAccount }) {
   const bitcoinLikeAccount = await coreAccount.asBitcoinLikeAccount();
   const bigInts = await bitcoinLikeAccount.getFees();
-  const bigNumbers = Promise.all(bigInts.map(libcoreBigIntToBigNumber));
+  const bigNumbers = await Promise.all(bigInts.map(libcoreBigIntToBigNumber));
+
   return {
     type: "feePerBytes",
     value: bigNumbers

--- a/src/families/bitcoin/libcore-getFees.js
+++ b/src/families/bitcoin/libcore-getFees.js
@@ -1,0 +1,15 @@
+// @flow
+import type { CoreAccount } from "../../libcore/types";
+import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
+
+async function bitcoin({ coreAccount }: { coreAccount: CoreAccount }) {
+  const bitcoinLikeAccount = await coreAccount.asBitcoinLikeAccount();
+  const bigInts = await bitcoinLikeAccount.getFees();
+  const bigNumbers = Promise.all(bigInts.map(libcoreBigIntToBigNumber));
+  return {
+    type: "feePerBytes",
+    value: bigNumbers
+  };
+}
+
+export default bitcoin;

--- a/src/families/bitcoin/libcore-getFees.js
+++ b/src/families/bitcoin/libcore-getFees.js
@@ -1,15 +1,29 @@
 // @flow
+import { BigNumber } from "bignumber.js";
+import type { Account } from "../../types";
 import type { CoreAccount } from "../../libcore/types";
 import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
 
-async function bitcoin({ coreAccount }: { coreAccount: CoreAccount }) {
+type Input = {
+  coreAccount: CoreAccount,
+  account: Account
+};
+
+type Output = Promise<{
+  type: "feePerBytes",
+  value: BigNumber[]
+}>;
+
+async function bitcoin({ coreAccount }: Input): Output {
   const bitcoinLikeAccount = await coreAccount.asBitcoinLikeAccount();
   const bigInts = await bitcoinLikeAccount.getFees();
   const bigNumbers = await Promise.all(bigInts.map(libcoreBigIntToBigNumber));
-
+  const normalized = bigNumbers.map(bn =>
+    bn.div(1000).integerValue(BigNumber.ROUND_CEIL)
+  );
   return {
     type: "feePerBytes",
-    value: bigNumbers
+    value: normalized
   };
 }
 

--- a/src/families/bitcoin/types.js
+++ b/src/families/bitcoin/types.js
@@ -1,6 +1,11 @@
 // @flow
 
-import type { CoreAmount, CoreDerivationPath, Spec } from "../../libcore/types";
+import type {
+  CoreBigInt,
+  CoreAmount,
+  CoreDerivationPath,
+  Spec
+} from "../../libcore/types";
 
 declare class CoreBitcoinLikeInput {
   getPreviousTransaction(): Promise<string>;
@@ -41,6 +46,7 @@ declare class CoreBitcoinLikeAccount {
     isPartial: boolean
   ): Promise<CoreBitcoinLikeTransactionBuilder>;
   broadcastRawTransaction(signed: string): Promise<string>;
+  getFees(): Promise<CoreBigInt[]>;
 }
 
 declare class CoreBitcoinLikeNetworkParameters {
@@ -150,6 +156,9 @@ export const reflect = (declare: (string, Spec) => void) => {
       },
       broadcastRawTransaction: {
         params: ["hex"]
+      },
+      getFees: {
+        returns: ["BigInt"]
       }
     }
   });

--- a/src/families/ethereum/libcore-getFees.js
+++ b/src/families/ethereum/libcore-getFees.js
@@ -1,0 +1,21 @@
+// @flow
+import type { CoreAccount } from "../../libcore/types";
+import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
+
+async function ethereum({
+  account,
+  coreAccount
+}: {
+  coreAccount: CoreAccount
+}) {
+  const ethereumLikeAccount = await coreAccount.asEthereumLikeAccount();
+  const bigInt = await ethereumLikeAccount.getFees();
+  const bigNum = await libcoreBigIntToBigNumber(bigInt);
+
+  return {
+    type: "gas",
+    value: bigNum
+  };
+}
+
+export default ethereum;

--- a/src/families/ethereum/libcore-getFees.js
+++ b/src/families/ethereum/libcore-getFees.js
@@ -1,20 +1,28 @@
 // @flow
+import type { BigNumber } from "bignumber.js";
+import type { Account, Unit } from "../../types";
 import type { CoreAccount } from "../../libcore/types";
 import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
 
-async function ethereum({
-  account,
-  coreAccount
-}: {
-  coreAccount: CoreAccount
-}) {
-  const ethereumLikeAccount = await coreAccount.asEthereumLikeAccount();
-  const bigInt = await ethereumLikeAccount.getFees();
-  const bigNum = await libcoreBigIntToBigNumber(bigInt);
+type Input = {
+  coreAccount: CoreAccount,
+  account: Account
+};
 
+type Output = Promise<{
+  type: "gasPrice",
+  value: BigNumber,
+  unit: Unit
+}>;
+
+async function ethereum({ coreAccount, account }: Input): Output {
+  const ethereumLikeAccount = await coreAccount.asEthereumLikeAccount();
+  const bigInt = await ethereumLikeAccount.getGasPrice();
+  const bigNum = await libcoreBigIntToBigNumber(bigInt);
   return {
-    type: "gas",
-    value: bigNum
+    type: "gasPrice",
+    value: bigNum,
+    unit: account.currency.units[1]
   };
 }
 

--- a/src/families/ethereum/types.js
+++ b/src/families/ethereum/types.js
@@ -51,6 +51,7 @@ declare class CoreEthereumLikeAccount {
   getERC20Accounts(): Promise<CoreERC20LikeAccount[]>;
   buildTransaction(): Promise<CoreEthereumLikeTransactionBuilder>;
   broadcastRawTransaction(signed: string): Promise<string>;
+  getFees(): Promise<CoreBigInt>;
 }
 
 declare class CoreERC20Token {
@@ -190,6 +191,9 @@ export const reflect = (declare: (string, Spec) => void) => {
       },
       getERC20Accounts: {
         returns: ["ERC20LikeAccount"]
+      },
+      getFees: {
+        returns: "BigInt"
       }
     }
   });

--- a/src/families/ethereum/types.js
+++ b/src/families/ethereum/types.js
@@ -51,7 +51,8 @@ declare class CoreEthereumLikeAccount {
   getERC20Accounts(): Promise<CoreERC20LikeAccount[]>;
   buildTransaction(): Promise<CoreEthereumLikeTransactionBuilder>;
   broadcastRawTransaction(signed: string): Promise<string>;
-  getFees(): Promise<CoreBigInt>;
+  getGasPrice(): Promise<CoreBigInt>;
+  getEstimatedGasLimit(address: string): Promise<CoreBigInt>;
 }
 
 declare class CoreERC20Token {
@@ -192,7 +193,10 @@ export const reflect = (declare: (string, Spec) => void) => {
       getERC20Accounts: {
         returns: ["ERC20LikeAccount"]
       },
-      getFees: {
+      getGasPrice: {
+        returns: "BigInt"
+      },
+      getEstimatedGasLimit: {
         returns: "BigInt"
       }
     }

--- a/src/families/ripple/libcore-getFees.js
+++ b/src/families/ripple/libcore-getFees.js
@@ -1,0 +1,16 @@
+// @flow
+import type { CoreAccount } from "../../libcore/types";
+import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
+
+async function ripple({ coreAccount }: { coreAccount: CoreAccount }) {
+  const rippleLikeAccount = await coreAccount.asRippleLikeAccount();
+  const bigInt = await rippleLikeAccount.getFees();
+  const bigNum = await libcoreBigIntToBigNumber(bigInt);
+
+  return {
+    type: "fee",
+    value: bigNum
+  };
+}
+
+export default ripple;

--- a/src/families/ripple/libcore-getFees.js
+++ b/src/families/ripple/libcore-getFees.js
@@ -1,15 +1,28 @@
 // @flow
+import type { BigNumber } from "bignumber.js";
+import type { Account, Unit } from "../../types";
 import type { CoreAccount } from "../../libcore/types";
-import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
+import { libcoreAmountToBigNumber } from "../../libcore/buildBigNumber";
 
-async function ripple({ coreAccount }: { coreAccount: CoreAccount }) {
+type Input = {
+  coreAccount: CoreAccount,
+  account: Account
+};
+
+type Output = Promise<{
+  type: "fee",
+  value: BigNumber,
+  unit: Unit
+}>;
+
+async function ripple({ coreAccount, account }: Input): Output {
   const rippleLikeAccount = await coreAccount.asRippleLikeAccount();
-  const bigInt = await rippleLikeAccount.getFees();
-  const bigNum = await libcoreBigIntToBigNumber(bigInt);
-
+  const fees = await rippleLikeAccount.getFees();
+  const value = await libcoreAmountToBigNumber(fees);
   return {
     type: "fee",
-    value: bigNum
+    value,
+    unit: account.currency.units[0]
   };
 }
 

--- a/src/families/ripple/types.js
+++ b/src/families/ripple/types.js
@@ -1,6 +1,6 @@
 // @flow
 
-import type { CoreAmount, Spec } from "../../libcore/types";
+import type { CoreAmount, CoreBigInt, Spec } from "../../libcore/types";
 
 declare class CoreRippleLikeAddress {
   toBase58(): Promise<string>;
@@ -30,6 +30,7 @@ declare class CoreRippleLikeTransactionBuilder {
 declare class CoreRippleLikeAccount {
   buildTransaction(): Promise<CoreRippleLikeTransactionBuilder>;
   broadcastRawTransaction(signed: string): Promise<string>;
+  getFees(): Promise<CoreBigInt>;
 }
 
 export type CoreStatics = {
@@ -112,6 +113,9 @@ export const reflect = (declare: (string, Spec) => void) => {
       },
       broadcastRawTransaction: {
         params: ["hex"]
+      },
+      getFees: {
+        returns: "BigInt"
       }
     }
   });

--- a/src/families/ripple/types.js
+++ b/src/families/ripple/types.js
@@ -30,7 +30,8 @@ declare class CoreRippleLikeTransactionBuilder {
 declare class CoreRippleLikeAccount {
   buildTransaction(): Promise<CoreRippleLikeTransactionBuilder>;
   broadcastRawTransaction(signed: string): Promise<string>;
-  getFees(): Promise<CoreBigInt>;
+  getFees(): Promise<CoreAmount>;
+  getBaseReserve(): Promise<CoreAmount>;
 }
 
 export type CoreStatics = {
@@ -115,7 +116,10 @@ export const reflect = (declare: (string, Spec) => void) => {
         params: ["hex"]
       },
       getFees: {
-        returns: "BigInt"
+        returns: "Amount"
+      },
+      getBaseReserve: {
+        returns: "Amount"
       }
     }
   });

--- a/src/generated/libcore-getFees.js
+++ b/src/generated/libcore-getFees.js
@@ -1,6 +1,10 @@
 // @flow
 import bitcoin from "../families/bitcoin/libcore-getFees";
+import ethereum from "../families/ethereum/libcore-getFees";
+import ripple from "../families/ripple/libcore-getFees";
 
 export default {
   bitcoin,
+  ethereum,
+  ripple,
 };

--- a/src/generated/libcore-getFees.js
+++ b/src/generated/libcore-getFees.js
@@ -1,0 +1,6 @@
+// @flow
+import bitcoin from "../families/bitcoin/libcore-getFees";
+
+export default {
+  bitcoin,
+};

--- a/src/libcore/getFees.js
+++ b/src/libcore/getFees.js
@@ -32,7 +32,7 @@ export type Output =
 
 type F = Input => Promise<Output>;
 
-export const getFees: F = withLibcoreF(core => async ({ account }) => {
+export const getFees: F = withLibcoreF(core => async account => {
   try {
     const { derivationMode, currency } = account;
     const walletName = getWalletName(account);
@@ -52,12 +52,10 @@ export const getFees: F = withLibcoreF(core => async ({ account }) => {
 
     const f = byFamily[currency.family];
     if (!f) throw new Error("currency " + currency.id + " not supported");
-    const fees = await f({
+    return await f({
       account,
       coreAccount
     });
-
-    return fees;
   } catch (error) {
     throw remapLibcoreErrors(error);
   }

--- a/src/libcore/getFees.js
+++ b/src/libcore/getFees.js
@@ -1,0 +1,64 @@
+// @flow
+
+import { BigNumber } from "bignumber.js";
+import { getWalletName } from "../account";
+import type { Account } from "../types";
+import { withLibcoreF } from "./access";
+import { remapLibcoreErrors } from "./errors";
+import { getOrCreateWallet } from "./getOrCreateWallet";
+import { getOrCreateAccount } from "./getOrCreateAccount";
+import byFamily from "../generated/libcore-getFees";
+
+export type Input = {
+  account: Account
+};
+
+export type Output =
+  | {
+      // btc
+      type: "feePerBytes",
+      value: BigNumber[]
+    }
+  | {
+      // eth?
+      type: "gas",
+      value: BigNumber
+    }
+  | {
+      // ripple?
+      type: "fee",
+      value: BigNumber
+    };
+
+type F = Input => Promise<Output>;
+
+export const getFees: F = withLibcoreF(core => async ({ account }) => {
+  try {
+    const { derivationMode, currency } = account;
+    const walletName = getWalletName(account);
+
+    const coreWallet = await getOrCreateWallet({
+      core,
+      walletName,
+      currency,
+      derivationMode
+    });
+
+    const coreAccount = await getOrCreateAccount({
+      core,
+      coreWallet,
+      account
+    });
+
+    const f = byFamily[currency.family];
+    if (!f) throw new Error("currency " + currency.id + " not supported");
+    const fees = await f({
+      account,
+      coreAccount
+    });
+
+    return fees;
+  } catch (error) {
+    throw remapLibcoreErrors(error);
+  }
+});

--- a/src/libcore/getFees.js
+++ b/src/libcore/getFees.js
@@ -2,16 +2,14 @@
 
 import { BigNumber } from "bignumber.js";
 import { getWalletName } from "../account";
-import type { Account } from "../types";
+import type { Account, Unit } from "../types";
 import { withLibcoreF } from "./access";
 import { remapLibcoreErrors } from "./errors";
 import { getOrCreateWallet } from "./getOrCreateWallet";
 import { getOrCreateAccount } from "./getOrCreateAccount";
 import byFamily from "../generated/libcore-getFees";
 
-export type Input = {
-  account: Account
-};
+export type Input = Account;
 
 export type Output =
   | {
@@ -21,13 +19,15 @@ export type Output =
     }
   | {
       // eth?
-      type: "gas",
-      value: BigNumber
+      type: "gasPrice",
+      value: BigNumber,
+      unit: Unit
     }
   | {
       // ripple?
       type: "fee",
-      value: BigNumber
+      value: BigNumber,
+      unit: Unit
     };
 
 type F = Input => Promise<Output>;
@@ -52,10 +52,11 @@ export const getFees: F = withLibcoreF(core => async account => {
 
     const f = byFamily[currency.family];
     if (!f) throw new Error("currency " + currency.id + " not supported");
-    return await f({
+    const res = await f({
       account,
       coreAccount
     });
+    return res;
   } catch (error) {
     throw remapLibcoreErrors(error);
   }

--- a/src/libcore/platforms/nodejs.js
+++ b/src/libcore/platforms/nodejs.js
@@ -355,6 +355,10 @@ export default (arg: {
             };
           } else {
             const f = m.prototype[method];
+            if (!f) {
+              console.warn(`no such method '${method}' in ${id}`);
+              return;
+            }
             m.prototype[method] = async function met(...a) {
               const args = params
                 ? a.map((value, i) => unwrapArg(params[i], value))

--- a/src/libcore/types/index.js
+++ b/src/libcore/types/index.js
@@ -529,11 +529,6 @@ export const reflect = (declare: (string, Spec) => void) => {
       newInstance: {
         returns: "ThreadDispatcher"
       }
-    },
-    methods: {
-      getMainExecutionContext: {
-        returns: "SerialContext"
-      }
     }
   });
 

--- a/tool/package.json
+++ b/tool/package.json
@@ -13,7 +13,7 @@
     "@ledgerhq/hw-transport-node-ble": "^4.68.2",
     "@ledgerhq/hw-transport-node-hid": "^4.68.2",
     "@ledgerhq/ledger-core": "^3.1.0-beta.2",
-    "@ledgerhq/live-common": "^7.9.3",
+    "@ledgerhq/live-common": "7.11.0-alpha.0",
     "@ledgerhq/logs": "^4.68.2",
     "axios": "^0.19.0",
     "babel-polyfill": "^6.26.0",

--- a/tool/src/commands.js
+++ b/tool/src/commands.js
@@ -29,6 +29,7 @@ import { getEnv } from "@ledgerhq/live-common/lib/env";
 import { isValidRecipient } from "@ledgerhq/live-common/lib/libcore/isValidRecipient";
 import signAndBroadcast from "@ledgerhq/live-common/lib/libcore/signAndBroadcast";
 import { getFeesForTransaction } from "@ledgerhq/live-common/lib/libcore/getFeesForTransaction";
+import { getFees } from "@ledgerhq/live-common/lib/libcore/getFees";
 import { formatCurrencyUnit } from "@ledgerhq/live-common/lib/currencies";
 import { encode } from "@ledgerhq/live-common/lib/cross";
 import manager from "@ledgerhq/live-common/lib/manager";
@@ -558,6 +559,18 @@ const all = {
       scan(opts).pipe(
         map(account =>
           (accountFormatters[opts.format] || accountFormatters.default)(account)
+        )
+      )
+  },
+
+  getFees: {
+    description: "Get fees for account",
+    args: [
+      ...scanCommonOpts,
+    ],
+    job: opts =>
+      scan(opts).pipe(
+        map(async account => console.log(await getFees(account))
         )
       )
   },

--- a/tool/src/scan.js
+++ b/tool/src/scan.js
@@ -3,6 +3,7 @@
 import { BigNumber } from "bignumber.js";
 import { from, defer, of, throwError } from "rxjs";
 import { skip, take, reduce, mergeMap, map, concatMap } from "rxjs/operators";
+import type { Account } from "@ledgerhq/live-common/lib/types";
 import { fromAccountRaw } from "@ledgerhq/live-common/lib/account";
 import { syncAccount } from "@ledgerhq/live-common/lib/libcore/syncAccount";
 import { scanAccountsOnDevice } from "@ledgerhq/live-common/lib/libcore/scanAccountsOnDevice";
@@ -161,7 +162,8 @@ export function scan(arg) {
         const derivationMode = scheme || "";
         return from(
           xpubArray.map(xpub => {
-            const account: Account = {
+            const account: $Exact<Account> = {
+              type: "Account",
               name:
                 cur.name +
                 " " +

--- a/tool/tests/getFees/test.sh
+++ b/tool/tests/getFees/test.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# just testing it doesn't crash here
+
+export EXPERIMENTAL_EXPLORERS=1
+ledger-live getFees -c eth --xpub xpub6BemYiVNp19aDejXFVmety2Sv1qruzhbE7p1zAkY6mjbEShEo4dkxyawqhXDuzQhpi83W6fZ463mcqdW1ZVJj9Y3V5hTqUB4YgBcw7UCFWp
+ledger-live getFees -c xrp --xpub xpub6BemYiVNp19ZzgoVip83uhipVPKjNMjM4QYFeSJdA5EAUzQjNF66swQqH4afV15848dNnMLfcdrKkWZjNMAx2CZk1bfcukrdFGM3zzDfv1z
+ledger-live getFees -c btc --xpub xpub6Bm5P7Xyx2UYrVBAgb54gEswXhbZaryZSWsPjeJ1jpb9K9S5UTD5z5cXW4EREkTqkNjSHQHxwHKZJVE7TFvftySnKabMAXAQCMSVJBdJxMC

--- a/tool/yarn.lock
+++ b/tool/yarn.lock
@@ -263,10 +263,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/errors/-/errors-4.68.2.tgz#634f132c9c95935668ac2af90991ce57ebc44d63"
   integrity sha512-JxMr4wj/9d7EQuTQ9khhJxQSzv5B6ZoLUm4spOY+FDfQo0ywx9qvD1NyBHHVzyn7uRtWvz/hOSfTSrlw2joM3w==
 
-"@ledgerhq/hw-app-btc@4.68.2":
-  version "4.68.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.68.2.tgz#df92bf47d251f0d33574b0d1635b453cc1f93432"
-  integrity sha512-9r/dmkrt1QfCy2rbpWBiXEQAKqXHmYBi8mAYJsNSiHb62dixaDpFLWyMkFau837A/4ZH3lQq9tnhvng+G9YlHA==
+"@ledgerhq/hw-app-btc@4.68.3":
+  version "4.68.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/hw-app-btc/-/hw-app-btc-4.68.3.tgz#8a73dfc02ed92fd098865a43b5cf9f3d60489afb"
+  integrity sha512-YfEzLO9Ozp5AHhJEA/MvVXlK0p/nMUeR02+FbqLb+HrZVx4jlzK8/ArCBP1TnT1H182gqVAUetRNYulW7DUOXQ==
   dependencies:
     "@ledgerhq/hw-transport" "^4.68.2"
     create-hash "^1.1.3"
@@ -361,14 +361,14 @@
     bindings "^1.3.0"
     nan "^2.6.2"
 
-"@ledgerhq/live-common@^7.9.3":
-  version "7.9.3"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-7.9.3.tgz#9bfb305aa6bedf76b42afbdb37bdee9868cd491f"
-  integrity sha512-2G0HvGaTqzc9TO7jVNK/BxNNsc5U3MFBFKeT/PwhVMbm7aEH/UjpOi4EyXfYoVtu59sY3n1w2Nbt5UQz2hEWyw==
+"@ledgerhq/live-common@7.11.0-alpha.0":
+  version "7.11.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-7.11.0-alpha.0.tgz#ec10bed4e02dc320435b01b6ac0156b9a3b12386"
+  integrity sha512-xJD4citHHPoEYKu9+OwkVfQNglkfwGxIQDzV2tASBnnp8tNFqx+hnbukLAQGlrhIWvbwgMu3VAEaDK7BW4IoKQ==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/errors" "4.68.2"
-    "@ledgerhq/hw-app-btc" "4.68.2"
+    "@ledgerhq/hw-app-btc" "4.68.3"
     "@ledgerhq/hw-app-eth" "4.68.2"
     "@ledgerhq/hw-app-xrp" "4.68.2"
     "@ledgerhq/hw-transport" "4.68.2"
@@ -379,7 +379,7 @@
     ethereumjs-tx "^1.3.7"
     invariant "^2.2.2"
     lodash "^4.17.15"
-    lru-cache "4.1.3"
+    lru-cache "5.1.1"
     numeral "^2.0.6"
     prando "^5.1.1"
     react "*"
@@ -3553,13 +3553,12 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
-  integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
+lru-cache@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
+    yallist "^3.0.2"
 
 macos-release@^2.2.0:
   version "2.2.0"
@@ -4272,11 +4271,6 @@ proxy-addr@~2.0.5:
   dependencies:
     forwarded "~0.1.2"
     ipaddr.js "1.9.0"
-
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-  integrity sha1-8FKijacOYYkX7wqKw0wa5aaChrM=
 
 pump@^1.0.0:
   version "1.0.3"
@@ -5582,11 +5576,6 @@ xtend@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.0.tgz#95ef94f85ecc81d007c264e190a120f0a3c8566b"
   integrity sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==
-
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
-  integrity sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.3"


### PR DESCRIPTION
introduce a generic getFees that works for all currencies and returns you network fees info.

- for xrp, it's the xrp fee
- for eth it's the gasPrice
- for btc it's the 3 fee per byte numbers

it is implemented into a generic switch type:

```js
getFees: Input => Promise<Output>;

// with:

type Input = Account;

type Output =
  | {
      // btc
      type: "feePerBytes",
      value: BigNumber[]
    }
  | {
      // eth?
      type: "gasPrice",
      value: BigNumber,
      unit: Unit
    }
  | {
      // ripple?
      type: "fee",
      value: BigNumber,
      unit: Unit
    };
```

we would later ideally map these different type into different UIs.