### PR TITLE
Wrong nested property accessor for encryption check

### DIFF
--- a/tool/src/commands.js
+++ b/tool/src/commands.js
@@ -224,7 +224,7 @@ const all = {
           const appjsondata = opts.appjson
             ? JSON.parse(fs.readFileSync(opts.appjson, "utf-8"))
             : { data: { accounts: [] } };
-          if (typeof appjsondata.accounts === "string") {
+          if (typeof appjsondata.data.accounts === "string") {
             return throwError(
               new Error("encrypted ledger live data is not supported")
             );


### PR DESCRIPTION
This would've never triggered on an encrypted `app.json`. Needs to do like here https://github.com/LedgerHQ/ledger-live-common/pull/319/files#diff-1a5f7bbd457e8fc8b1f91b9711b91307R126