### PR TITLE
Add legacy_on_bch for BTC sent to BCH derivation (invalid)

### DIFF
--- a/src/derivation.js
+++ b/src/derivation.js
@@ -37,6 +37,11 @@ const modes = Object.freeze({
     skipFirst: true, // already included in the normal bip44,
     tag: "metamask"
   },
+  // many users have wrongly sent BTC on BCH paths
+  legacy_on_bch: {
+    overridesCoinType: 145,
+    isInvalid: true
+  },
   // chrome app and LL wrongly used to derivate vertcoin on 128
   vertcoin_128: {
     tag: "legacy",
@@ -102,6 +107,7 @@ const modes = Object.freeze({
 (modes: { [_: DerivationMode]: ModeSpec }); // eslint-disable-line
 
 const legacyDerivations: $Shape<CryptoCurrencyConfig<DerivationMode[]>> = {
+  bitcoin: ["legacy_on_bch"],
   vertcoin: ["vertcoin_128", "vertcoin_128_segwit"],
   ethereum: ["ethM", "ethMM"],
   ethereum_classic: ["ethM", "etcM", "ethMM"]


### PR DESCRIPTION
**How to test it**

- go on Bitcoin Cash app on device and do `ledger-live sync`. take a bch address and send a tiny amount of BTC on it. (*tradeoff limitation: only works with the first BCH account and if the address is not too far (stops working after 20 first address i think)*)
- go on Bitcoin app and scan with `SCAN_FOR_INVALID_PATHS=1 ledger-live sync`, you should see a new `Bitcoin 1 (custom)`.
- confirm it doesn't appear without the flag SCAN_FOR_INVALID_PATHS=1
- confirm sending back the BTC funds works (no reason it shouldn't but still good to test)