### PR TITLE
Add the deleteLibcore function.

### DIFF
--- a/src/libcore/access.js
+++ b/src/libcore/access.js
@@ -93,3 +93,8 @@ async function load(): Promise<Core> {
 export function setLoadCoreImplementation(loadCore: () => Promise<Core>) {
   loadCoreImpl = loadCore;
 }
+
+export function deleteLibcore() {
+  corePromise = null;
+  core = null;
+}


### PR DESCRIPTION
That function is needed in order to correctly reset Core / CorePromise
objects in both Live Desktop and Live Mobile.