### PR TITLE
formatSize with blockSize

### DIFF
--- a/src/apps/formatting.js
+++ b/src/apps/formatting.js
@@ -1,8 +1,8 @@
 // @flow
 import type { AppOp, InstalledItem } from "./types";
 
-/** format bytes size according to given block size */
-export const formatSize = (size?: number, blockSize: number = 1) => {
+/** format bytes size according to given block size (defaults to 4096) */
+export const formatSize = (size?: number, blockSize: number = 4096) => {
   const formatedSize =
     size && Math.ceil((Math.ceil(size / blockSize) * blockSize) / 1024);
   return formatedSize ? `${formatedSize}Kb` : "";

--- a/src/apps/formatting.js
+++ b/src/apps/formatting.js
@@ -1,8 +1,12 @@
 // @flow
 import type { AppOp, InstalledItem } from "./types";
 
-export const formatSize = (size?: number, defaultString?: string = "") =>
-  !size ? defaultString : Math.round(size / 1024) + "Kb";
+/** format bytes size according to given block size */
+export const formatSize = (size?: number, blockSize: number = 1) => {
+  const formatedSize =
+    size && Math.ceil((Math.ceil(size / blockSize) * blockSize) / 1024);
+  return formatedSize ? `${formatedSize}Kb` : "";
+};
 
 export const prettyActionPlan = (ops: AppOp[]) =>
   ops.map(op => (op.type === "install" ? "+" : "-") + op.name).join(", ");

--- a/src/apps/formatting.test.js
+++ b/src/apps/formatting.test.js
@@ -2,9 +2,8 @@
 import { formatSize } from "./formatting";
 
 test("Scenario: Formatting - format bytes", () => {
-  const defaultSize = "default";
-  const bytes = [[1024 * 10], [0], [undefined, defaultSize]];
+  const bytes = [[4096], [1], [1025], [4097, 4096], [undefined], [0]];
   const formattedBytes = bytes.map(args => formatSize(...args));
-  const expectedSizes = ["10Kb", "", defaultSize];
+  const expectedSizes = ["4Kb", "1Kb", "2Kb", "8Kb", "", ""];
   expect(formattedBytes).toEqual(expectedSizes);
 });

--- a/src/apps/formatting.test.js
+++ b/src/apps/formatting.test.js
@@ -2,8 +2,8 @@
 import { formatSize } from "./formatting";
 
 test("Scenario: Formatting - format bytes", () => {
-  const bytes = [[4096], [1], [1025], [4097, 4096], [undefined], [0]];
+  const bytes = [[4096], [1], [1025, 1024], [4097], [undefined], [0]];
   const formattedBytes = bytes.map(args => formatSize(...args));
-  const expectedSizes = ["4Kb", "1Kb", "2Kb", "8Kb", "", ""];
+  const expectedSizes = ["4Kb", "4Kb", "2Kb", "8Kb", "", ""];
   expect(formattedBytes).toEqual(expectedSizes);
 });


### PR DESCRIPTION
format size function can now take a block size as parameter