### PR TITLE
undo recent hacks that workaround libcore bugs + fix error precision

### DIFF
--- a/src/families/tezos/bridge/libcore.js
+++ b/src/families/tezos/bridge/libcore.js
@@ -66,9 +66,8 @@ const createTransaction = () => ({
   gasLimit: null,
   storageLimit: null,
   recipient: "",
-  networkInfo: null
-  // Problem with send max feature
-  // useAllAmount: false
+  networkInfo: null,
+  useAllAmount: false
 });
 
 const updateTransaction = (t, patch) => ({ ...t, ...patch });
@@ -140,7 +139,7 @@ const getTransactionStatus = async (a, t) => {
     amount = BigNumber(0);
   }
 
-  if (amount.gt(0) && estimatedFees.times(10).gt(amount)) {
+  if (t.mode === "send" && amount.gt(0) && estimatedFees.times(10).gt(amount)) {
     warnings.feeTooHigh = new FeeTooHigh();
   }
 

--- a/src/families/tezos/libcore-buildSubAccounts.js
+++ b/src/families/tezos/libcore-buildSubAccounts.js
@@ -1,6 +1,5 @@
 // @flow
 
-import { log } from "@ledgerhq/logs";
 import type { CryptoCurrency, ChildAccount, Account } from "../../types";
 import type { CoreAccount } from "../../libcore/types";
 import type {
@@ -11,8 +10,6 @@ import { libcoreAmountToBigNumber } from "../../libcore/buildBigNumber";
 import { buildOperation } from "../../libcore/buildAccount/buildOperation";
 import { minimalOperationsBuilder } from "../../reconciliation";
 import { shortAddressPreview } from "../../account";
-import { parseCurrencyUnit } from "../../currencies";
-import network from "../../network";
 
 const OperationOrderKey = {
   date: 0
@@ -56,16 +53,6 @@ async function buildOriginatedAccount({
         currency
       })
   );
-
-  try {
-    log("libcore-buildSubAccounts", "fallback on fetching the balance from JS");
-    const { data } = await network(
-      `https://tzstats.ledger.com/explorer/account/${address}`
-    );
-    balance = parseCurrencyUnit(currency.units[0], String(data.total_balance));
-  } catch (e) {
-    log("libcore-buildSubAccounts", "fails with " + String(e));
-  }
 
   const originatedAccount: $Exact<ChildAccount> = {
     type: "ChildAccount",

--- a/src/families/tezos/test-dataset.js
+++ b/src/families/tezos/test-dataset.js
@@ -1,49 +1,148 @@
 // @flow
+import { NotEnoughBalance } from "@ledgerhq/errors";
 import { BigNumber } from "bignumber.js";
-import { FeeTooHigh } from "@ledgerhq/errors";
 import { fromTransactionRaw } from "../../transaction";
 import type { DatasetTest } from "../dataset";
 
-const networkInfo = {
-  family: "tezos",
-  fees: "1420"
-};
-
 const dataset: DatasetTest = {
-  // TODO test not yet enabled because bugs in libcore impl
-  implementations: [], // ["libcore"],
+  implementations: ["libcore"],
   currencies: {
     tezos: {
       accounts: [
         {
           transactions: [
             {
-              name: "success1",
+              name: "to kt account",
               transaction: fromTransactionRaw({
                 amount: "1000000",
-                recipient: "tz1bd2A1bdafn7kKTNFd8gPjnFiEWJUsVB39",
+                recipient: "KT1Mfe3rRhQw9KnEUZzoxkhmyHXBeN3zCzXL",
+                useAllAmount: false,
                 family: "tezos",
                 mode: "send",
-                networkInfo,
+                networkInfo: {
+                  family: "tezos",
+                  fees: "1420"
+                },
                 fees: "1420",
-                gasLimit: "10300",
+                gasLimit: "10600",
                 storageLimit: "300"
               }),
               expectedStatus: {
                 errors: {},
-                warnings: {
-                  feeTooHigh: new FeeTooHigh()
-                },
-                estimatedFees: BigNumber("14626000"),
+                warnings: {},
+                estimatedFees: BigNumber("1420"),
                 amount: BigNumber("1000000"),
-                totalSpent: BigNumber("15626000"),
-                recipientIsReadOnly: false
+                totalSpent: BigNumber("1001420")
+              }
+            },
+            {
+              name: "regular tx",
+              transaction: fromTransactionRaw({
+                amount: "1230000",
+                recipient: "tz1ZshTmtorFVkcZ7CpceCAxCn7HBJqTfmpk",
+                useAllAmount: false,
+                family: "tezos",
+                mode: "send",
+                networkInfo: { family: "tezos", fees: "3075" },
+                fees: "3075",
+                gasLimit: "10600",
+                storageLimit: "300"
+              }),
+              expectedStatus: {
+                errors: {},
+                warnings: {},
+                estimatedFees: BigNumber("3075"),
+                amount: BigNumber("1230000"),
+                totalSpent: BigNumber("1233075")
+              }
+            },
+            {
+              name: "not enough balance",
+              transaction: fromTransactionRaw({
+                amount: "12300000000",
+                recipient: "tz1ZshTmtorFVkcZ7CpceCAxCn7HBJqTfmpk",
+                useAllAmount: false,
+                family: "tezos",
+                mode: "send",
+                networkInfo: { family: "tezos", fees: "3075" },
+                fees: "3075",
+                gasLimit: "10600",
+                storageLimit: "300"
+              }),
+              expectedStatus: {
+                errors: { amount: new NotEnoughBalance() },
+                warnings: {},
+                estimatedFees: BigNumber("0"),
+                amount: BigNumber("12300000000"),
+                totalSpent: BigNumber("12300000000")
+              }
+            },
+            {
+              name: "from KT to TZ",
+              transaction: fromTransactionRaw({
+                amount: "230000",
+                recipient: "tz1ZshTmtorFVkcZ7CpceCAxCn7HBJqTfmpk",
+                useAllAmount: false,
+                subAccountId:
+                  "libcore:1:tezos:020c38103f932f446dc4c09ac946e9643386609453e77716d3df45f1149aa52072:tezbox+KT1PTC8w6Mk6MSnx56TzMRx4Z8weLLq3oGgP",
+                family: "tezos",
+                mode: "send",
+                networkInfo: { family: "tezos", fees: "3213" },
+                fees: "3213",
+                gasLimit: "10600",
+                storageLimit: "300"
+              }),
+              expectedStatus: {
+                errors: {},
+                warnings: {},
+                estimatedFees: BigNumber("3213"),
+                amount: BigNumber("230000"),
+                totalSpent: BigNumber("233213")
+              }
+            },
+            {
+              name: "send max",
+              transaction: fromTransactionRaw({
+                amount: "0",
+                recipient: "tz1ZshTmtorFVkcZ7CpceCAxCn7HBJqTfmpk",
+                useAllAmount: true,
+                family: "tezos",
+                mode: "send",
+                networkInfo: { family: "tezos", fees: "64433" },
+                fees: "64433",
+                gasLimit: "10600",
+                storageLimit: "300"
+              }),
+              expectedStatus: {
+                errors: {},
+                warnings: {}
+              }
+            },
+            {
+              name: "delegate",
+              transaction: fromTransactionRaw({
+                amount: "1000",
+                recipient: "tz1ZshTmtorFVkcZ7CpceCAxCn7HBJqTfmpk",
+                useAllAmount: false,
+                family: "tezos",
+                mode: "delegate",
+                networkInfo: { family: "tezos", fees: "4495" },
+                fees: "4495",
+                gasLimit: "10600",
+                storageLimit: "300"
+              }),
+              expectedStatus: {
+                errors: {},
+                warnings: {},
+                estimatedFees: BigNumber("4495"),
+                amount: BigNumber("1000"),
+                totalSpent: BigNumber("5495")
               }
             }
           ],
           raw: {
             id:
-              "libcore:1:tezos:xpub661MyMwAqRbcGJRaWpV3ooVkBC232h197qBQtdshZA5L7H24SXJZWepnJpyzHrXYeisTjz9MAFab7UTyapUWziCZJku6Ym7p4RTbHYPMLwN:tezbox",
+              "libcore:1:tezos:020c38103f932f446dc4c09ac946e9643386609453e77716d3df45f1149aa52072:tezbox",
             seedIdentifier:
               "02706dbe651d40b272e6bfe66d1ff466b490e262c223f48bd140b95898adce8965",
             name: "Tezos 1 (tezbox)",
@@ -57,15 +156,15 @@ const dataset: DatasetTest = {
                 derivationPath: "44'/1729'/0'/0'"
               }
             ],
-            blockHeight: 623107,
+            blockHeight: 671368,
             operations: [],
             pendingOperations: [],
             currencyId: "tezos",
             unitMagnitude: 6,
-            lastSyncDate: "2019-09-25T13:28:07.470Z",
-            balance: "43788260",
+            lastSyncDate: "2019-10-29T20:25:33.095Z",
+            balance: "30963414",
             xpub:
-              "xpub661MyMwAqRbcGJRaWpV3ooVkBC232h197qBQtdshZA5L7H24SXJZWepnJpyzHrXYeisTjz9MAFab7UTyapUWziCZJku6Ym7p4RTbHYPMLwN",
+              "020c38103f932f446dc4c09ac946e9643386609453e77716d3df45f1149aa52072",
             subAccounts: []
           }
         }

--- a/tool/src/__tests__/bridges.js
+++ b/tool/src/__tests__/bridges.js
@@ -20,6 +20,11 @@ import dataset from "@ledgerhq/live-common/lib/generated/test-dataset";
 import specifics from "@ledgerhq/live-common/lib/generated/test-specifics";
 import { setup } from "../live-common-setup-test";
 
+const blacklistOpsSumEq = {
+  currencies: ["ripple", "ethereum"],
+  impls: ["mock"]
+};
+
 setup("bridges");
 
 function syncAccount(bridge, account) {
@@ -38,7 +43,7 @@ Object.keys(dataset).forEach(family => {
   const { implementations, currencies } = data;
   Object.keys(currencies).forEach(currencyId => {
     const currencyData = currencies[currencyId];
-    currencyData.accounts.slice(0, 1).forEach(accountData =>
+    currencyData.accounts.forEach(accountData =>
       implementations.forEach(impl => {
         const account = fromAccountRaw({
           ...accountData.raw,
@@ -85,7 +90,10 @@ all
           expect(bridge).toBe(getAccountBridge(account, null));
         });
 
-        if (initialAccount.currency.id !== "ripple" && impl !== "mock") {
+        if (
+          !blacklistOpsSumEq.currencies.includes(initialAccount.currency.id) &&
+          !blacklistOpsSumEq.impls.includes(impl)
+        ) {
           function expectBalanceIsOpsSum(a) {
             expect(a.balance).toEqual(
               a.operations.reduce(


### PR DESCRIPTION
works with incoming https://github.com/LedgerHQ/lib-ledger-core/pull/373

also made sure that the error properly deserialize for http errors back to our serialized errors so we don't lose precision, typically when we extract the error message from network.

In future, this needs to be covered by libcore btw (getting back to us with precise errors)

**before**

<img width="495" alt="Capture d’écran 2019-10-30 à 07 26 56" src="https://user-images.githubusercontent.com/211411/67835876-69280600-faeb-11e9-9a19-d49a3e4ab840.png">

**after**

properly deserialized as a "LedgerHTTP5xx" error on our side, that allows us to map to translated errors wording as well as providing the exact error reason message from the http payload.

<img width="487" alt="Capture d’écran 2019-10-30 à 08 01 14" src="https://user-images.githubusercontent.com/211411/67835905-75ac5e80-faeb-11e9-8992-16b6f956c203.png">

