### PR TITLE
Tests for react hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,9 @@
     "react": "16",
     "react-dom": "16",
     "react-redux": "7.2.0",
+    "react-test-renderer": "^16.12.0",
     "svgr": "^1.10.0",
-    "timemachine": "^0.3.0"
+    "timemachine": "^0.3.0",
+    "@testing-library/react-hooks": "^3.2.1"
   }
 }

--- a/src/apps/mock.js
+++ b/src/apps/mock.js
@@ -64,11 +64,15 @@ export const parseInstalled = (installedDesc: string): InstalledItem[] =>
           availableVersion: "1.0.0"
         };
       }
+
+      // Check if the name contains the number of blocks too
+      const b = /(.*)_(\d*)blocks/.exec(trimmed);
+      const _name = b ? b[1] : trimmed;
       return {
-        name: trimmed,
+        name: _name,
         updated: true,
-        hash: "hash_" + trimmed,
-        blocks: 1,
+        hash: "hash_" + _name,
+        blocks: Number(b ? b[2] : 1),
         version: "1.0.0",
         availableVersion: "1.0.0"
       };

--- a/src/apps/react.test.js
+++ b/src/apps/react.test.js
@@ -1,0 +1,161 @@
+// @flow
+import { renderHook } from "@testing-library/react-hooks";
+import { initState } from "../../lib/apps";
+import { deviceInfo155, mockListAppsResult } from "../../lib/apps/mock";
+import {
+  useAppInstallNeedsDeps,
+  useAppInstallProgress,
+  useAppsSections,
+  useAppUninstallNeedsDeps
+} from "./react";
+import { useNotEnoughMemoryToInstall } from "../../lib/apps/react";
+
+const mockedState = initState(
+  mockListAppsResult(
+    "Bitcoin, Ethereum, Litecoin, Dogecoin, Ethereum Classic, XRP, Bitcoin Cash",
+    "Litecoin (outdated), Ethereum, Ethereum Classic",
+    deviceInfo155
+  )
+);
+
+test("Apps hooks - useAppInstallNeedsDeps - Expect dep apps", () => {
+  const { result } = renderHook(() =>
+    useAppInstallNeedsDeps(mockedState, mockedState.appByName["Bitcoin Cash"])
+  );
+
+  expect(result.current.dependencies.length).toBe(1);
+  expect(result.current.dependencies[0].name).toBe("Bitcoin");
+});
+
+test("Apps hooks - useAppInstallNeedsDeps - Expect no dep apps", () => {
+  const { result } = renderHook(() =>
+    useAppInstallNeedsDeps(mockedState, mockedState.appByName["Bitcoin"])
+  );
+  expect(result.current).toBe(null);
+});
+
+test("Apps hooks - useAppUninstallNeedsDeps - Expect dep apps", () => {
+  const { result } = renderHook(() =>
+    useAppUninstallNeedsDeps(mockedState, mockedState.appByName["Ethereum"])
+  );
+  expect(result.current.dependents.length).toBe(1);
+  expect(result.current.dependents[0].name).toBe("Ethereum Classic");
+});
+
+test("Apps hooks - useAppUninstallNeedsDeps - Expect no dep apps", () => {
+  const { result } = renderHook(() =>
+    useAppUninstallNeedsDeps(
+      mockedState,
+      mockedState.appByName["Ethereum Classic"]
+    )
+  );
+  expect(result.current).toBe(null);
+});
+
+test("Apps hooks - useAppInstallProgress - Queued or unknown app", () => {
+  const { result } = renderHook(() =>
+    useAppInstallProgress(mockedState, "not_in_queue")
+  );
+  expect(result.current).toBe(1);
+});
+
+test("Apps hooks - useAppInstallProgress - Current app", () => {
+  const { result } = renderHook(() =>
+    useAppInstallProgress(
+      {
+        ...mockedState,
+        currentProgress: {
+          appOp: { type: "install", name: "XRP" },
+          progress: 0.71
+        }
+      },
+      "XRP"
+    )
+  );
+  expect(result.current).toBe(0.71);
+});
+
+const mockedWithFreeBlocksStateNanoS = initState(
+  mockListAppsResult(
+    "Bitcoin, Ethereum, Litecoin, Dogecoin, Ethereum Classic, XRP, Bitcoin Cash, Stellar, Monero, Tezos",
+    "Bitcoin, Ethereum, Litecoin, Dogecoin, Ethereum Classic, XRP, Bitcoin Cash",
+    deviceInfo155 // NB 4096 blocks
+  )
+);
+
+const mockedNoFreeBlocksStateNanoS = initState(
+  mockListAppsResult(
+    "Bitcoin, Ethereum, Litecoin, Dogecoin, Ethereum Classic, XRP, Bitcoin Cash, Stellar, Monero, Tezos",
+    "Bitcoin_4090blocks, Ethereum, Litecoin, Dogecoin, Ethereum Classic, XRP, Bitcoin Cash",
+    deviceInfo155 // NB 4096 blocks
+  )
+);
+
+test("Apps hooks - useNotEnoughMemoryToInstall - Will fit new install", () => {
+  const { result } = renderHook(() =>
+    useNotEnoughMemoryToInstall(mockedWithFreeBlocksStateNanoS, "Tezos")
+  );
+  expect(result.current).toBe(false);
+});
+
+test("Apps hooks - useNotEnoughMemoryToInstall - Will not fit install", () => {
+  const { result } = renderHook(() =>
+    useNotEnoughMemoryToInstall(mockedNoFreeBlocksStateNanoS, "Tezos")
+  );
+  expect(result.current).toBe(true);
+});
+
+test("Apps hooks - useAppsSections - Correct number of updatable apps", () => {
+  const { result } = renderHook(() =>
+    useAppsSections(mockedState, {
+      query: "",
+      appFilter: "all",
+      sort: { type: "name", order: "desc" }
+    })
+  );
+  expect(result.current.update.length).toBe(1);
+});
+
+test("Apps hooks - useAppsSections - Correct number of installed apps", () => {
+  const { result } = renderHook(() =>
+    useAppsSections(mockedState, {
+      query: "",
+      appFilter: "all",
+      sort: { type: "name", order: "desc" }
+    })
+  );
+  expect(result.current.device.length).toBe(3);
+});
+
+test("Apps hooks - useAppsSections - Correct number of catalog apps", () => {
+  const { result } = renderHook(() =>
+    useAppsSections(mockedState, {
+      query: "",
+      appFilter: "all",
+      sort: { type: "name", order: "desc" }
+    })
+  );
+  expect(result.current.catalog.length).toBe(7);
+});
+
+test("Apps hooks - useAppsSections - Correct number of catalog apps with query", () => {
+  const { result } = renderHook(() =>
+    useAppsSections(mockedState, {
+      query: "coin",
+      appFilter: "all",
+      sort: { type: "name", order: "desc" }
+    })
+  );
+  expect(result.current.catalog.length).toBe(4);
+});
+
+test("Apps hooks - useAppsSections - Correct number of installed apps with query", () => {
+  const { result } = renderHook(() =>
+    useAppsSections(mockedState, {
+      query: "coin",
+      appFilter: "all",
+      sort: { type: "name", order: "desc" }
+    })
+  );
+  expect(result.current.device.length).toBe(1);
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -867,6 +867,13 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
+"@babel/runtime@^7.5.4":
+  version "7.8.4"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.8.4.tgz#d79f5a2040f7caa24d53e563aad49cbc05581308"
+  integrity sha512-neAp3zt80trRVBI1x0azq6c57aNBqYZH8KhMm3TaB7wEI5Q4A2SHfBHE8w9gOhI/lrqxtEbXZgQIrHP+wvSGwQ==
+  dependencies:
+    regenerator-runtime "^0.13.2"
+
 "@babel/template@^7.7.4", "@babel/template@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.3.tgz#e02ad04fe262a657809327f578056ca15fd4d1b8"
@@ -1225,6 +1232,14 @@
   dependencies:
     type-detect "4.0.8"
 
+"@testing-library/react-hooks@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/react-hooks/-/react-hooks-3.2.1.tgz#19b6caa048ef15faa69d439c469033873ea01294"
+  integrity sha512-1OB6Ksvlk6BCJA1xpj8/WWz0XVd1qRcgqdaFAq+xeC6l61Ucj0P6QpA5u+Db/x9gU4DCX8ziR5b66Mlfg0M2RA==
+  dependencies:
+    "@babel/runtime" "^7.5.4"
+    "@types/testing-library__react-hooks" "^3.0.0"
+
 "@types/babel__core@^7.1.0":
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.3.tgz#e441ea7df63cd080dfcd02ab199e6d16a735fc30"
@@ -1300,15 +1315,43 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-13.1.4.tgz#4cfd90175a200ee9b02bd6b1cd19bc349741607e"
   integrity sha512-Lue/mlp2egZJoHXZr4LndxDAd7i/7SQYhV0EjWfb/a4/OZ6tuVwMCVPiwkU5nsEipxEf7hmkSU7Em5VQ8P5NGA==
 
+"@types/prop-types@*":
+  version "15.7.3"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
+  integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
+
 "@types/q@^1.5.1":
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.2.tgz#690a1475b84f2a884fd07cd797c00f5f31356ea8"
   integrity sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==
 
+"@types/react-test-renderer@*":
+  version "16.9.2"
+  resolved "https://registry.yarnpkg.com/@types/react-test-renderer/-/react-test-renderer-16.9.2.tgz#e1c408831e8183e5ad748fdece02214a7c2ab6c5"
+  integrity sha512-4eJr1JFLIAlWhzDkBCkhrOIWOvOxcCAfQh+jiKg7l/nNZcCIL2MHl2dZhogIFKyHzedVWHaVP1Yydq/Ruu4agw==
+  dependencies:
+    "@types/react" "*"
+
+"@types/react@*":
+  version "16.9.20"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.20.tgz#e83285766340fb1a7fafe7e5c4708c53832e3641"
+  integrity sha512-jRrWBr25zzEVNa4QbESKLPluvrZ3W6Odfwrfe2F5vzbrDuNvlpnHa/xbZcXg8RH5D4CE181J5VxrRrLvzRH+5A==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^2.2.0"
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
+
+"@types/testing-library__react-hooks@^3.0.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@types/testing-library__react-hooks/-/testing-library__react-hooks-3.2.0.tgz#52f3a109bef06080e3b1e3ae7ea1c014ce859897"
+  integrity sha512-dE8iMTuR5lzB+MqnxlzORlXzXyCL0EKfzH0w/lau20OpkHD37EaWjZDz0iNG8b71iEtxT4XKGmSKAGVEqk46mw==
+  dependencies:
+    "@types/react" "*"
+    "@types/react-test-renderer" "*"
 
 "@types/ws@^3.2.0":
   version "3.2.1"
@@ -2346,6 +2389,11 @@ cssstyle@^2.0.0:
   integrity sha512-QXSAu2WBsSRXCPjvI43Y40m6fMevvyRm8JVAuF9ksQz5jha4pWP1wpaK7Yu5oLFc6+XAY+hj8YhefyXcBB53gg==
   dependencies:
     cssom "~0.3.6"
+
+csstype@^2.2.0:
+  version "2.6.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.9.tgz#05141d0cd557a56b8891394c1911c40c8a98d098"
+  integrity sha512-xz39Sb4+OaTsULgUERcCk+TJj8ylkL4aSVDQiX/ksxbELSqwkgt4d4RD7fovIdgJGSuNYqwZEiVjYY5l0ask+Q==
 
 damerau-levenshtein@^1.0.4:
   version "1.0.5"
@@ -5513,7 +5561,7 @@ react-dom@16:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -5528,6 +5576,16 @@ react-redux@7.2.0:
     loose-envify "^1.4.0"
     prop-types "^15.7.2"
     react-is "^16.9.0"
+
+react-test-renderer@^16.12.0:
+  version "16.12.0"
+  resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-16.12.0.tgz#11417ffda579306d4e841a794d32140f3da1b43f"
+  integrity sha512-Vj/teSqt2oayaWxkbhQ6gKis+t5JrknXfPVo+aIJ8QwYAqMPH77uptOdrlphyxl8eQI/rtkOYg86i/UWkpFu0w==
+  dependencies:
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    react-is "^16.8.6"
+    scheduler "^0.18.0"
 
 react@16:
   version "16.12.0"


### PR DESCRIPTION
Adds new tests for the hooked functionality of the manager v2, it uses the `testing-library/react-hooks` which makes it pretty nice to write jest tests for hooks without manually instantiating the components and mocking it. 