### PR TITLE
Remove mandatory account flatten for getPortfolio

### DIFF
--- a/src/__tests__/portfolio.js
+++ b/src/__tests__/portfolio.js
@@ -11,6 +11,7 @@ import {
 } from "../portfolio";
 import { genAccount } from "../mock/account";
 import { baseMockBTCRates } from "../countervalues/mock";
+import { flattenAccounts } from "../../lib/account";
 
 const accounts = Array(100)
   .fill(null)
@@ -163,7 +164,7 @@ test("getPortfolio calculateCounterValue can complete fails", () => {
   const account = genAccount("seed_6", { tokenAccountsCount: 0 });
   const account2 = genAccount("seed_7", { tokenAccountsCount: 0 });
   const portfolio = getPortfolio(
-    [account, account2],
+    flattenAccounts([account, account2]),
     "month",
     (c, value, date) => null
   );
@@ -172,7 +173,7 @@ test("getPortfolio calculateCounterValue can complete fails", () => {
 
 test("getPortfolio with lot of accounts", () => {
   const portfolio = getPortfolio(
-    accounts,
+    flattenAccounts(accounts),
     "week",
     (c, value, date) => value // using identity, at any time, 1 token = 1 USD
   );

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -272,11 +272,10 @@ const portfolioMemo: { [_: *]: Portfolio } = {};
  * @memberof account
  */
 export function getPortfolio(
-  topAccounts: Account[],
+  accounts: Account[],
   range: PortfolioRange,
   calc: (TokenCurrency | CryptoCurrency, BigNumber, Date) => ?BigNumber
 ): Portfolio {
-  const accounts = flattenAccounts(topAccounts);
   const availableAccounts = [];
   const unavailableAccounts = [];
   const histories: BalanceHistoryWithCountervalue[] = [];


### PR DESCRIPTION
-----
### ⚠️ This is a breaking change that requires updating [desktop](https://github.com/LedgerHQ/ledger-live-desktop/blob/0a0b7c75ab3a75617116ee29b374d759f34cf95f/src/actions/portfolio.js#L57) and [mobile](https://github.com/LedgerHQ/ledger-live-mobile/blob/5c74a84979669432e43da6984395071decf6b394/src/actions/portfolio.js#L60)
-----

This allows us to get the combined history of a subset of accounts without assuming that we want the to be flattened. This is needed for the crypto assets page for example since I dont want to get the token accounts included when I'm looking at the ETH page