### PR TITLE
Use one wallet for each account

### DIFF
--- a/src/account/accountId.js
+++ b/src/account/accountId.js
@@ -55,11 +55,13 @@ export function decodeAccountId(accountId: string): AccountIdParams {
 export function getWalletName({
   seedIdentifier,
   derivationMode,
-  currency
+  currency,
+  index
 }: {
   seedIdentifier: string,
   derivationMode: DerivationMode,
-  currency: CryptoCurrency
+  currency: CryptoCurrency,
+  index: number
 }) {
-  return `${seedIdentifier}_${currency.id}_${derivationMode}`;
+  return `${seedIdentifier}_${currency.id}_${derivationMode}_${index}`;
 }

--- a/src/libcore/getAccountNetworkInfo.js
+++ b/src/libcore/getAccountNetworkInfo.js
@@ -26,7 +26,8 @@ export const getAccountNetworkInfo: F = withLibcoreF(core => async account => {
       core,
       walletName,
       currency,
-      derivationMode
+      derivationMode,
+      index: account.index
     });
 
     const coreAccount = await getOrCreateAccount({

--- a/src/libcore/getCoreAccount.js
+++ b/src/libcore/getCoreAccount.js
@@ -13,19 +13,21 @@ export const getCoreAccount = async (
   coreAccount: CoreAccount,
   walletName: string
 }> => {
-  const { currency, derivationMode, seedIdentifier } = account;
+  const { currency, derivationMode, seedIdentifier, index } = account;
 
   const walletName = getWalletName({
     currency,
     seedIdentifier,
-    derivationMode
+    derivationMode,
+    index
   });
 
   const coreWallet = await getOrCreateWallet({
     core,
     walletName,
     currency,
-    derivationMode
+    derivationMode,
+    index
   });
 
   const coreAccount = await getOrCreateAccount({

--- a/src/libcore/getOrCreateAccount.js
+++ b/src/libcore/getOrCreateAccount.js
@@ -18,11 +18,11 @@ const restoreWithAccountCreationInfo = {
 };
 
 export const getOrCreateAccount: F = atomicQueue(
-  async ({ core, coreWallet, account: { xpub, index, currency } }) => {
-    log("libcore", "getOrCreateAccount", { xpub, index });
+  async ({ core, coreWallet, account: { xpub, currency } }) => {
+    log("libcore", "getOrCreateAccount", { xpub });
     let coreAccount;
     try {
-      coreAccount = await coreWallet.getAccount(index);
+      coreAccount = await coreWallet.getAccount(0);
     } catch (err) {
       if (!isNonExistingAccountError(err)) {
         throw err;
@@ -31,23 +31,20 @@ export const getOrCreateAccount: F = atomicQueue(
       invariant(xpub, "xpub is missing. Please reimport the account.");
 
       if (restoreWithAccountCreationInfo[currency.id]) {
-        const accountCreationInfos = await coreWallet.getAccountCreationInfo(
-          index
-        );
+        const accountCreationInfos = await coreWallet.getAccountCreationInfo(0);
         const chainCodes = await accountCreationInfos.getChainCodes();
         const publicKeys = await accountCreationInfos.getPublicKeys();
         const derivations = await accountCreationInfos.getDerivations();
         const owners = await accountCreationInfos.getOwners();
         publicKeys.push(xpub);
         log("libcore", "AccountCreationInfo.init", {
-          index,
           owners,
           derivations,
           publicKeys,
           chainCodes
         });
         const newAccountCreationInfos = await core.AccountCreationInfo.init(
-          index,
+          0,
           owners,
           derivations,
           publicKeys,
@@ -59,7 +56,7 @@ export const getOrCreateAccount: F = atomicQueue(
         return account;
       } else {
         const extendedInfos = await coreWallet.getExtendedKeyAccountCreationInfo(
-          index
+          0
         );
         const infosIndex = await extendedInfos.getIndex();
         const extendedKeys = await extendedInfos.getExtendedKeys();

--- a/src/libcore/getOrCreateWallet.js
+++ b/src/libcore/getOrCreateWallet.js
@@ -13,11 +13,12 @@ type F = ({
   core: Core,
   walletName: string,
   currency: CryptoCurrency,
-  derivationMode: DerivationMode
+  derivationMode: DerivationMode,
+  index: number
 }) => Promise<CoreWallet>;
 
 export const getOrCreateWallet: F = atomicQueue(
-  async ({ core, walletName, currency, derivationMode }) => {
+  async ({ core, walletName, currency, derivationMode, index }) => {
     const poolInstance = core.getPoolInstance();
     let wallet;
 
@@ -33,7 +34,10 @@ export const getOrCreateWallet: F = atomicQueue(
       }
     }
 
-    const derivationScheme = getDerivationScheme({ currency, derivationMode });
+    const derivationScheme = getDerivationScheme({
+      currency,
+      derivationMode
+    }).replace("<account>", String(index));
     await config.putString("KEYCHAIN_DERIVATION_SCHEME", derivationScheme);
 
     const KEYCHAIN_OBSERVABLE_RANGE = getEnv("KEYCHAIN_OBSERVABLE_RANGE");


### PR DESCRIPTION
This is an attempt to address problem with our current usage of libcore.

We've often noticed report from users that got their account data badly swapped and we always have suspected problem related to wallet index iteration.

In recent iteration, we've introduced new derivation path for Tezos, and they have intersection between each other (`44'/1729'/x'/0'` and `44'/1729'/0'/x'`) so we have special rules to "skip" an index (starts the second at index 1). This obviously reveal the bug.

The last usecase we have is we want to be able to have different configuration per account, and today configuration is at the wallet level.. which is not a concept we have in Live so we can't offer users a way to configure that settings.

The solution is simple: I don't think we need the concept of wallet, so we're just going to always create one wallet for each account. If this works without a glitch, i think we can move to this unless someone have a problem.

interestingly, on the way doing this, i've found an optimisation to cache the derivation so we don't ask `44'/0'` to the device N times.
