### PR TITLE
Update apps Logic

### DIFF
--- a/cli/src/commands/devDeviceAppsScenario.js
+++ b/cli/src/commands/devDeviceAppsScenario.js
@@ -49,7 +49,7 @@ const scenariosValues = Object.keys(scenarios).join(" | ");
 const installScenario = (apps, transport, deviceInfo, scene) => {
   const appVersionsPerId = {};
   apps.forEach(a =>
-    a.forEach(av => {
+    a.application_versions.forEach(av => {
       appVersionsPerId[av.id] = av;
     })
   );

--- a/src/apps/mock.js
+++ b/src/apps/mock.js
@@ -55,13 +55,22 @@ export const parseInstalled = (installedDesc: string): InstalledItem[] =>
       const m = /(.*)\(outdated\)/.exec(trimmed);
       if (m) {
         const name = m[1].trim();
-        return { name, updated: false, hash: "hash_" + name, blocks: 1 };
+        return {
+          name,
+          updated: false,
+          hash: "hash_" + name,
+          blocks: 1,
+          version: "0.0.0",
+          availableVersion: "1.0.0"
+        };
       }
       return {
         name: trimmed,
         updated: true,
         hash: "hash_" + trimmed,
-        blocks: 1
+        blocks: 1,
+        version: "1.0.0",
+        availableVersion: "1.0.0"
       };
     });
 
@@ -104,7 +113,8 @@ export function mockListAppsResult(
         dateModified: "",
         compatibleWallets: [],
         currencyId: currency ? currency.id : null,
-        indexOfMarketCap
+        indexOfMarketCap,
+        isDevTools: false
       };
     });
   const appByName = {};
@@ -157,7 +167,9 @@ export const mockExecWithInstalledContext = (
             name: appOp.name,
             updated: true,
             blocks: 0,
-            hash: ""
+            hash: "",
+            version: "1.0.0",
+            availableVersion: "1.0.0"
           });
         }
         break;

--- a/src/apps/runner.js
+++ b/src/apps/runner.js
@@ -9,7 +9,7 @@ import {
   throttleTime
 } from "rxjs/operators";
 import type { Exec, State, AppOp, RunnerEvent } from "./types";
-import { reducer, getActionPlan } from "./logic";
+import { reducer, getActionPlan, getNextAppOp } from "./logic";
 import { delay } from "../promise";
 import { getEnv } from "../env";
 
@@ -57,3 +57,19 @@ export const runAll = (state: State, exec: Exec): Observable<State> =>
     map(event => ({ type: "onRunnerEvent", event })),
     reduce(reducer, state)
   );
+
+export const runOneAppOp = (
+  state: State,
+  appOp: AppOp,
+  exec: Exec
+): Observable<State> =>
+  runAppOp(state, appOp, exec).pipe(
+    map(event => ({ type: "onRunnerEvent", event })),
+    reduce(reducer, state)
+  );
+
+export const runOne = (state: State, exec: Exec): Observable<State> => {
+  const next = getNextAppOp(state);
+  if (!next) return of(state);
+  return runOneAppOp(state, next, exec);
+};

--- a/src/apps/types.js
+++ b/src/apps/types.js
@@ -14,7 +14,9 @@ export type InstalledItem = {
   name: string,
   updated: boolean,
   hash: string,
-  blocks: number
+  blocks: number,
+  version: string,
+  availableVersion: string
 };
 
 export type ListAppsEvent =
@@ -40,6 +42,7 @@ export type State = {
   apps: App[],
   installedAvailable: boolean,
   installed: InstalledItem[],
+  recentlyInstalledApps: string[],
   installQueue: string[],
   uninstallQueue: string[],
   // queue saved at the time of a "updateAll" action

--- a/src/types/manager.js
+++ b/src/types/manager.js
@@ -170,7 +170,8 @@ export type App = {
   bytes: ?number,
   warning: ?string,
   // -1 if coin not in marketcap, otherwise index in the tickers list of https://countervalues.api.live.ledger.com/tickers
-  indexOfMarketCap: number
+  indexOfMarketCap: number,
+  isDevTools: boolean
 };
 
 export type Category = {


### PR DESCRIPTION
- use bytes from the actually installed app version
- introduce `version` and `availableVersion` on InstalledItem
- add `recentlyInstalledApps` in the state
- add test for updateAllProgress and ensure it does not go out of range
- `isDevTools` on App
- Fixes LL-2137