### PR TITLE
LL-1909 Fix countervalue roi to use first non zero value from history

### DIFF
--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -226,11 +226,13 @@ const getBHWCV: GetBalanceHistoryWithCountervalue = (account, r, calc) => {
       countervalueReceiveSum: BigNumber(0), // not available here
       countervalueSendSum: BigNumber(0),
       cryptoChange: {
-        value: to.value.minus(from.value),
+        value: to.value.minus(fromEffective.value),
         percentage: null
       },
       countervalueChange: {
-        value: (to.countervalue || ZERO).minus(from.countervalue || ZERO),
+        value: (to.countervalue || ZERO).minus(
+          fromEffective.countervalue || ZERO
+        ),
         percentage: meaningfulPercentage(
           (to.countervalue || ZERO).minus(fromEffective.countervalue || ZERO),
           fromEffective.countervalue


### PR DESCRIPTION
This fixes the old implementation, the one that is activated with the `EXPERIMENTAL_ROI_CALCULATION` flag gives different (and seemingly wrong) results for the yearly roi.