### PR TITLE
TRON: add send transaction on CLI

### DIFF
--- a/src/derivation.js
+++ b/src/derivation.js
@@ -81,6 +81,9 @@ const modes = Object.freeze({
       TEZOS_XPUB_CURVE: "SECP256K1" // FIXME bug in libcore? it should be ED25519
     }
   },
+  tron: {
+    overridesDerivation: "44'/195'/<account>'/0/0"
+  },
   native_segwit: {
     purpose: 84,
     libcoreConfig: {

--- a/src/derivation.js
+++ b/src/derivation.js
@@ -81,9 +81,6 @@ const modes = Object.freeze({
       TEZOS_XPUB_CURVE: "SECP256K1" // FIXME bug in libcore? it should be ED25519
     }
   },
-  tron: {
-    overridesDerivation: "44'/195'/<account>'/0/0"
-  },
   native_segwit: {
     purpose: 84,
     libcoreConfig: {

--- a/src/hw/signTransaction/index.js
+++ b/src/hw/signTransaction/index.js
@@ -5,6 +5,7 @@ import type { CryptoCurrency } from "../../types";
 
 import ethereum from "./ethereum";
 import ripple from "./ripple";
+import tron from "./tron";
 
 type Resolver = (
   currency: CryptoCurrency,
@@ -18,8 +19,8 @@ const all = {
   ethereum_testnet: ethereum,
   ethereum_classic: ethereum,
   ethereum_classic_testnet: ethereum,
-
-  ripple
+  ripple,
+  tron
 };
 
 const m: Resolver = (currency, transport, path, transaction) => {

--- a/src/hw/signTransaction/tron.js
+++ b/src/hw/signTransaction/tron.js
@@ -1,0 +1,16 @@
+// @flow
+import Trx from "../../families/tron/hw-app-trx";
+import type Transport from "@ledgerhq/hw-transport";
+import type { CryptoCurrency } from "../../types";
+
+export default async (
+  currency: CryptoCurrency,
+  transport: Transport<*>,
+  path: string,
+  txArg: Object
+) => {
+  const tx = { ...txArg };
+  const trx = new Trx(transport);
+  const signature = await trx.signTransaction(path, tx.raw_data_hex);
+  return Buffer.from(signature).toString("hex");
+};

--- a/tool/src/transaction.js
+++ b/tool/src/transaction.js
@@ -255,6 +255,16 @@ export function inferTransactions(
         };
       }
 
+      case "tron": {
+        return {
+          family: "tron",
+          recipient,
+          amount,
+          token: token || "TRX",
+          useAllAmount
+        };
+      }
+
       default:
         throw new Error("family " + account.currency.family + " not supported");
     }


### PR DESCRIPTION
Since we rely already on `trongrid` for sync of accounts and we want quick support of new currencies, I relied on `trongrid` to forge and broadcast transactions :trollface:  .
This was tested many times with CLI + NanoS of @FabriceDautriat 🚀  , SFYL 🚎, FYI I made transactions between (`44'/195'/0'/0/0` => `44'/195'/0'/0/1`) since self-transactions are forbidden.