### PR TITLE
Fix extracting minor version inside seVersion

### DIFF
--- a/src/hw/getDeviceInfo.js
+++ b/src/hw/getDeviceInfo.js
@@ -26,7 +26,7 @@ export default async function getDeviceInfo(
   const { targetId, mcuVersion, flags } = res;
   const isOSU = seVersion.includes("-osu");
   const version = seVersion.replace("-osu", "");
-  const m = seVersion.match(/([0-9]+.[0-9])+(.[0-9]+)?(-(.*))?/);
+  const m = seVersion.match(/([0-9]+.[0-9]+)(.[0-9]+)?(-(.*))?/);
   const [, majMin, , , providerName] = m || [];
   const forceProvider = getEnv("FORCE_PROVIDER");
   const providerId =


### PR DESCRIPTION
The regex was extracting only the first char of the minor.

Didn't caused trouble until now because all our minor were 1 char LOL :smile:
But Nano S firmw upgrade 1.6.0 is flashing MCU from bootloader `0.11`, which was extracted as `0.1` and this was very likely causing the failure during our tests.