### PR TITLE
Update lru-cache dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "ethereumjs-tx": "^1.3.7",
     "invariant": "^2.2.2",
     "lodash": "^4.17.15",
-    "lru-cache": "4.1.3",
+    "lru-cache": "5.1.1",
     "numeral": "^2.0.6",
     "prando": "^5.1.1",
     "react": "*",

--- a/src/cache.js
+++ b/src/cache.js
@@ -10,7 +10,7 @@ export const makeLRUCache = <A: Array<*>, T>(
     maxAge: 5 * 60 * 1000
   }
 ): ((...args: A) => Promise<T>) => {
-  const cache = LRU(lruOpts);
+  const cache = new LRU(lruOpts);
   return (...args) => {
     const key = keyExtractor(...args);
     let promise = cache.get(key);

--- a/yarn.lock
+++ b/yarn.lock
@@ -5100,13 +5100,12 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-lru-cache@4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
-  integrity sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==
+lru-cache@5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
   dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
+    yallist "^3.0.2"
 
 lru-cache@^4.0.1:
   version "4.1.5"


### PR DESCRIPTION
having this out-of-date sub-dep prevent us from bumping live-common to latest
no real changes except it now use class.

see https://github.com/isaacs/node-lru-cache/commit/9ce69193c4cefbeee27e759b1cf94e02a3eadf8b