### PR TITLE
Add btc_testnet to the v3 explorers

### DIFF
--- a/src/api/Ledger.js
+++ b/src/api/Ledger.js
@@ -70,6 +70,7 @@ const ledgerExplorersV2 = {
 
 const ledgerExplorersV3 = {
   bitcoin: "btc",
+  bitcoin_testnet: "btc_testnet",
   ethereum: "eth",
   ethereum_ropsten: "eth_ropsten",
   ethereum_classic: "etc"


### PR DESCRIPTION
In the context of the local everything docker setup, in order to be able to sync against a local blockchain for regtest, we need this change.