### PR TITLE
[DRAFT] Implement getBalanceHistory from libcore

### DIFF
--- a/cli/src/__tests__/bridges.js
+++ b/cli/src/__tests__/bridges.js
@@ -23,6 +23,10 @@ import {
 import dataset from "@ledgerhq/live-common/lib/generated/test-dataset";
 import specifics from "@ledgerhq/live-common/lib/generated/test-specifics";
 import { setup } from "../live-common-setup-test";
+import {withLibcore} from "@ledgerhq/live-common/lib/libcore/access";
+import {getCoreAccount} from "@ledgerhq/live-common/lib/libcore/getCoreAccount";
+import getAccountBalanceHistory from "@ledgerhq/live-common/lib/libcore/getAccountBalanceHistory";
+import {getBalanceHistory} from "@ledgerhq/live-common/lib/portfolio";
 
 const blacklistOpsSumEq = {
   currencies: ["ripple", "ethereum"],
@@ -213,6 +217,21 @@ accountsRelated
           });
         });
       });
+
+      
+      // FIXME, tests don't match for some of the cases
+      // see https://ledgerhq.atlassian.net/browse/LLC-475
+      if(impl==="libcore"){
+        test("balanceHistory", async () => {
+          await withLibcore(async core => {
+            const account = await getSynced();
+            const { coreAccount } = await getCoreAccount(core, account);
+            const libcoreBalanceHistory = await getAccountBalanceHistory(coreAccount, "week", 0);
+            const { history } = getBalanceHistory(account, "week");
+            expect(libcoreBalanceHistory.map(b=>b.value)).toEqual(history.map(b=>b.value));
+          });
+        });
+      }
 
       describe("createTransaction", () => {
         test("empty transaction is an object with empty recipient and zero amount", () => {

--- a/src/libcore/getAccountBalanceHistory.js
+++ b/src/libcore/getAccountBalanceHistory.js
@@ -1,0 +1,39 @@
+// @flow
+
+import type { PortfolioRange } from "../types";
+import type { CoreAccount } from "./types";
+import { libcoreAmountToBigNumber } from "./buildBigNumber";
+import { getDates, getPortfolioRange } from "../portfolio";
+import { TimePeriod } from "./types";
+import invariant from "invariant";
+
+const getAccountBalanceHistory = async (
+  coreAccount: CoreAccount,
+  range: PortfolioRange,
+  granularity: $Values<typeof TimePeriod> = 0
+) => {
+  const dates = getDates(range);
+  const conf = getPortfolioRange(range);
+
+  // FIXME @gre the weird date adjustment we are doing
+  const to = new Date(conf.startOf(new Date()).getTime() + conf.increment - 1);
+
+  const rawBalances = await coreAccount.getBalanceHistory(
+    new Date(dates[0] - conf.increment).toISOString(),
+    to.toISOString(),
+    granularity
+  );
+
+  const balances = await Promise.all(
+    rawBalances.map(balance => libcoreAmountToBigNumber(balance))
+  );
+
+  invariant(
+    balances.length === dates.length,
+    "Mismatch in sizes dates/balance"
+  );
+
+  return balances.map((value, i) => ({ date: dates[i], value }));
+};
+
+export default getAccountBalanceHistory;

--- a/src/libcore/types/index.js
+++ b/src/libcore/types/index.js
@@ -56,8 +56,19 @@ declare class CoreWallet {
   ): Promise<CoreAccount>;
 }
 
+export const TimePeriod = {
+  DAY: 0,
+  WEEK: 1,
+  MONTH: 2
+};
+
 declare type CoreAccount = {
   getBalance(): Promise<CoreAmount>,
+  getBalanceHistory(
+    from: string,
+    to: string,
+    timePeriod: $Values<typeof TimePeriod>
+  ): Promise<CoreAmount>,
   getLastBlock(): Promise<CoreBlock>,
   getFreshPublicAddresses(): Promise<CoreAddress[]>,
   getRestoreKey(): Promise<string>,
@@ -370,6 +381,9 @@ export const reflect = (declare: (string, Spec) => void) => {
       ...AccountMethods,
       getBalance: {
         returns: "Amount"
+      },
+      getBalanceHistory: {
+        returns: ["Amount"]
       },
       getLastBlock: {
         returns: "Block"

--- a/src/portfolio.js
+++ b/src/portfolio.js
@@ -32,6 +32,8 @@ function startOfDay(t) {
   return new Date(t.getFullYear(), t.getMonth(), t.getDate());
 }
 
+export const getPortfolioRange = (k: PortfolioRange) => perPortfolioRange[k];
+
 const perPortfolioRange: { [k: PortfolioRange]: * } = {
   year: {
     count: 365,

--- a/src/types/account.js
+++ b/src/types/account.js
@@ -4,6 +4,7 @@ import type { BigNumber } from "bignumber.js";
 import type { CryptoCurrency, TokenCurrency, Unit } from "./currencies";
 import type { OperationRaw, Operation } from "./operation";
 import type { DerivationMode } from "../derivation";
+import type { BalanceHistory } from "./portfolio";
 
 // A token belongs to an Account and share the parent account address
 export type TokenAccount = {
@@ -127,7 +128,12 @@ export type Account = {
   // I'm just inside the Ethereum 1: { account: Ethereum 1, parentAccount: undefined }
   // "account" is the primary account that you use/select/view. It is a `AccountLike`.
   // "parentAccount", if available, is the contextual account. It is a `?Account`.
-  subAccounts?: SubAccount[]
+  subAccounts?: SubAccount[],
+
+  // An array of { Date: BigNumber } pairs that represented the balance evolution throughout
+  // time. This can be used to represent the balance in things like the chart without recomputing
+  // the operations for an account.
+  balanceHistory?: BalanceHistory
 };
 
 export type SubAccount = TokenAccount | ChildAccount;


### PR DESCRIPTION
The first approach to integrating `getBalanceHistory` from libcore in order to be able to fetch the balance history for an account without having to compute it from the transactions themselves. This could open the door for a more performant graph (with more features @IAmMorrow :trollface:)

Current draft has added the balance history to the Account model but no further logic has been added to actually populate that during sync, this was something we talked about during our peer programming sessions @gre 

In order to get the CLI to work, you'll need to yalc the live-common version.

**Note:** Behavior doesn't match the js computed version, there are some inconsistencies following https://ledgerhq.atlassian.net/browse/LLC-475