### PR TITLE
LL-2264 Allow accounts with ChildAccount to export operations

### DIFF
--- a/src/csvExport.js
+++ b/src/csvExport.js
@@ -74,7 +74,7 @@ const accountRows = (
 const accountsRows = (accounts: Account[]) =>
   flattenAccounts(accounts).reduce((all, account) => {
     const parentAccount =
-      account.type === "TokenAccount"
+      account.type !== "Account"
         ? accounts.find(a => a.id === account.parentId)
         : null;
     return all.concat(accountRows(account, parentAccount));


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/4631227/75886674-e8766f00-5e28-11ea-9802-9380f8236ac7.png)


Investigating https://ledgerhq.atlassian.net/browse/TECSUPPORT-579 we found that while we were handling `TokenAccount` type for operation exports, we weren't doing this for `ChildAccount` type. Meaning the export operations has been broken for Tezos with children accounts since the beginning of time.

### How to test this
- Try to export a Tezos account with child accounts on develop branch. This should ask for the destination file but not produce any actual file. There'll be some traces on the console if it's open. 
- Try to do the same on this branch, it should generate the csv file correctly.