### PR TITLE
add `ledger-live envs` CLI command to print envs

### DIFF
--- a/cli/src/commands-index.js
+++ b/cli/src/commands-index.js
@@ -6,6 +6,7 @@ import deviceAppVersion from "./commands/deviceAppVersion";
 import deviceInfo from "./commands/deviceInfo";
 import deviceVersion from "./commands/deviceVersion";
 import discoverDevices from "./commands/discoverDevices";
+import envs from "./commands/envs";
 import exportAccounts from "./commands/exportAccounts";
 import firmwareRepair from "./commands/firmwareRepair";
 import firmwareUpdate from "./commands/firmwareUpdate";
@@ -38,6 +39,7 @@ export default {
   deviceInfo,
   deviceVersion,
   discoverDevices,
+  envs,
   exportAccounts,
   firmwareRepair,
   firmwareUpdate,

--- a/cli/src/commands/envs.js
+++ b/cli/src/commands/envs.js
@@ -1,0 +1,23 @@
+// @flow
+
+import { from } from "rxjs";
+import { map } from "rxjs/operators";
+import {
+  getEnvDesc,
+  getEnv,
+  getAllEnvNames
+} from "@ledgerhq/live-common/lib/env";
+
+export default {
+  description: "Print available environment variables",
+  args: [],
+  job: () =>
+    from(getAllEnvNames()).pipe(
+      map(
+        name =>
+          `# ${name} ${getEnvDesc(name)}\n${name}=${JSON.stringify(
+            getEnv(name)
+          )}\n`
+      )
+    )
+};


### PR DESCRIPTION
`ledger-live envs`

will prints

```bash
# API_TEZOS_BAKER bakers API for tezos
API_TEZOS_BAKER="https://tezos-bakers.api.live.ledger.com"

# API_TEZOS_BLOCKCHAIN_EXPLORER_API_ENDPOINT Ledger explorer API for tezos
API_TEZOS_BLOCKCHAIN_EXPLORER_API_ENDPOINT="https://xtz-explorer.api.live.ledger.com/explorer"

# API_TEZOS_NODE node API for tezos (for broadcast only)
API_TEZOS_NODE="https://xtz-node.api.live.ledger.com"

# BASE_SOCKET_URL Ledger script runner API
BASE_SOCKET_URL="wss://api.ledgerwallet.com/update"

# BRIDGE_FORCE_IMPLEMENTATION force implementation for ALL currency bridges (affects scanning accounts)
BRIDGE_FORCE_IMPLEMENTATION=""

# DEVICE_CANCEL_APDU_FLUSH_MECHANISM enable a mechanism that send a 0x00 apdu to force device to awake from its 'Processing' UI state
DEVICE_CANCEL_APDU_FLUSH_MECHANISM=true

# DEVICE_PROXY_URL enable a proxy to use instead of a physical device
DEVICE_PROXY_URL=""

# DISABLE_TRANSACTION_BROADCAST disable broadcast of transactions
DISABLE_TRANSACTION_BROADCAST=false

# EXPERIMENTAL_BLE enable experimental support of Bluetooth
EXPERIMENTAL_BLE=false

# EXPERIMENTAL_CURRENCIES enable experimental support of currencies (comma separated)
EXPERIMENTAL_CURRENCIES=""

# EXPERIMENTAL_EXPLORERS enable experimental explorer APIs
EXPERIMENTAL_EXPLORERS=false

# EXPERIMENTAL_FALLBACK_APDU_LISTAPPS if HSM list apps fails, fallback on APDU version (>=1.6.0)
EXPERIMENTAL_FALLBACK_APDU_LISTAPPS=false

# EXPERIMENTAL_LANGUAGES enable experimental languages
EXPERIMENTAL_LANGUAGES=false

# EXPERIMENTAL_LIBCORE enable experimental libcore implementation of a currency (affects scan accounts)
EXPERIMENTAL_LIBCORE=false

# EXPERIMENTAL_MANAGER enable an experimental version of Manager
EXPERIMENTAL_MANAGER=false

# EXPERIMENTAL_PORTFOLIO_RANGE enable an experimental version of available graph ranges and granularity
EXPERIMENTAL_PORTFOLIO_RANGE=false

# EXPERIMENTAL_ROI_CALCULATION enable an experimental version of the portfolio percentage calculation
EXPERIMENTAL_ROI_CALCULATION=false

# EXPERIMENTAL_SEND_MAX force enabling SEND MAX even if not yet stable
EXPERIMENTAL_SEND_MAX=false

# EXPERIMENTAL_USB enable an experimental implementation of USB support
EXPERIMENTAL_USB=false

# EXPLORER Ledger main explorer API (multi currencies)
EXPLORER="https://explorers.api.live.ledger.com"

# FORCE_PROVIDER use a different provider for app store (for developers only)
FORCE_PROVIDER=1

# GET_CALLS_RETRY how many times to retry a GET http call
GET_CALLS_RETRY=2

# GET_CALLS_TIMEOUT how much time to timeout a GET http call
GET_CALLS_TIMEOUT=60000

# HIDE_EMPTY_TOKEN_ACCOUNTS hide the sub accounts when they are empty
HIDE_EMPTY_TOKEN_ACCOUNTS=false

# KEYCHAIN_OBSERVABLE_RANGE overrides the gap limit specified by BIP44 (default to 20)
KEYCHAIN_OBSERVABLE_RANGE=0

# LEDGER_COUNTERVALUES_API Ledger countervalues API
LEDGER_COUNTERVALUES_API="https://countervalues.api.live.ledger.com"

# LEDGER_REST_API_BASE DEPRECATED
LEDGER_REST_API_BASE="https://explorers.api.live.ledger.com"

# LEGACY_KT_SUPPORT_TO_YOUR_OWN_RISK enable sending to KT accounts. Not tested.
LEGACY_KT_SUPPORT_TO_YOUR_OWN_RISK=false

# LIBCORE_BALANCE_HISTORY_NOGO comma-separated list of currencies which does not properly support balance history libcore implementation
LIBCORE_BALANCE_HISTORY_NOGO="ripple,ethereum,tezos"

# LIBCORE_PASSWORD libcore encryption password
LIBCORE_PASSWORD=""

# MANAGER_API_BASE Ledger Manager API
MANAGER_API_BASE="https://manager.api.live.ledger.com/api"

# MANAGER_DEV_MODE enable visibility of utility apps in Manager
MANAGER_DEV_MODE=false

# MANAGER_INSTALL_DELAY defines the time to wait before installing apps to prevent known glitch (<=1.5.5) when chaining installs
MANAGER_INSTALL_DELAY=1000

# MAX_ACCOUNT_NAME_SIZE maximum size of account names
MAX_ACCOUNT_NAME_SIZE=50

# MOCK switch the app into a MOCK mode for test purpose
MOCK=false

# OPERATION_ADDRESSES_LIMIT limit the number of addresses in from/to of operations
OPERATION_ADDRESSES_LIMIT=100

# OPERATION_OPTIMISTIC_RETENTION timeout to keep an optimistic operation that was broadcasted but not yet visible from libcore or the API
OPERATION_OPTIMISTIC_RETENTION=1800000

# OPERATION_PAGE_SIZE_INITIAL defines the initial default operation length page to use
OPERATION_PAGE_SIZE_INITIAL=100

# SCAN_FOR_INVALID_PATHS enable searching accounts in exotic derivation paths
SCAN_FOR_INVALID_PATHS=false

# SHOW_LEGACY_NEW_ACCOUNT allow the creation of legacy accounts
SHOW_LEGACY_NEW_ACCOUNT=false

# SKIP_ONBOARDING dev flag to skip onboarding flow
SKIP_ONBOARDING=false

# SYNC_ALL_INTERVAL delay between successive sync
SYNC_ALL_INTERVAL=120000

# SYNC_BOOT_DELAY delay before the sync starts
SYNC_BOOT_DELAY=2000

# SYNC_PENDING_INTERVAL delay between sync when an operation is still pending
SYNC_PENDING_INTERVAL=10000

# SYNC_OUTDATED_CONSIDERED_DELAY delay until Live consider a sync outdated
SYNC_OUTDATED_CONSIDERED_DELAY=120000

# SYNC_MAX_CONCURRENT maximum limit to synchronize accounts concurrently to limit overload
SYNC_MAX_CONCURRENT=4

# USER_ID unique identifier of app instance. used to derivate dissociated ids for difference purposes (e.g. the firmware update incremental deployment).
USER_ID=""

# WITH_DEVICE_POLLING_DELAY delay when polling device
WITH_DEVICE_POLLING_DELAY=500
```