### PR TITLE
Rewrite socket logic to fix race condition in transport

### DIFF
--- a/cli/src/commands-index.js
+++ b/cli/src/commands-index.js
@@ -1,4 +1,5 @@
 import app from "./commands/app";
+import appsInstallAll from "./commands/appsInstallAll";
 import appsUpdateTestAll from "./commands/appsUpdateTestAll";
 import balanceHistory from "./commands/balanceHistory";
 import broadcast from "./commands/broadcast";
@@ -31,6 +32,7 @@ import version from "./commands/version";
 
 export default {
   app,
+  appsInstallAll,
   appsUpdateTestAll,
   balanceHistory,
   broadcast,

--- a/cli/src/commands/appsInstallAll.js
+++ b/cli/src/commands/appsInstallAll.js
@@ -1,0 +1,33 @@
+/* eslint-disable no-console */
+// @flow
+
+import { from } from "rxjs";
+import { mergeMap, filter, map } from "rxjs/operators";
+import { withDevice } from "@ledgerhq/live-common/lib/hw/deviceAccess";
+import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
+import { initState, reducer, runAll } from "@ledgerhq/live-common/lib/apps";
+import { listApps, execWithTransport } from "@ledgerhq/live-common/lib/apps/hw";
+import { deviceOpt } from "../scan";
+
+export default {
+  description: "test script to install and uninstall all apps",
+  args: [deviceOpt],
+  job: ({ device }: $Shape<{ device: string }>) =>
+    withDevice(device || "")(t => {
+      const exec = execWithTransport(t);
+      return from(getDeviceInfo(t)).pipe(
+        mergeMap(deviceInfo =>
+          listApps(t, deviceInfo).pipe(
+            filter(e => e.type === "result"),
+            map(e =>
+              e.result.appsListNames.reduce(
+                (s, name) => reducer(s, { type: "install", name }),
+                initState(e.result)
+              )
+            ),
+            mergeMap(s => runAll(s, exec))
+          )
+        )
+      );
+    })
+};

--- a/cli/src/commands/appsUpdateTestAll.js
+++ b/cli/src/commands/appsUpdateTestAll.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 // @flow
 
-import { from, of } from "rxjs";
+import { from, of, Observable } from "rxjs";
 import { mergeMap, ignoreElements, filter, map } from "rxjs/operators";
 import { withDevice } from "@ledgerhq/live-common/lib/hw/deviceAccess";
 import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
@@ -26,54 +26,95 @@ export default {
       const exec = execWithTransport(t);
       // $FlowFixMe
       return from(getDeviceInfo(t)).pipe(
-        mergeMap(deviceInfo =>
-          listApps(t, deviceInfo).pipe(
-            filter(e => e.type === "result"),
-            map(e => e.result)
-          )
-        ),
-        mergeMap(listAppsResult => {
-          return listAppsResult.appsListNames.slice(index || 0).reduce(
-            ($state, name) =>
-              $state.pipe(
-                mergeMap(s => {
-                  if (s.currentError) {
-                    console.error(
-                      "FAILED " +
-                        s.currentError.appOp.type +
-                        " " +
-                        s.currentError.appOp.name +
-                        ": " +
-                        String(s.currentError.error)
-                    );
-                  }
-                  console.log(
-                    "on device: " +
-                      s.installed
-                        .map(i => i.name + (!i.updated ? " (outdated)" : ""))
-                        .join(", ")
-                  );
-                  s = reducer(s, { type: "wipe" });
-                  console.log(
-                    "wipe action plan = " + prettyActionPlan(getActionPlan(s))
-                  );
-                  return runAll(s, exec);
-                }),
-                mergeMap(s => {
-                  s = reducer(s, { type: "install", name });
-                  console.log(
-                    "install '" +
-                      name +
-                      "' action plan = " +
-                      prettyActionPlan(getActionPlan(s))
-                  );
-                  return runAll(s, exec);
-                })
-              ),
-            of(initState(listAppsResult))
-          );
-        }),
-        ignoreElements()
+        mergeMap(
+          deviceInfo =>
+            listApps(t, deviceInfo).pipe(
+              filter(e => e.type === "result"),
+              map(e => e.result),
+              mergeMap(listAppsResult => {
+                return listAppsResult.appsListNames.slice(index || 0).reduce(
+                  ($state, name) =>
+                    $state.pipe(
+                      mergeMap(s => {
+                        if (s.currentError) {
+                          console.error(
+                            "FAILED " +
+                              s.currentError.appOp.type +
+                              " " +
+                              s.currentError.appOp.name +
+                              ": " +
+                              String(s.currentError.error)
+                          );
+                        }
+                        console.log(
+                          "on device: " +
+                            s.installed
+                              .map(
+                                i => i.name + (!i.updated ? " (outdated)" : "")
+                              )
+                              .join(", ")
+                        );
+                        s = reducer(s, { type: "wipe" });
+                        console.log(
+                          "wipe action plan = " +
+                            prettyActionPlan(getActionPlan(s))
+                        );
+                        return runAll(s, exec);
+                      }),
+                      mergeMap(s => {
+                        s = reducer(s, { type: "install", name });
+                        console.log(
+                          "install '" +
+                            name +
+                            "' action plan = " +
+                            prettyActionPlan(getActionPlan(s))
+                        );
+                        return runAll(s, exec);
+                      }),
+                      mergeMap(state =>
+                        Observable.create(o => {
+                          let sub;
+                          const timeout = setTimeout(() => {
+                            sub = listApps(t, deviceInfo).subscribe(o);
+                          }, 4000);
+                          return () => {
+                            clearTimeout(timeout);
+                            if (sub) sub.unsubscribe();
+                          };
+                        }).pipe(
+                          filter(e => e.type === "result"),
+                          map(e => e.result),
+                          map(results => {
+                            const app = results.installed.find(
+                              a => a.name === name
+                            );
+                            if (!app) {
+                              throw new Error(
+                                "after install " +
+                                  name +
+                                  ", app is not visible on listApps"
+                              );
+                            }
+                            if (app && !app.updated) {
+                              throw new Error(
+                                "after install " +
+                                  name +
+                                  ", app hash is not matching latest one. Got " +
+                                  app.hash
+                              );
+                            }
+                            // continue with state
+                            return state;
+                          })
+                        )
+                      )
+                    ),
+                  of(initState(listAppsResult))
+                );
+              })
+            ),
+          ignoreElements()
+        )
       );
     })
 };

--- a/cli/src/live-common-setup-base.js
+++ b/cli/src/live-common-setup-base.js
@@ -10,7 +10,6 @@ import {
 } from "@ledgerhq/live-common/lib/network";
 import { implementCountervalues } from "@ledgerhq/live-common/lib/countervalues";
 import { log, listen } from "@ledgerhq/logs";
-import { logs as socketLogs } from "@ledgerhq/live-common/lib/api/socket";
 import implementLibcore from "@ledgerhq/live-common/lib/libcore/platforms/nodejs";
 import "@ledgerhq/live-common/lib/load/tokens/ethereum/erc20";
 import { setSupportedCurrencies } from "@ledgerhq/live-common/lib/data/cryptocurrencies";
@@ -89,13 +88,6 @@ listen(({ id, date, type, message, ...rest }) => {
   logger.log("debug", {
     message: type + (message ? ": " + message : ""),
     // $FlowFixMe
-    ...rest
-  });
-});
-
-socketLogs.subscribe(({ type, ...rest }) => {
-  logger.log("debug", {
-    message: "socket:" + type,
     ...rest
   });
 });

--- a/docs/socket.md
+++ b/docs/socket.md
@@ -1,0 +1,199 @@
+## api/socket `createDeviceSocket` and script runner
+
+Device operations like genuine check, managing apps or firmware update involve the establishement of a secure channel between the Ledger devices and a Ledger [HSM](https://en.wikipedia.org/wiki/Hardware_security_module).
+
+One of the way to do that, that live-common is implementing, is using a WebSocket API: the "script runner". There are many ping-pong exchanges that happens and a WebSocket is appropriate not only for performance but also for having a lifecycle of such bond.
+
+In live-common, we exposes this API using a [rxjs.Observable](https://github.com/ReactiveX/rxjs). It's a convenient, composable, functional, stream abstraction. We will document in here the behavior of the underlying function `createDeviceSocket`.
+
+Here is the gist of executing a genuine check:
+
+```js
+import { createDeviceSocket } from "@ledgerhq/live-common/lib/api/socket";
+
+const genuineCheck = (
+  transport: Transport<*>,
+  { targetId, perso }: { targetId: number, perso: string } // these info are returned in getDeviceInfo
+): Observable<boolean> =>
+  createDeviceSocket(transport, {
+    url: URL.format({
+      pathname: `${getEnv("BASE_SOCKET_URL")}/genuine`,
+      query: { targetId, perso }
+    })
+  }).pipe( // example of composing it
+    filter(e.type === "result"), // let's look at the result
+    map(e => e.payload === "0000") // success code for genuine check
+  );
+};
+
+// usage:
+
+genuineCheck(hidTransport, meta).subscribe(
+  isSuccess => {  isSuccess ? console.log("yeah!") : console.log("bad result") },
+  error => { console.error("oops!", error) }
+)
+```
+
+## `createDeviceSocket` signature
+
+```js
+(Transport<*>, { url: string }) => Observable<SocketEvent>
+```
+
+It creates a transport (that is coming from [`ledgerjs`](https://github.com/ledgerhq/ledgerjs)) and open a secure channel to the given wss:// URL. It returns an Observable of `SocketEvent` which can be one of these:
+
+```js
+type SocketEvent =
+  | { type: "bulk-progress", progress: number, index: number, total: number }
+  | { type: "result", payload: any }
+  | { type: "warning", message: string }
+  | { type: "device-permission-requested", wording: string }
+  | { type: "device-permission-granted" }
+  | { type: "exchange-before", nonce: number, apdu: Buffer }
+  | {
+      type: "exchange",
+      nonce: number,
+      apdu: Buffer,
+      data: Buffer,
+      status: Buffer
+    }
+  | { type: "opened" }
+  | { type: "closed" };
+```
+
+The observable terminates when everything is finished with the device or errors when something unexpected happened (included device errors, see Section "Error cases").
+
+## The protocol
+
+The API is exposed over a secured WebSocket.
+
+Each "script" to run is exposed under a different path, and some parameters are given to contextualize it to the device version.
+
+For instance, installing BTC 1.3.17 on Nano S 1.6.0 will use `wss://api.ledgerwallet.com/update/install?targetId=823132164&perso=perso_11&deleteKey=nanos%2F1.6.0%2Fbitcoin%2Fapp_1.3.17_del_key&firmware=nanos%2F1.6.0%2Fbitcoin%2Fapp_1.3.17&firmwareKey=nanos%2F1.6.0%2Fbitcoin%2Fapp_1.3.17_key&hash=8514a59f3ec27eab4637fb6ec626a6ea31f876f429f1e484d29cc8ec5cf15896`
+
+### Messages
+
+Messages of the WebSocket channel are plain text of serialized JSON of shape: `{ query, nonce, ...otherfields }`.
+
+- `nonce` is a counter that starts from 1.
+- `query` is a discriminant field to handle different cases:
+
+#### `query="exchange"`
+
+`"exchange"` requests the client to execute one APDU command with the device. It is typically used for the initial secure channel establishment.
+
+It is **never** a terminating event, meaning there are more events to come in the websocket after this one.
+
+In this case, we have also these fields required in the JSON:
+
+- `data`: an hexadecimal APDU command to send to the device.
+
+At the end of the step, the client send back to the server this event:
+
+```js
+{ nonce: number,
+  response: "success" | "error",
+  data: string } // hexadecimal
+```
+
+In live-common case, during this step, two events are emitted out of the Observable:
+
+```js
+| { type: "exchange-before", nonce: number, apdu: Buffer }
+| { type: "exchange", nonce: number, apdu: Buffer, data: Buffer, status: Buffer }
+```
+
+But this step can also emit these events, in case "Allow Manager" needs to be validated by the user:
+
+```js
+| { type: "device-permission-requested", wording: string }
+| { type: "device-permission-granted" }
+```
+
+#### `query="success"`
+
+`"success"` terminates the socket with a payload data.
+
+It is a **terminating event**, no events are to expect from the server after this event and the websocket will be closed (by server and can be be the client too).
+
+In this case, we have also these fields required in the JSON:
+
+- `data` or `result`: anything. (can be a string, or a complex JSON object)
+
+For some (legacy?) it's either `data` or `result` field that is used. In live-common side, we semantically unify this into `"payload"`.
+
+In live-common case, an event is emitted at the end and the observable closes:
+
+```js
+| { type: "result", payload: any }
+```
+
+#### `query="error"`
+
+`"error"` terminates the socket with an error that occured on the HSM.
+
+- `data` field will contains the error message in String format.
+
+in live-common case, the Observable will terminates with an error `DeviceSocketFail` containing the actual error text.
+
+#### `query="warning"`
+
+`"warning"` query can be emit from the HSM to notify the client of a warning. This is a system in place for Manager notification but that is not yet used at the moment. It does not terminates the stream and can be in the middle of other events.
+
+- `data` field will contains the warning message in String format.
+
+in live-common case, the Observable emits:
+
+```js
+  | { type: "warning", message: string }
+```
+
+#### `query="bulk"`
+
+`"bulk"` **terminates** the socket with a big series of APDUs to execute on the device.
+
+- `data` an Array of string. Where each string is an hexadecimal APDU to run on the device.
+
+At this point, the client might close the WebSocket connection because we know it's a closing event. Any socket event is also silenced from the client.
+
+In any case, the live-common logic will run all the APDUs and the progress will be notified.
+
+```js
+| { type: "bulk-progress", progress: number 0 to 1, index: number 0 to N, total: number N }
+```
+
+If everything succeed, the Observable will normally close.
+
+If one of the APDU exchange result of a non 9000 status from the device, an error `TransportStatusError` is thrown.
+
+If the device becomes unresponsive at some point of the execution, this step can throw `ManagerDeviceLockedError` because that's a locking case.
+
+### Error cases
+
+There are many cases of errors or channel interruptions.
+
+Any of these error, if comes from the client, will unsubscribe the observable and therefore result of closing the WebSocket channel.
+
+#### `WebsocketConnectionError`
+
+This can typically happens Network can goes down / channel timeout. This error will be thrown in the observable.
+
+#### `DeviceSocketFail`
+
+An HSM error occurred.
+
+#### `UserRefusedAllowManager`
+
+It means user have denied the "Allow manager".
+
+#### Transport errors
+
+Any transport error can be thrown, for instance `DisconnectedDevice` and `DisconnectedDeviceDuringOperation` when the user unplug the device.
+
+#### `TransportStatusError` devices returns an error code
+
+In any cases that is not a `9000` status code, a TransportStatusError will be thrown. It is usually always managed by Live and remapped to appropriate wording (for instance, install have special code to tell "not enough space" which will be thrown if you use the higher level install app functions).
+
+#### User interrupts the actual flow
+
+This can happens because user cancelled/left an action and we no longer need the channel. In that case, we will just close the websocket and no error will be emitted, it's a usual Observable subscription unsubscribe().

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "git://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "11.3.0",
+  "version": "11.4.0-beta.0",
   "main": "lib/index.js",
   "license": "MIT",
   "scripts": {

--- a/src/__tests__/test-helpers/libcore-setup.js
+++ b/src/__tests__/test-helpers/libcore-setup.js
@@ -3,7 +3,6 @@ import winston from "winston";
 import { listen } from "@ledgerhq/logs";
 import "./setup";
 import { setEnvUnsafe } from "../../env";
-import { logs as socketLogs } from "../../api/socket";
 import implementLibcore from "../../libcore/platforms/nodejs";
 import "../../load/tokens/ethereum/erc20";
 
@@ -59,13 +58,6 @@ listen(({ id, date, type, message, ...rest }) => {
   logger.log("debug", {
     message: type + (message ? ": " + message : ""),
     // $FlowFixMe
-    ...rest
-  });
-});
-
-socketLogs.subscribe(({ type, ...rest }) => {
-  logger.log("debug", {
-    message: "socket:" + type,
     ...rest
   });
 });

--- a/src/api/socket.js
+++ b/src/api/socket.js
@@ -1,63 +1,25 @@
 // @flow
 
-import invariant from "invariant";
 import type Transport from "@ledgerhq/hw-transport";
+import { log } from "@ledgerhq/logs";
 import { Observable, Subject } from "rxjs";
 import {
   WebsocketConnectionError,
-  WebsocketConnectionFailed,
   DeviceSocketFail,
-  DeviceSocketNoBulkStatus,
-  DisconnectedDeviceDuringOperation
+  DisconnectedDeviceDuringOperation,
+  TransportStatusError,
+  UserRefusedAllowManager,
+  ManagerDeviceLockedError
 } from "@ledgerhq/errors";
 import { cancelDeviceAction } from "../hw/deviceAccess";
 import { createWebSocket } from "../network";
 import { getEnv } from "../env";
+import type { SocketEvent } from "../types/manager";
 
-const logsSubject = new Subject();
 const warningsSubject = new Subject();
-
-export const logs: Observable<*> = logsSubject.asObservable();
 export const warnings: Observable<string> = warningsSubject.asObservable();
 
-// TODO move to @ledgerhq/logs
-const log = (obj: *) => {
-  logsSubject.next(obj);
-};
-
-export type SocketEvent =
-  | {
-      type: "bulk-progress",
-      progress: number,
-      index: number,
-      total: number
-    }
-  | {
-      type: "result",
-      payload: any
-    }
-  | {
-      type: "warning",
-      message: string
-    }
-  | {
-      type: "exchange-before",
-      nonce: number,
-      apdu: Buffer
-    }
-  | {
-      type: "exchange",
-      nonce: number,
-      apdu: Buffer,
-      data: Buffer,
-      status: Buffer
-    }
-  | {
-      type: "opened"
-    }
-  | {
-      type: "closed"
-    };
+const UNRESPONSIVE_DELAY = 1000;
 
 /**
  * use Ledger WebSocket API to exchange data with the device
@@ -66,204 +28,184 @@ export type SocketEvent =
 export const createDeviceSocket = (
   transport: Transport<*>,
   {
-    url,
-    ignoreWebsocketErrorDuringBulk
+    url
   }: {
-    url: string,
-    // ignoreWebsocketErrorDuringBulk is a workaround to continue bulk even if the ws connection is termined
-    // the WS connection can be terminated typically because ws timeout
-    ignoreWebsocketErrorDuringBulk?: boolean
+    url: string
   }
 ): Observable<SocketEvent> =>
   Observable.create(o => {
-    let ws;
-    let lastMessage: ?any;
-    let interrupted = false;
-    let terminated = false;
-    let inBulk = false;
-    let ignoreError = false;
+    let deviceError = null; // the socket was interrupted by device problem
+    let unsubscribed = false; // subscriber wants to stops everything
+    let normallyFinished = false; // the socket logic reach a normal termination
+    let inBulk = false; // bulk is a mode where we have many apdu to run on device and no longer need the connection
 
-    const onDisconnect = e => {
-      transport.off("disconnect", onDisconnect);
-      o.error(new DisconnectedDeviceDuringOperation((e && e.message) || ""));
-    };
-    transport.on("disconnect", onDisconnect);
-
-    try {
-      ws = createWebSocket(url);
-    } catch (err) {
-      o.error(new WebsocketConnectionFailed(err.message, { url }));
-      return () => {};
-    }
-    invariant(ws, "websocket is available");
+    const ws = createWebSocket(url);
 
     ws.onopen = () => {
       o.next({ type: "opened" });
-      log({ type: "socket-opened", url });
+      log("socket-opened", url);
     };
 
     ws.onerror = e => {
-      if (ignoreError) return;
-      log({ type: "socket-error", message: e.message, stack: e.stack });
-      if (!inBulk || !ignoreWebsocketErrorDuringBulk) {
-        terminated = true;
-        o.error(new WebsocketConnectionError(e.message, { url }));
-      }
+      log("socket-error", e.message);
+      if (inBulk) return;
+      o.error(new WebsocketConnectionError(e.message, { url }));
     };
 
     ws.onclose = () => {
-      log({ type: "socket-close" });
-      if (!inBulk || !ignoreWebsocketErrorDuringBulk) {
-        terminated = true;
-        o.next({ type: "result", payload: lastMessage });
+      log("socket-close");
+      if (inBulk) return;
+      if (normallyFinished) {
         o.complete();
+      } else {
+        o.error(new WebsocketConnectionError("closed"));
       }
     };
 
-    const send = (nonce, response, data) => {
-      const msg = {
-        nonce,
-        response,
-        data
-      };
-      log({ type: "socket-send", nonce, response });
-      const strMsg = JSON.stringify(msg);
-      ws.send(strMsg);
-    };
-
-    const handlers = {
-      exchange: async input => {
-        const { nonce } = input;
-        const apdu = Buffer.from(input.data, "hex");
-        o.next({ type: "exchange-before", nonce, apdu });
-        const r: Buffer = await transport.exchange(apdu);
-        if (interrupted) return;
-        const status = r.slice(r.length - 2);
-        const data = r.slice(0, r.length - 2);
-        o.next({ type: "exchange", nonce, apdu, status, data });
-        const strStatus = status.toString("hex");
-        send(
-          nonce,
-          strStatus === "9000" ? "success" : "error",
-          data.toString("hex")
-        );
-      },
-
-      bulk: async input => {
-        inBulk = true;
-        try {
-          const { data, nonce } = input;
-
-          o.next({
-            type: "bulk-progress",
-            progress: 0,
-            index: 0,
-            total: data.length
-          });
-
-          // Execute all apdus and collect last status
-          let lastStatus = null;
-          for (let i = 0; i < data.length; i++) {
-            const apdu = data[i];
-            const r: Buffer = await transport.exchange(
-              Buffer.from(apdu, "hex")
-            );
-            lastStatus = r.slice(r.length - 2);
-            if (lastStatus.toString("hex") !== "9000") break;
-            if (interrupted) return;
-            o.next({
-              type: "bulk-progress",
-              progress: (i + 1) / data.length,
-              index: i + 1,
-              total: data.length
-            });
-          }
-
-          if (!lastStatus) {
-            throw new DeviceSocketNoBulkStatus();
-          }
-
-          const strStatus = lastStatus.toString("hex");
-
-          if (ignoreWebsocketErrorDuringBulk && ws.readyState !== 1) {
-            terminated = true;
-            o.next({
-              type: "result",
-              payload: lastStatus ? lastStatus.toString("hex") : ""
-            });
-            o.complete();
-          } else {
-            send(
-              nonce,
-              strStatus === "9000" ? "success" : "error",
-              strStatus === "9000" ? "" : strStatus
-            );
-          }
-        } finally {
-          inBulk = false;
-        }
-      },
-
-      success: msg => {
-        lastMessage = msg.data || msg.result;
-        ignoreError = true;
-        ws.close();
-      },
-
-      error: msg => {
-        log({ type: "socket-message-error", message: msg.data });
-        throw new DeviceSocketFail(msg.data, { url });
-      },
-
-      warning: (msg: { data: string }) => {
-        log({ type: "socket-message-warning", message: msg.data });
-        o.next({
-          type: "warning",
-          message: msg.data
-        });
-        warningsSubject.next(msg.data);
-      }
-    };
-
-    const stackMessage = async e => {
-      if (interrupted) return;
+    ws.onmessage = async e => {
+      if (unsubscribed) return;
       try {
-        const msg = JSON.parse(e.data);
-        const l: Object = { ...msg, type: "socket-receive" };
-        delete l.data; // too verbose
-        log(l);
-        if (!(msg.query in handlers)) {
-          console.warn(`Cannot handle msg of type ${msg.query}`, {
-            query: msg.query,
-            url
-          });
-          return;
+        const input = JSON.parse(e.data);
+        log("socket-in", input.query, input);
+        switch (input.query) {
+          case "exchange": {
+            // a single ping-pong apdu with the HSM
+            const { nonce } = input;
+            const apdu = Buffer.from(input.data, "hex");
+            o.next({ type: "exchange-before", nonce, apdu });
+
+            // specific logic for detecting allow manager
+            let requested = false;
+            const timeout = setTimeout(() => {
+              if (unsubscribed) return;
+              if (apdu.slice(0, 2).toString("hex") === "e051") {
+                requested = true;
+                o.next({
+                  type: "device-permission-requested",
+                  wording: "Allow Ledger manager"
+                });
+              }
+            }, UNRESPONSIVE_DELAY);
+
+            const r = await transport.exchange(apdu);
+            clearTimeout(timeout);
+            if (unsubscribed) return;
+            const status = r.slice(r.length - 2);
+
+            // if allow manager was requested, we either throw if deny or emit accepted
+            if (requested) {
+              if (status.toString("hex") === "6985") {
+                o.error(new UserRefusedAllowManager());
+                return;
+              }
+              o.next({ type: "device-permission-granted" });
+            }
+
+            const data = r.slice(0, r.length - 2);
+            o.next({ type: "exchange", nonce, apdu, status, data });
+            const strStatus = status.toString("hex");
+            const msg = {
+              nonce,
+              response: strStatus === "9000" ? "success" : "error",
+              data: data.toString("hex")
+            };
+            log("socket-out", msg.response);
+            const strMsg = JSON.stringify(msg);
+            ws.send(strMsg);
+
+            break;
+          }
+
+          case "bulk": {
+            // in bulk, we just have to unroll a lot of apdus, we no longer need the WS
+            inBulk = true;
+            ws.close();
+
+            const { data } = input;
+            const notify = index =>
+              o.next({
+                type: "bulk-progress",
+                progress: index / data.length,
+                index,
+                total: data.length
+              });
+
+            const unresponsive = () => {
+              if (unsubscribed) return;
+              o.error(new ManagerDeviceLockedError());
+            };
+
+            notify(0);
+            let timeout;
+            for (let i = 0; i < data.length; i++) {
+              timeout = setTimeout(unresponsive, UNRESPONSIVE_DELAY);
+              const r = await transport.exchange(Buffer.from(data[i], "hex"));
+              clearTimeout(timeout);
+              if (unsubscribed) return;
+              const status = r.readUInt16BE(r.length - 2);
+              if (status !== 0x9000) throw new TransportStatusError(status);
+              notify(i + 1);
+            }
+            normallyFinished = true;
+            o.complete();
+            break;
+          }
+
+          case "success": {
+            // a final success event with some data payload
+            const payload = input.result || input.data;
+            if (payload) o.next({ type: "result", payload });
+            normallyFinished = true;
+            o.complete();
+            break;
+          }
+
+          case "error": {
+            // an error from HSM
+            throw new DeviceSocketFail(input.data, { url });
+          }
+
+          case "warning": {
+            // a warning from HSM
+            o.next({ type: "warning", message: input.data });
+            warningsSubject.next(input.data);
+            break;
+          }
+
+          default:
+            console.warn(`Cannot handle msg of type ${input.query}`, {
+              query: input.query,
+              url
+            });
         }
-        await handlers[msg.query](msg);
       } catch (err) {
-        log({
-          type: "socket-message-error",
-          message: err.message,
-          stack: err.stack
-        });
+        deviceError = err;
+        log("socket-message-error", err.message);
         o.error(err);
       }
     };
 
-    ws.onmessage = rawMsg => {
-      stackMessage(rawMsg).catch(e => {
-        o.error(e);
-      });
+    const onDisconnect = e => {
+      transport.off("disconnect", onDisconnect);
+      const error = new DisconnectedDeviceDuringOperation(
+        (e && e.message) || ""
+      );
+      deviceError = error;
+      o.error(error);
     };
+    transport.on("disconnect", onDisconnect);
 
     return () => {
-      interrupted = true;
-      if (!terminated) {
+      unsubscribed = true;
+      if (!normallyFinished && !deviceError && inBulk) {
+        // if it was not normally ended, we might have to flush it
         if (getEnv("DEVICE_CANCEL_APDU_FLUSH_MECHANISM")) {
           cancelDeviceAction(transport);
         }
       }
-      if (ws.readyState !== 1) return;
-      ws.close();
+      if (ws.readyState === 1) {
+        // connection still active. we close it (unsubscribe)
+        ws.close();
+      }
     };
   });

--- a/src/api/socket.mock.js
+++ b/src/api/socket.mock.js
@@ -1,0 +1,62 @@
+// @flow
+
+import {
+  Observable,
+  Subject,
+  merge,
+  throwError,
+  interval,
+  concat,
+  of
+} from "rxjs";
+import { mergeMap, take, map, ignoreElements } from "rxjs/operators";
+import type { SocketEvent } from "../types/manager";
+
+export const socketErrorSubject: Subject<*> = new Subject();
+
+export const withSocketErrors = (
+  observable: Observable<SocketEvent>
+): Observable<SocketEvent> =>
+  merge(observable, socketErrorSubject.pipe(mergeMap(e => throwError(e))));
+
+const pause = ms => interval(ms).pipe(take(1), ignoreElements());
+
+export const secureChannelMock = (
+  managerGranted: boolean = false
+): Observable<SocketEvent> =>
+  !managerGranted
+    ? concat(
+        pause(500),
+        of({
+          type: "device-permission-requested",
+          wording: "Allow Ledger manager"
+        }),
+        pause(500),
+        of({
+          type: "device-permission-granted"
+        }),
+        pause(500)
+      )
+    : pause(1000);
+
+export const bulkSocketMock = (
+  duration: number = 1000
+): Observable<SocketEvent> => {
+  const total = Math.floor((duration - 100) / 100);
+  return interval(100).pipe(
+    take(total + 1),
+    map(index => ({
+      type: "bulk-progress",
+      progress: index / total,
+      index,
+      total
+    }))
+  );
+};
+
+export const resultMock = (payload: any): Observable<SocketEvent> =>
+  of({ type: "result", payload });
+
+export const createMockSocket = (
+  ...observables: Array<Observable<SocketEvent>>
+): Observable<SocketEvent> => withSocketErrors(concat(...observables));

--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -57,13 +57,11 @@ export const listApps = (
           next: e => {
             if (e.type === "result") {
               resolve(e.payload);
-            } else if (e.type === "allow-manager-accepted") {
-              o.next({ type: "device-permission-granted" });
-            } else if (e.type === "allow-manager-requested") {
-              o.next({
-                type: "device-permission-requested",
-                wording: "Allow Ledger manager"
-              });
+            } else if (
+              e.type === "device-permission-granted" ||
+              e.type === "device-permission-requested"
+            ) {
+              o.next(e);
             }
           },
           error: reject

--- a/src/apps/runner.js
+++ b/src/apps/runner.js
@@ -2,7 +2,13 @@
 
 import { useReducer, useEffect, useMemo } from "react";
 import { Observable, from, of, defer, concat } from "rxjs";
-import { map, materialize, reduce, ignoreElements } from "rxjs/operators";
+import {
+  map,
+  materialize,
+  reduce,
+  ignoreElements,
+  throttleTime
+} from "rxjs/operators";
 import type {
   Exec,
   State,
@@ -33,6 +39,7 @@ export const runAppOp = (
     // we need to allow a 1s delay for the action to be achieved without glitch (bug in old firmware when you do things too closely)
     defer(() => delay(getEnv("MANAGER_INSTALL_DELAY"))).pipe(ignoreElements()),
     defer(() => exec(appOp, deviceInfo.targetId, app)).pipe(
+      throttleTime(100),
       materialize(),
       map(n => {
         switch (n.kind) {

--- a/src/hw/checkDeviceForManager.js
+++ b/src/hw/checkDeviceForManager.js
@@ -2,13 +2,13 @@
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, of, throwError } from "rxjs";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
-import type { DeviceInfo, GenuineCheckEvent } from "../types/manager";
+import type { DeviceInfo, SocketEvent } from "../types/manager";
 import genuineCheck from "./genuineCheck";
 
 export default (
   transport: Transport<*>,
   deviceInfo: DeviceInfo
-): Observable<GenuineCheckEvent> =>
+): Observable<SocketEvent> =>
   deviceInfo.isOSU || deviceInfo.managerAllowed
     ? of({ type: "result", payload: "0000" })
     : deviceInfo.isBootloader

--- a/src/hw/genuineCheck.js
+++ b/src/hw/genuineCheck.js
@@ -4,13 +4,13 @@
 import Transport from "@ledgerhq/hw-transport";
 import { Observable, from } from "rxjs";
 import { switchMap } from "rxjs/operators";
-import type { DeviceInfo, GenuineCheckEvent } from "../types/manager";
+import type { DeviceInfo, SocketEvent } from "../types/manager";
 import ManagerAPI from "../api/Manager";
 
 export default (
   transport: Transport<*>,
   deviceInfo: DeviceInfo
-): Observable<GenuineCheckEvent> =>
+): Observable<SocketEvent> =>
   from(
     ManagerAPI.getDeviceVersion(deviceInfo.targetId, deviceInfo.providerId)
   ).pipe(

--- a/src/types/manager.js
+++ b/src/types/manager.js
@@ -184,14 +184,19 @@ export type Category = {
   date_last_modified: string
 };
 
-export type GenuineCheckEvent =
+export type SocketEvent =
+  | { type: "bulk-progress", progress: number, index: number, total: number }
+  | { type: "result", payload: any }
+  | { type: "warning", message: string }
+  | { type: "device-permission-requested", wording: string }
+  | { type: "device-permission-granted" }
+  | { type: "exchange-before", nonce: number, apdu: Buffer }
   | {
-      type: "result",
-      payload: string
+      type: "exchange",
+      nonce: number,
+      apdu: Buffer,
+      data: Buffer,
+      status: Buffer
     }
-  | {
-      type: "allow-manager-requested"
-    }
-  | {
-      type: "allow-manager-accepted"
-    };
+  | { type: "opened" }
+  | { type: "closed" };


### PR DESCRIPTION
- rewrite the socket logic in order to make it work with upcoming script runner as well as the previous one
- add command appsInstallAll
- make appsUpdateTestAll to do a listApps after EACH install. It reveals the bug in current script runner and assess it's in fact fixed in the upcoming. We do that to also verify that the hash of install app matches the hash of the api (and we spot and reported problems on Nano X)
- Introduce a way to mock the socket that is enabled in MOCK=1 mode (will be eventually used for UI test purpose)
- the socket.js logic have the mecanism to detect the "allow manager" built in into it which allowed to simplify some code
- the logs observable exported from api/socket has been dropped because we are just using the @ledgerhq/logs like other parts
- the progress event out of the apps logic is throttle by 100ms


This will require heavy testing and we'll do it in context of "lldv2" and "llm", i'll release a .alpha for this purpose