### PR TITLE
Fix logs viewer

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -23,7 +23,7 @@
     "react-router-dom": "^5.1.2",
     "react-scripts": "3.2.0",
     "react-select": "^3.0.8",
-    "react-table": "^6.10.3",
+    "react-table": "^6.11.4",
     "react-tooltip": "^3.11.1",
     "redux": "^4.0.4",
     "redux-devtools-extension": "^2.13.8",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1567,6 +1567,13 @@
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/react-table@^6.8.5":
+  version "6.8.5"
+  resolved "https://registry.yarnpkg.com/@types/react-table/-/react-table-6.8.5.tgz#deb2bf2fcedcfb81e9020edbb7df0d8459ca348b"
+  integrity sha512-ueCsAadG1IwuuAZM+MWf2SoxbccSWweyQa9YG6xGN5cOVK3SayPOJW4MsUHGpY0V/Q+iZWgohpasliiao29O6g==
+  dependencies:
+    "@types/react" "*"
+
 "@types/react-transition-group@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/@types/react-transition-group/-/react-transition-group-4.2.3.tgz#4924133f7268694058e415bf7aea2d4c21131470"
@@ -9334,12 +9341,14 @@ react-select@^3.0.8:
     react-input-autosize "^2.2.2"
     react-transition-group "^2.2.1"
 
-react-table@^6.10.3:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.11.2.tgz#d814ade6523e53f3ff2639ad171e0e64c606e55f"
-  integrity sha512-UspBbCrPc+zZM5b+y6wRU9TYOcb/iknbAni3Gs1SnO47akj5eLkURwJTAvmBP3bBBFBsM4pYjq+5VeCZZc0wSw==
+react-table@^6.11.4:
+  version "6.11.5"
+  resolved "https://registry.yarnpkg.com/react-table/-/react-table-6.11.5.tgz#84e52885db426a07a6c4ce2c7e942f2cd4e2aa58"
+  integrity sha512-LM+AS9v//7Y7lAlgTWW/cW6Sn5VOb3EsSkKQfQTzOW8FngB1FUskLLNEVkAYsTX9LjOWR3QlGjykJqCE6eXT/g==
   dependencies:
+    "@types/react-table" "^6.8.5"
     classnames "^2.2.5"
+    react-is "^16.8.1"
 
 react-tooltip@^3.11.1:
   version "3.11.1"


### PR DESCRIPTION
The `react-table` version we used had a bug which broke the logs viewer.

This should fix that