### PR TITLE
(AppsLogic): issue on devmode installed apps not showing 

### DIFF
--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -257,7 +257,9 @@ export const listApps = (
 
       const appsListNames = (getEnv("MANAGER_DEV_MODE")
         ? apps
-        : apps.filter(a => !a.isDevTools)
+        : apps.filter(
+            a => !a.isDevTools || installed.some(({ name }) => name === a.name)
+          )
       ).map(a => a.name);
 
       const result: ListAppsResult = {

--- a/src/apps/logic.js
+++ b/src/apps/logic.js
@@ -23,8 +23,6 @@ export const initState = ({
 }: ListAppsResult): State => ({
   ...listAppsResult,
   apps: appsListNames
-    .concat(listAppsResult.installed.map(({ name }) => name)) // append installed app names including potential dev-mode ones
-    .filter((val, i, arr) => arr.indexOf(val) === i) // filter duplicates
     .map(name => listAppsResult.appByName[name])
     .filter(Boolean),
   deviceModel: getDeviceModel(deviceModelId),

--- a/src/apps/logic.js
+++ b/src/apps/logic.js
@@ -23,6 +23,8 @@ export const initState = ({
 }: ListAppsResult): State => ({
   ...listAppsResult,
   apps: appsListNames
+    .concat(listAppsResult.installed.map(({ name }) => name)) // append installed app names including potential dev-mode ones
+    .filter((val, i, arr) => arr.indexOf(val) === i) // filter duplicates
     .map(name => listAppsResult.appByName[name])
     .filter(Boolean),
   deviceModel: getDeviceModel(deviceModelId),


### PR DESCRIPTION
In context of manager
the listApps now handles the case of installed dev-mode apps in regular mode thus allowing to uninstall them even if devmode isn't activated.