### PR TITLE
Allow exporting to BRIDGESTREAM_DATA and use app.json as source

### DIFF
--- a/tool/README.md
+++ b/tool/README.md
@@ -51,15 +51,17 @@ Usage: ledger-live liveData   # utility for Ledger Live app.json file
      --appjson <filename>     : path to a live desktop app.json
  -a, --add                    : add accounts to live data
 
-Usage: ledger-live liveQR     # Show Live QR Code to export to mobile
+Usage: ledger-live exportAccounts # Export given accounts to Live QR or console for importing
      --device <String>        : provide a specific HID path of a device
      --xpub <String>          : use an xpub (alternatively to --device)
      --file <filename>        : use a JSON account file or '-' for stdin (alternatively to --device)
+     --appjsonFile <filename> : use a desktop app.json (alternatively to --device)
  -c, --currency <String>      : Currency name or ticker. If not provided, it will be inferred from the device.
  -s, --scheme <String>        : if provided, filter the derivation path that are scanned by a given sceme. Providing '' empty string will only use the default standard derivation scheme.
  -i, --index <Number>         : select the account by index
  -l, --length <Number>        : set the number of accounts after the index. Defaults to 1 if index was provided, Infinity otherwise.
-
+     --out                    : instead of Live QR Code, output to consoleappjson
+ 
 Usage: ledger-live genuineCheck # Perform a genuine check with Ledger's HSM
      --device <String>        : provide a specific HID path of a device
 


### PR DESCRIPTION
Since https://github.com/LedgerHQ/ledger-live-mobile/pull/994 got merged already we have a way to trigger an import response on mobile (android), this  pr build on that premise allowing the previously called `liveQR` command (now `exportAccounts`) to _either_ output to a LiveQR in the terminal or directly  return a `BRIDGESTREAM_DATA` string that we can then pipe into `yarn android:import` on mobile.

If we don't pass the `--out` flag it will behave as it did before by outputting to a liveqr stream.

### Sample exports 
```
ledger-live exportAccounts --appjsonFile "/path/to/app.json" --out
ledger-live exportAccounts --xpub XPUB_STRING --currency bitcoin --out
```

### How to use to import on mobile
Simply pipe the output of any of the previous commands to `yarn android:import $(YOUR_EXPORT)`