### PR TITLE
Sorting and filtering utils for the managerv2 for mobile and desktop

### DIFF
--- a/src/apps/filtering.js
+++ b/src/apps/filtering.js
@@ -1,10 +1,107 @@
 // @flow
 import type { App } from "../types/manager";
+import type { InstalledItem } from "./types";
+import { getCryptoCurrencyById, isCurrencySupported } from "../currencies";
 
-export type SortOptions = *;
+export type SortOptions = {
+  type: "name" | "marketcap",
+  order: "asc" | "desc",
+  marketcapTickers?: string[]
+};
 
-export const sortApps = (apps: App[], _options: SortOptions): App[] => apps;
+export type FilterOptions = {
+  query?: string,
+  installedApps: InstalledItem[],
+  type: "all" | "installed" | "not_installed" | "supported" | "updatable"
+};
 
-export type FilterOptions = *;
+type UpdateAwareInstalledApps = {
+  [string]: boolean // NB [AppName]: isUpdated
+};
 
-export const filterApps = (apps: App[], _options: FilterOptions): App[] => apps;
+type ScoredApps = {
+  [string]: number // NB [AppName]: computed score for sorting
+};
+
+const searchFilter = (query?: string) => ({ name, currencyId }) => {
+  if (!query) return true;
+  const currency = currencyId ? getCryptoCurrencyById(currencyId) : null;
+  const terms = `${name} ${
+    currency ? `${currency.name} ${currency.ticker}` : ""
+  }`;
+  return terms.toLowerCase().includes(query.toLowerCase().trim());
+};
+
+const typeFilter = (
+  type = "all",
+  updateAwareInstalledApps: UpdateAwareInstalledApps
+) => app => {
+  switch (type) {
+    case "installed":
+      return updateAwareInstalledApps.hasOwnProperty(app.name);
+    case "not_installed":
+      return !updateAwareInstalledApps.hasOwnProperty(app.name);
+    case "updatable":
+      return (
+        updateAwareInstalledApps.hasOwnProperty(app.name) &&
+        !updateAwareInstalledApps[app.name]
+      );
+    case "supported":
+      return (
+        app.currencyId &&
+        isCurrencySupported(getCryptoCurrencyById(app.currencyId))
+      );
+    default:
+      return true;
+  }
+};
+
+export const sortApps = (apps: App[], _options: SortOptions): App[] => {
+  const { type, marketcapTickers, order } = _options;
+  const asc = order === "asc";
+  const sortedApps = [...apps];
+  const marketcapScoreBase = 10e6;
+
+  const scoredApps: ScoredApps = sortedApps.reduce(
+    (names, { name, currencyId }) => {
+      let appScore = 0;
+
+      if (marketcapTickers && type === "marketcap" && currencyId) {
+        const index = marketcapTickers.indexOf(
+          getCryptoCurrencyById(currencyId).ticker
+        );
+
+        appScore += index >= 0 ? marketcapScoreBase - 1000 * index : 0;
+      }
+
+      // By name
+      appScore += name[0].toLowerCase().charCodeAt(0);
+
+      return { ...names, [name]: appScore * (asc ? 1 : -1) };
+    },
+    {}
+  );
+
+  return sortedApps.sort(
+    (app1, app2) => scoredApps[app1.name] - scoredApps[app2.name]
+  );
+};
+
+export const filterApps = (apps: App[], _options: FilterOptions): App[] => {
+  const { query, installedApps, type = "all" } = _options;
+  const updateAwareInstalledApps = installedApps.reduce(
+    (names, { name }) => ({ ...names, [name]: true }),
+    {}
+  );
+  return apps
+    .filter(searchFilter(query))
+    .filter(typeFilter(type, updateAwareInstalledApps));
+};
+
+export const sortFilterApps = (
+  apps: App[],
+  _filterOptions: FilterOptions,
+  _sortOptions: SortOptions
+): App[] => {
+  return sortApps(filterApps(apps, _filterOptions), _sortOptions);
+};

--- a/src/apps/filtering.js
+++ b/src/apps/filtering.js
@@ -98,7 +98,12 @@ export const useSortedFilteredApps = (
   const { type: sortType, order } = _sortOptions;
 
   return useMemo(
-    () => sortApps(filterApps(apps, _filterOptions), _sortOptions),
+    () =>
+      sortFilterApps(
+        apps,
+        { query, installedApps, type: filterType },
+        { type: sortType, order }
+      ),
     [apps, query, installedApps, filterType, sortType, order]
   );
 };

--- a/src/apps/mock.js
+++ b/src/apps/mock.js
@@ -8,6 +8,7 @@ import { getDependencies, getDependents } from "./polyfill";
 import { findCryptoCurrency } from "../currencies";
 import type { ListAppsResult, AppOp, Exec, InstalledItem } from "./types";
 import type { App, DeviceInfo, FinalFirmware } from "../types/manager";
+import { tickersByMarketCap } from "../countervalues/mock";
 
 export const deviceInfo155 = {
   version: "1.5.5",
@@ -76,6 +77,10 @@ export function mockListAppsResult(
     .map((name, i) => {
       const dependencies = getDependencies(name);
       const currency = findCryptoCurrency(c => c.managerAppName === name);
+      const indexOfMarketCap = currency
+        ? tickersByMarketCap.indexOf(currency.ticker)
+        : -1;
+
       return {
         id: i,
         app: i,
@@ -99,7 +104,7 @@ export function mockListAppsResult(
         dateModified: "",
         compatibleWallets: [],
         currencyId: currency ? currency.id : null,
-        indexOfMarketCap: 0
+        indexOfMarketCap
       };
     });
   const appByName = {};

--- a/src/countervalues/mock.js
+++ b/src/countervalues/mock.js
@@ -133,7 +133,7 @@ export const fetchExchangesForPairImplementation = async () => {
   ];
 };
 
-const tickersByMarketCap = [
+export const tickersByMarketCap = [
   "BTC",
   "ETH",
   "XRP",


### PR DESCRIPTION
### What is this
Shared logic for sorting/filtering the list of apps in the catalog. Currently supporting filtering by installed, not installed, needing an update, supported by live (maybe we can do more?) and sorting by name and marketcap.

### Usage
Since most of the time we would like to compound a search and a filter we have the `sortFilterApps` which  receives both sets of options and returns the filtered and ordered app array. The only thing to keep in mind is that we need to provide the installed app list (which is not of type `App[]` but rather `InstalledItem[]`) from the state in order to match with the catalog. Same applies for sorting from marketcap, the function expects us to provide the sorted tickers list, which can be obtained in a number of ways with the easiest being `const marketcapTickers = useMarketcapTickers();`.

### Testing?
I believe @gre wanted some tests on live-common for this so, that part is still pending. I don't want to write tests before the implementation is approved and makes sense.