### PR TITLE
LL-1768 Changed on the string sanitazition logic

### DIFF
--- a/src/__tests__/helpers/currencies.js
+++ b/src/__tests__/helpers/currencies.js
@@ -561,4 +561,12 @@ test("sanitizeValueString", () => {
     display: "13",
     value: "13"
   });
+  expect(sanitizeValueString(btcUnit, "000.12345678")).toMatchObject({
+    display: "0.12345678",
+    value: "12345678"
+  });
+  expect(sanitizeValueString(btcUnit, "001.23456789")).toMatchObject({
+    display: "1.23456789",
+    value: "123456789"
+  });
 });

--- a/src/currencies/sanitizeValueString.js
+++ b/src/currencies/sanitizeValueString.js
@@ -24,11 +24,14 @@ export const sanitizeValueString = (
       if (decimals >= 0) {
         decimals++;
         if (decimals > unit.magnitude) break;
-        value += c;
+        value = value === "0" ? c : value + c;
         display += c;
       } else if (value !== "0") {
         value += c;
         display += c;
+      } else {
+        value = c;
+        display = c;
       }
     } else if (decimals === -1 && (c === "," || c === ".")) {
       if (unit.magnitude === 0) {


### PR DESCRIPTION
The issue was brought up by @Arnaud97234 , on some input fields deleting the 1 from 1000 would automatically return 0 (which is fine) but put then typing a 1 (sending 01) to validation would also return zero meaning you couldn't type anymore, this wasn't the only buggy behaviour related to leading zeros.

This pr removes leading zeros that are not immediatelly followed by a decimal separator.