### PR TITLE
Add `transportId` parameter to withDevice, withDevicePolling & open

### DIFF
--- a/src/hw/deviceAccess.js
+++ b/src/hw/deviceAccess.js
@@ -81,7 +81,7 @@ export const cancelDeviceAction = (transport: Transport<*>) => {
 
 const deviceQueues = {};
 
-export const withDevice = (deviceId: string) => <T>(
+export const withDevice = (deviceId: string, transportId?: string) => <T>(
   job: (t: Transport<*>) => Observable<T>
 ): Observable<T> =>
   Observable.create(o => {
@@ -107,7 +107,7 @@ export const withDevice = (deviceId: string) => <T>(
 
     // for any new job, we'll now wait the exec queue to be available
     deviceQueue
-      .then(() => open(deviceId)) // open the transport
+      .then(() => open(deviceId, transportId)) // open the transport
       .then(async transport => {
         if (unsubscribed) {
           // it was unsubscribed prematurely
@@ -179,11 +179,16 @@ export const retryWhileErrors = (acceptError: Error => boolean) => (
     })
   );
 
-export const withDevicePolling = (deviceId: string) => <T>(
+export const withDevicePolling = (deviceId: string, transportId?: string) => <
+  T
+>(
   job: (Transport<*>) => Observable<T>,
   acceptError: Error => boolean = genericCanRetryOnError
 ): Observable<T> =>
-  withDevice(deviceId)(job).pipe(
+  withDevice(
+    deviceId,
+    transportId
+  )(job).pipe(
     // $FlowFixMe
     retryWhen(retryWhileErrors(acceptError))
   );

--- a/src/hw/index.js
+++ b/src/hw/index.js
@@ -57,9 +57,13 @@ export const discoverDevices = (
   );
 };
 
-export const open = (deviceId: string): Promise<Transport<*>> => {
+export const open = (
+  deviceId: string,
+  transportId?: string
+): Promise<Transport<*>> => {
   for (let i = 0; i < modules.length; i++) {
     const m = modules[i];
+    if (transportId && m.id !== transportId) continue;
     const p = m.open(deviceId);
     if (p) return p;
   }


### PR DESCRIPTION
:book:  A bit of context from this summer: https://github.com/LedgerHQ/ledger-vault-front/pull/1000#discussion_r317095477

:star: The purpose of this PR is to provide a way to target a specific transport if you:
- have registered multiple transports
- want to use `withDevice` / `withDevicePolling`

:raised_hand_with_fingers_splayed:  The today behavior is to automatically select the [first working registered transport](https://github.com/LedgerHQ/ledger-live-common/blob/77ef279cf71fedf926c6ab0680781f3096ecb03c/src/hw/index.js#L61-L65) which is not our use case (we want to let user choose what he want).

So now you can:

```js
registerTransportModule({ id: "u2f", ... });
registerTransportModule({ id: "webusb", ... });
registerTransportModule({ id: "quantum-mechanics", ... });

const userChoice = localStorage.getItem("PREFERRED_TRANSPORT") || "webusb";

withDevicePolling(deviceID, userChoice)(transport => { /* blablabl */ })
```

Oh, I hear you shouting:

# > "Why don't you just register one transport based on the user preference?"

That's what we do now. But the whole thing is to allow dynamically change the transport without reloading the page (which is [our current workaround now](https://github.com/LedgerHQ/ledger-vault-front/blob/51ce50ec91b2d0ab222b045ac74e5d224fc77c0a/src/components/TransportChooser.js#L30-L36)).