### PR TITLE
NEO: add send transaction on CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react": "*"
   },
   "dependencies": {
+    "@cityofzion/neon-js": "^4.7.1",
     "@ledgerhq/compressjs": "1.3.2",
     "@ledgerhq/errors": "4.72.1",
     "@ledgerhq/hw-app-btc": "4.72.1",

--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -1441,7 +1441,7 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
       {
         name: "NEO",
         code: "NEO",
-        magnitude: 8
+        magnitude: 0
       }
     ],
     explorerViews: [

--- a/src/families/neo/hw-app-neo/crypto.js
+++ b/src/families/neo/hw-app-neo/crypto.js
@@ -40,14 +40,14 @@ function sha256(hex: string): string {
  * @param unencodedKey unencoded public key
  * @return encoded public key
  */
-function getPublicKeyEncoded(unencodedKey: string): string {
+export const getPublicKeyEncoded = (unencodedKey: string): string => {
   const publicKeyArray = new Uint8Array(hexstring2ab(unencodedKey));
   if (publicKeyArray[64] % 2 === 1) {
     return "03" + ab2hexstring(publicKeyArray.slice(1, 33));
   } else {
     return "02" + ab2hexstring(publicKeyArray.slice(1, 33));
   }
-}
+};
 
 /**
  * Converts a public key to verification script form.

--- a/src/families/neo/hw-app-neo/index.js
+++ b/src/families/neo/hw-app-neo/index.js
@@ -6,7 +6,6 @@ import { getAddressFromScriptHash, getScriptHashFromPublicKey } from "./crypto";
 import { foreach } from "./utils";
 const CLA = 0x80;
 const PATH_SIZE = 4;
-const PATHS_LENGTH_SIZE = 1;
 const CHUNK_SIZE = 240;
 const SIGN = 0x02;
 /**
@@ -49,7 +48,7 @@ export default class Neo {
    */
   async signTransaction(path: string, rawTxHex: string) {
     const bipPath = BIPPath.fromString(path).toPathArray();
-    const pathBuffer = new Buffer(PATHS_LENGTH_SIZE + PATH_SIZE * bipPath.length);
+    const pathBuffer = new Buffer(PATH_SIZE * bipPath.length);
     bipPath.forEach((element, index) => {
       pathBuffer.writeUInt32BE(element, 4 * index);
     });

--- a/src/families/neo/hw-app-neo/index.js
+++ b/src/families/neo/hw-app-neo/index.js
@@ -47,7 +47,7 @@ export default class Neo {
    * @example
    eth.signTransaction("44'/888'/0'/0/0", "0800e1f505000000001405db7c48065877c220bb84b4f88ca9b9ef7e966e1405db7c48065877c220bb84b4f88ca9b9ef7e966e53c1087472616e736665726769090d990e0af2d6647682fb0ecca4b1871f04fe").then(result => ...)
    */
-  async signTransaction(path, rawTxHex) {
+  async signTransaction(path: string, rawTxHex: string) {
     const bipPath = BIPPath.fromString(path).toPathArray();
     const pathBuffer = new Buffer(PATHS_LENGTH_SIZE + PATH_SIZE * bipPath.length);
     bipPath.forEach((element, index) => {

--- a/src/families/neo/hw-app-neo/utils.js
+++ b/src/families/neo/hw-app-neo/utils.js
@@ -1,0 +1,12 @@
+module.exports.foreach = function foreach(arr, callback) {
+  function iterate(index, array, result) {
+    if (index >= array.length) {
+      return result;
+    } else
+      return callback(array[index], index).then(function(res) {
+        result.push(res);
+        return iterate(index + 1, array, result);
+      });
+  }
+  return Promise.resolve().then(() => iterate(0, arr, []));
+};

--- a/src/hw/signTransaction/index.js
+++ b/src/hw/signTransaction/index.js
@@ -6,6 +6,7 @@ import type { CryptoCurrency } from "../../types";
 import ethereum from "./ethereum";
 import ripple from "./ripple";
 import tron from "./tron";
+import neo from "./neo";
 
 type Resolver = (
   currency: CryptoCurrency,
@@ -20,7 +21,8 @@ const all = {
   ethereum_classic: ethereum,
   ethereum_classic_testnet: ethereum,
   ripple,
-  tron
+  tron,
+  neo
 };
 
 const m: Resolver = (currency, transport, path, transaction) => {

--- a/src/hw/signTransaction/neo.js
+++ b/src/hw/signTransaction/neo.js
@@ -1,0 +1,15 @@
+// @flow
+import Trx from "../../families/neo/hw-app-neo";
+import type Transport from "@ledgerhq/hw-transport";
+import type { CryptoCurrency } from "../../types";
+
+export default async (
+  currency: CryptoCurrency,
+  transport: Transport<*>,
+  path: string,
+  rawTransaction: string
+) => {
+  const trx = new Trx(transport);
+  const signature = await trx.signTransaction(path, rawTransaction);
+  return Buffer.from(signature).toString("hex");
+};

--- a/src/hw/signTransaction/neo.js
+++ b/src/hw/signTransaction/neo.js
@@ -3,6 +3,37 @@ import Trx from "../../families/neo/hw-app-neo";
 import type Transport from "@ledgerhq/hw-transport";
 import type { CryptoCurrency } from "../../types";
 
+const retrieveSignature = (rawSignature: Buffer) => {
+  // DER prefix + total length
+  let offset = 2;
+
+  // R field: marker
+  offset += 1;
+  //TODO: would use VarInts but r is always 32 bytes so ...
+  const rLength = rawSignature.readUIntBE(offset, 1);
+  // R length
+  offset += 1;
+  // Get R field
+  const r = rawSignature
+  .slice(offset, offset + rLength)
+  .toString('hex')
+  .padStart(64, '0');
+
+  // S field: marker
+  offset += rLength + 1;
+  //TODO: would use VarInts but s is always 32 bytes so ...
+  const sLength = rawSignature.readUIntBE(offset, 1);
+  // S length
+  offset += 1;
+  // Get S field
+  const s = rawSignature
+  .slice(offset, offset + sLength)
+  .toString('hex')
+  .padStart(64, '0');
+
+  return r.concat('', s);
+};
+
 export default async (
   currency: CryptoCurrency,
   transport: Transport<*>,
@@ -11,5 +42,6 @@ export default async (
 ) => {
   const trx = new Trx(transport);
   const signature = await trx.signTransaction(path, rawTransaction);
-  return Buffer.from(signature).toString("hex");
+  //Signature we get is DER so let's format it
+  return retrieveSignature(signature);
 };

--- a/tool/src/transaction.js
+++ b/tool/src/transaction.js
@@ -265,6 +265,15 @@ export function inferTransactions(
         };
       }
 
+      case "neo": {
+        return {
+          family: "neo",
+          recipient,
+          amount,
+          useAllAmount
+        };
+      }
+
       default:
         throw new Error("family " + account.currency.family + " not supported");
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -699,6 +699,53 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
+"@cityofzion/neon-api@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@cityofzion/neon-api/-/neon-api-4.7.1.tgz#78647b24a7b2e5931e4c024f9e9e2ae30be4c574"
+  integrity sha512-vxZ1sucg6WamSsAsgwgv7E/IoLTdbIj6UYHTCKKRQS9hXOY7i6W4iRvYVvRUpuI5QvlPdy/4rJ8JSU3yO1HcIg==
+  dependencies:
+    "@cityofzion/neon-core" "^4.7.1"
+    axios "0.19.0"
+
+"@cityofzion/neon-core@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@cityofzion/neon-core/-/neon-core-4.7.1.tgz#de71f1ac35a99468b1afcae549edc5aa7e3cf6a4"
+  integrity sha512-/XTIn+Rai6UEQGSMY/+WGkPkBJKXv9JQoZmNBdPO1xTJ3kF6Xg2eoOCg4qrC6Q1mSpdw8n4uTckHgz7PO73WnQ==
+  dependencies:
+    "@types/bn.js" "4.11.5"
+    "@types/bs58" "4.0.0"
+    "@types/crypto-js" "3.1.43"
+    "@types/elliptic" "6.4.10"
+    "@types/node" "12.7.11"
+    axios "0.19.0"
+    bignumber.js "7.2.1"
+    bn.js "4.11.8"
+    bs58 "4.0.1"
+    bs58check "2.1.2"
+    crypto-js "3.1.9-1"
+    elliptic "6.4.1"
+    loglevel "1.6.4"
+    loglevel-plugin-prefix "0.8.4"
+    scrypt-js "2.0.4"
+    secure-random "1.1.1"
+    wif "2.0.6"
+
+"@cityofzion/neon-js@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@cityofzion/neon-js/-/neon-js-4.7.1.tgz#02e57059499c9bbe96ae3a0e753aebb9bb6c11ab"
+  integrity sha512-/Xjnu6qXqcpFOHx+BHati/wRxfAjSrObt3APBeR4cz+PwHT/E4uFPC+3Q5am/TwhvUC2mI4blucnGEf1vscKNg==
+  dependencies:
+    "@cityofzion/neon-api" "^4.7.1"
+    "@cityofzion/neon-core" "^4.7.1"
+    "@cityofzion/neon-nep5" "^4.7.1"
+
+"@cityofzion/neon-nep5@^4.7.1":
+  version "4.7.1"
+  resolved "https://registry.yarnpkg.com/@cityofzion/neon-nep5/-/neon-nep5-4.7.1.tgz#3e1b8ebe5acc4d38cbacc7c3c02f3cf8ab823a7e"
+  integrity sha512-n291ub9Y59CDgSCPp2I2J2FAhiVv/KJ3IxusK7/zRnG54nfQz+x/OjlQRBN9LFMhne2lwgILlXQgafV4kMf2Ww==
+  dependencies:
+    "@cityofzion/neon-core" "^4.7.1"
+
 "@ledgerhq/compressjs@1.3.2":
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/@ledgerhq/compressjs/-/compressjs-1.3.2.tgz#22571c51740901c8de20ea302be123e0b96aa8fd"
@@ -786,6 +833,39 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.7.0.tgz#9a06f4f137ee84d7df0460c1fdb1135ffa6c50fd"
   integrity sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==
 
+"@types/base-x@*":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/base-x/-/base-x-3.0.0.tgz#a1365259d1d3fa3ff973ab543192a6bdd4cb2f90"
+  integrity sha512-vnqSlpsv9uFX5/z8GyKWAfWHhLGJDBkrgRRsnxlsX23DHOlNyqP/eHQiv4TwnYcZULzQIxaWA/xRWU9Dyy4qzw==
+  dependencies:
+    "@types/node" "*"
+
+"@types/bn.js@*", "@types/bn.js@4.11.5":
+  version "4.11.5"
+  resolved "https://registry.yarnpkg.com/@types/bn.js/-/bn.js-4.11.5.tgz#40e36197433f78f807524ec623afcf0169ac81dc"
+  integrity sha512-AEAZcIZga0JgVMHNtl1CprA/hXX7/wPt79AgR4XqaDt7jyj3QWYw6LPoOiznPtugDmlubUnAahMs2PFxGcQrng==
+  dependencies:
+    "@types/node" "*"
+
+"@types/bs58@4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/bs58/-/bs58-4.0.0.tgz#baec75cb007b419ede3ec6b3410d2c8f14c92fc5"
+  integrity sha512-gYX+MHD4G/R+YGYwdhG5gbJj4LsEQGr3Vg6gVDAbe7xC5Bn8dNNG2Lpo6uDX/rT5dE7VBj0rGEFuV8L0AEx4Rg==
+  dependencies:
+    "@types/base-x" "*"
+
+"@types/crypto-js@3.1.43":
+  version "3.1.43"
+  resolved "https://registry.yarnpkg.com/@types/crypto-js/-/crypto-js-3.1.43.tgz#b859347d6289ba13e347c335a4c9efa63337a748"
+  integrity sha512-EHe/YKctU3IYNBsDmSOPX/7jLHPRlx8WaiDKSY9JCTnJ8XJeM4c0ZJvx+9Gxmr2s2ihI92R+3U/gNL1sq5oRuQ==
+
+"@types/elliptic@6.4.10":
+  version "6.4.10"
+  resolved "https://registry.yarnpkg.com/@types/elliptic/-/elliptic-6.4.10.tgz#352078ebc911484e30fc0d1eca3e3c865bf0e8f8"
+  integrity sha512-9h+Bw+aNiLzcq9DGstHccNxSsJ5iNId7mzruid7+kwm7F1IGvb4rBOOPo3+twt9ZPhI3y+JJ2m1UfgU8cOEJuQ==
+  dependencies:
+    "@types/bn.js" "*"
+
 "@types/lodash@^4.14.85":
   version "4.14.123"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.123.tgz#39be5d211478c8dd3bdae98ee75bb7efe4abfe4d"
@@ -795,6 +875,11 @@
   version "11.13.4"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.4.tgz#f83ec3c3e05b174b7241fadeb6688267fe5b22ca"
   integrity sha512-+rabAZZ3Yn7tF/XPGHupKIL5EcAbrLxnTr/hgQICxbeuAfWtT0UZSfULE+ndusckBItcv4o6ZeOJplQikVcLvQ==
+
+"@types/node@12.7.11":
+  version "12.7.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
+  integrity sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==
 
 "@types/q@^1.5.1":
   version "1.5.2"
@@ -1078,7 +1163,7 @@ aws4@^1.8.0:
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.8.0.tgz#f0e003d9ca9e7f59c7a508945d7b2ef9a04a542f"
   integrity sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==
 
-axios@^0.19.0:
+axios@0.19.0, axios@^0.19.0:
   version "0.19.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-0.19.0.tgz#8e09bff3d9122e133f7b8101c8fbdd00ed3d2ab8"
   integrity sha512-1uvKqKQta3KBxIz14F2v06AEHZ/dIoeKfbTRkK1E5oqjDnuEerLmYTgJB5AiQZHJcljpg1TuRzdjDR06qNk0DQ==
@@ -1989,6 +2074,11 @@ big.js@^5.2.2:
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
   integrity sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==
 
+bignumber.js@7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
+
 bignumber.js@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
@@ -2056,15 +2146,15 @@ bluebird@~3.4.1:
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.4.7.tgz#f72d760be09b7f76d08ed8fae98b289a8d05fab3"
   integrity sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=
 
+bn.js@4.11.8, bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.3, bn.js@^4.4.0:
+  version "4.11.8"
+  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
+  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
+
 bn.js@^3.1.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-3.3.0.tgz#1138e577889fdc97bbdab51844f2190dfc0ae3d7"
   integrity sha1-ETjld4if3Je72rUYRPIZDfwK49c=
-
-bn.js@^4.11.0, bn.js@^4.11.1, bn.js@^4.11.3, bn.js@^4.4.0:
-  version "4.11.8"
-  resolved "https://registry.yarnpkg.com/bn.js/-/bn.js-4.11.8.tgz#2cde09eb5ee341f484746bb0309b3253b1b1442f"
-  integrity sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==
 
 boolbase@^1.0.0, boolbase@~1.0.0:
   version "1.0.0"
@@ -2157,14 +2247,14 @@ browserslist@^4.5.2, browserslist@^4.5.4:
     electron-to-chromium "^1.3.122"
     node-releases "^1.1.13"
 
-bs58@^4.0.0:
+bs58@4.0.1, bs58@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/bs58/-/bs58-4.0.1.tgz#be161e76c354f6f788ae4071f63f34e8c4f0a42a"
   integrity sha1-vhYedsNU9veIrkBx9j806MTwpCo=
   dependencies:
     base-x "^3.0.2"
 
-bs58check@^2.1.2:
+bs58check@2.1.2, bs58check@<3.0.0, bs58check@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/bs58check/-/bs58check-2.1.2.tgz#53b018291228d82a5aa08e7d796fdafda54aebfc"
   integrity sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==
@@ -2596,7 +2686,7 @@ crypt@~0.0.1:
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs=
 
-crypto-js@^3.1.9-1:
+crypto-js@3.1.9-1, crypto-js@^3.1.9-1:
   version "3.1.9-1"
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.1.9-1.tgz#fda19e761fc077e01ffbfdc6e9fdfc59e8806cd8"
   integrity sha1-/aGedh/Ad+Af+/3G6f38WeiAbNg=
@@ -2894,17 +2984,7 @@ electron-to-chromium@^1.3.122, electron-to-chromium@^1.3.47:
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.124.tgz#861fc0148748a11b3e5ccebdf8b795ff513fa11f"
   integrity sha512-glecGr/kFdfeXUHOHAWvGcXrxNU+1wSO/t5B23tT1dtlvYB26GY8aHzZSWD7HqhqC800Lr+w/hQul6C5AF542w==
 
-elliptic@^5.1.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-5.2.1.tgz#fa294b6563c6ddbc9ba3dc8594687ae840858f10"
-  integrity sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=
-  dependencies:
-    bn.js "^3.1.1"
-    brorand "^1.0.1"
-    hash.js "^1.0.0"
-    inherits "^2.0.1"
-
-elliptic@^6.2.3:
+elliptic@6.4.1, elliptic@^6.2.3:
   version "6.4.1"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.4.1.tgz#c2d0b7776911b86722c632c3c06c60f2f819939a"
   integrity sha512-BsXLz5sqX8OHcsh7CqBMztyXARmGQ3LWPtGjJi6DiJHq5C/qvi9P3OqgswKSDftbu8+IoI/QDTAm2fFnQ9SZSQ==
@@ -2916,6 +2996,16 @@ elliptic@^6.2.3:
     inherits "^2.0.1"
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
+
+elliptic@^5.1.0:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-5.2.1.tgz#fa294b6563c6ddbc9ba3dc8594687ae840858f10"
+  integrity sha1-+ilLZWPG3bybo9yFlGh66ECFjxA=
+  dependencies:
+    bn.js "^3.1.1"
+    brorand "^1.0.1"
+    hash.js "^1.0.0"
+    inherits "^2.0.1"
 
 emoji-regex@^7.0.1, emoji-regex@^7.0.2:
   version "7.0.3"
@@ -5135,6 +5225,16 @@ lodash@^4.12.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+loglevel-plugin-prefix@0.8.4:
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/loglevel-plugin-prefix/-/loglevel-plugin-prefix-0.8.4.tgz#2fe0e05f1a820317d98d8c123e634c1bd84ff644"
+  integrity sha512-WpG9CcFAOjz/FtNht+QJeGpvVl/cdR6P0z6OcXSkr8wFJOsV2GRj2j10JLfjuA4aYkcKCNIEqRGCyTife9R8/g==
+
+loglevel@1.6.4:
+  version "1.6.4"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.6.4.tgz#f408f4f006db8354d0577dcf6d33485b3cb90d56"
+  integrity sha512-p0b6mOGKcGa+7nnmKbpzR6qloPbrgLcnio++E+14Vo/XffOGwZtRpUhr8dTH/x2oCMmEoIU0Zwm3ZauhvYD17g==
+
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -6677,6 +6777,11 @@ saxes@^3.1.5:
   dependencies:
     xmlchars "^1.3.1"
 
+scrypt-js@2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
+  integrity sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==
+
 secp256k1@^3.0.1:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/secp256k1/-/secp256k1-3.6.2.tgz#da835061c833c74a12f75c73d2ec2e980f00dc1f"
@@ -6690,6 +6795,11 @@ secp256k1@^3.0.1:
     elliptic "^6.2.3"
     nan "^2.2.1"
     safe-buffer "^5.1.0"
+
+secure-random@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/secure-random/-/secure-random-1.1.1.tgz#0880f2d8c5185f4bcb4684058c836b4ddb07145a"
+  integrity sha1-CIDy2MUYX0vLRoQFjINrTdsHFFo=
 
 "semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
   version "5.7.0"
@@ -7571,6 +7681,13 @@ wide-align@^1.1.0:
   integrity sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
   dependencies:
     string-width "^1.0.2 || 2"
+
+wif@2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/wif/-/wif-2.0.6.tgz#08d3f52056c66679299726fade0d432ae74b4704"
+  integrity sha1-CNP1IFbGZnkplyb63g1DKudLRwQ=
+  dependencies:
+    bs58check "<3.0.0"
 
 windows-release@^3.1.0:
   version "3.2.0"


### PR DESCRIPTION
Add `send` on CLI for NEO 🚀 .
So I managed to test: 
- [x] Build of transaction, 
- [x] Stream to device, 
- [x] Display of right informations on device.

Unfortunately, the only command I can validate on device is `Deny` (which is a good feature :trollface: haha), this is the only remaining issue to debug. I already checked the hex of the raw unsigned tx and the streamed data to device and both look fine to me, but I will spend more time to find why `Sign Tx` and `Sign Now Tx` are blocked :rage4: !

I've already implemented: 
- [x] Signature injection in raw transaction,
- [x] Broadcast of transaction. 

But of course because of above reasons I couldn't test (since `tester c'est douter` it should be ok :trollface: ).

TODO:
- [x] Find remaining issue on tx validation on device,
- [x] (Alright let's )Test broadcast, 
- [x] Think about strategy of fee selection (please refer to `families/neo/bridge/js.js`).

Update: 
Everything is fixed, I managed to sign and broadcast a transaction 🚀  , @gre I gave you back the 1 NEO you sent to me 🎊 : [d9bc8acfe90d3e136272b59d0b2e44e9e71f5665b6d07a58dee2dbc348ea908f](https://neoscan.io/transaction/d9bc8acfe90d3e136272b59d0b2e44e9e71f5665b6d07a58dee2dbc348ea908f)
