### PR TITLE
Use fromEffective for value too, to avoid mismatch

### DIFF
--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -480,7 +480,7 @@ export function getCurrencyPortfolio(
     percentage: null
   };
   const countervalueChange = {
-    value: (to.countervalue || ZERO).minus(from.countervalue || ZERO),
+    value: (to.countervalue || ZERO).minus(fromEffective.countervalue || ZERO),
     percentage: meaningfulPercentage(
       (to.countervalue || ZERO).minus(fromEffective.countervalue || ZERO),
       fromEffective.countervalue


### PR DESCRIPTION
This solves the error pointed out by @Arnaud97234 on https://github.com/LedgerHQ/ledger-live-desktop/pull/2302 where a value didn't seem to match the delta anymore. This was caused by value using the oldest `from` available instead of the first one with a value.

> Value change caused by market, not me.

### Before
![image](https://user-images.githubusercontent.com/4631227/64431714-436a1c00-d0bb-11e9-9e4b-39ee1221cab8.png)
### After
<img width="307" alt="image" src="https://user-images.githubusercontent.com/4631227/64431802-6c8aac80-d0bb-11e9-83b0-14ba9a661641.png">
