### PR TITLE
Remove star sorting from the comparator

### DIFF
--- a/src/__tests__/accounts/ordering.js
+++ b/src/__tests__/accounts/ordering.js
@@ -126,39 +126,3 @@ test("Accounts ordering | balance desc", () => {
   const sortedAccounts = accounts.sort(compareFn);
   expect(sortedAccounts.map(a => a.name)).toEqual(["AA", "C", "CA", "B", "A"]);
 });
-
-test("Accounts ordering | starred + name", () => {
-  const starredIds = ["ethereumjs:2:ethereum:0x01:"];
-  const compareFn = sortAccountsComparatorFromOrder(
-    "name|desc",
-    mockedCalculateCountervalue
-  );
-  const sortedAccounts = accounts
-    .map(a => ({
-      ...a,
-      starred: starredIds.includes(a.id)
-    }))
-    .sort(compareFn);
-  expect(sortedAccounts.map(a => a.name)).toEqual(["A", "CA", "C", "B", "AA"]);
-});
-
-test("Accounts ordering | all accounts starred, then balance, then name", () => {
-  const starredIds = [
-    "ethereumjs:2:ethereum:0x01:",
-    "ethereumjs:2:ethereum:0x02:",
-    "libcore:1:ethereum:xpub3:",
-    "libcore:1:ethereum:xpub3B:",
-    "libcore:1:ethereum:xpub1B:"
-  ];
-  const compareFn = sortAccountsComparatorFromOrder(
-    "balance|desc",
-    mockedCalculateCountervalue
-  );
-  const sortedAccounts = accounts
-    .map(a => ({
-      ...a,
-      starred: starredIds.includes(a.id)
-    }))
-    .sort(compareFn);
-  expect(sortedAccounts.map(a => a.name)).toEqual(["AA", "C", "CA", "B", "A"]);
-});

--- a/src/account/ordering.js
+++ b/src/account/ordering.js
@@ -34,12 +34,8 @@ export const sortAccountsComparatorFromOrder = (
   const [order, sort] = orderAccounts.split("|");
   const ascValue = sort === "desc" ? -1 : 1;
   if (order === "name") {
-    return (a, b) => {
-      const starDiff = Number(b.starred) - Number(a.starred);
-      if (starDiff === 0)
-        return ascValue * sortNameLense(a).localeCompare(sortNameLense(b));
-      return starDiff;
-    };
+    return (a, b) =>
+      ascValue * sortNameLense(a).localeCompare(sortNameLense(b));
   }
   const cvCaches = {};
   const lazyCalcCV = a => {
@@ -50,17 +46,13 @@ export const sortAccountsComparatorFromOrder = (
     return v;
   };
   return (a, b) => {
-    const starDiff = Number(b.starred) - Number(a.starred);
-    if (starDiff === 0) {
-      const diff =
-        ascValue *
-        lazyCalcCV(a)
-          .minus(lazyCalcCV(b))
-          .toNumber();
-      if (diff === 0) return sortNameLense(a).localeCompare(sortNameLense(b));
-      return diff;
-    }
-    return starDiff;
+    const diff =
+      ascValue *
+      lazyCalcCV(a)
+        .minus(lazyCalcCV(b))
+        .toNumber();
+    if (diff === 0) return sortNameLense(a).localeCompare(sortNameLense(b));
+    return diff;
   };
 };
 


### PR DESCRIPTION
Due to unforeseen complications in the UX that result from the introduction of the starred property into the comparator function, we are going to disable it for now. It makes no sense to see jumping accounts and it's too problematic to fix this due to the implementation of the flattenedSortedAccounts selector (or whatever it's called)