### PR TITLE
LL-2015 Change error for not enough spendable balance

### DIFF
--- a/src/families/ripple/bridge/js.js
+++ b/src/families/ripple/bridge/js.js
@@ -28,6 +28,7 @@ import {
   isIterableDerivationMode,
   derivationModeSupportsIndex
 } from "../../../derivation";
+import { formatCurrencyUnit } from "../../../currencies";
 import {
   getAccountPlaceholderName,
   getNewAccountPlaceholderName
@@ -663,7 +664,13 @@ const getTransactionStatus = async (a, t) => {
   } else if (t.fee.eq(0)) {
     errors.fee = new FeeRequired();
   } else if (totalSpent.gt(a.balance.minus(reserveBaseXRP))) {
-    errors.amount = new NotEnoughSpendableBalance();
+    errors.amount = new NotEnoughSpendableBalance(null, {
+      minimumAmount: formatCurrencyUnit(a.currency.units[0], reserveBaseXRP, {
+        disableRounding: true,
+        useGrouping: false,
+        showCode: true
+      })
+    });
   } else if (
     t.recipient &&
     (await cachedRecipientIsNew(a.endpointConfig, t.recipient)) &&

--- a/src/families/ripple/bridge/libcore.js
+++ b/src/families/ripple/bridge/libcore.js
@@ -22,6 +22,7 @@ import { withLibcore } from "../../../libcore/access";
 import { getCoreAccount } from "../../../libcore/getCoreAccount";
 import signOperation from "../libcore-signOperation";
 import broadcast from "../libcore-broadcast";
+import { formatCurrencyUnit } from "../../../currencies";
 
 const createTransaction = () => ({
   family: "ripple",
@@ -67,7 +68,13 @@ const getTransactionStatus = async (a, t) => {
     errors.fee = new FeeRequired();
     totalSpent.gt(a.balance.minus(baseReserve));
   } else if (totalSpent.gt(a.balance.minus(baseReserve))) {
-    errors.amount = new NotEnoughSpendableBalance();
+    errors.amount = new NotEnoughSpendableBalance(null, {
+      minimumAmount: formatCurrencyUnit(a.currency.units[0], baseReserve, {
+        disableRounding: true,
+        useGrouping: false,
+        showCode: true
+      })
+    });
   } else if (
     amount.lt(baseReserve) &&
     !(await isAddressActivated(a, t.recipient))

--- a/src/families/ripple/bridge/mock.js
+++ b/src/families/ripple/bridge/mock.js
@@ -18,6 +18,7 @@ import {
   sync,
   isInvalidRecipient
 } from "../../../bridge/mockHelpers";
+import { formatCurrencyUnit } from "../../../currencies";
 
 const notCreatedAddresses = [];
 
@@ -32,7 +33,7 @@ const createTransaction = (): Transaction => ({
   amount: BigNumber(0),
   recipient: "",
   fee: BigNumber(10),
-  feeCustomUnit: getCryptoCurrencyById("ethereum").units[1],
+  feeCustomUnit: getCryptoCurrencyById("ripple").units[1],
   tag: undefined,
   networkInfo: null,
   useAllAmount: false
@@ -62,12 +63,32 @@ const getTransactionStatus = (a, t) => {
   }
 
   if (totalSpent.gt(a.balance)) {
-    errors.amount = new NotEnoughSpendableBalance();
+    errors.amount = new NotEnoughSpendableBalance(null, {
+      minimumAmount: formatCurrencyUnit(
+        a.currency.units[0],
+        BigNumber(minimalBaseAmount),
+        {
+          disableRounding: true,
+          useGrouping: false,
+          showCode: true
+        }
+      )
+    });
   } else if (
     minimalBaseAmount &&
     a.balance.minus(totalSpent).lt(minimalBaseAmount)
   ) {
-    errors.amount = new NotEnoughSpendableBalance();
+    errors.amount = new NotEnoughSpendableBalance(null, {
+      minimumAmount: formatCurrencyUnit(
+        a.currency.units[0],
+        BigNumber(minimalBaseAmount),
+        {
+          disableRounding: true,
+          useGrouping: false,
+          showCode: true
+        }
+      )
+    });
   } else if (
     minimalBaseAmount &&
     (t.recipient.includes("new") ||

--- a/src/families/ripple/test-dataset.js
+++ b/src/families/ripple/test-dataset.js
@@ -9,11 +9,13 @@ import {
 import { fromTransactionRaw } from "./transaction";
 import type { Transaction } from "./types";
 import { addNotCreatedRippleMockAddress } from "./bridge/mock";
+import { getCryptoCurrencyById } from "../../data/cryptocurrencies";
+import { formatCurrencyUnit } from "../../currencies";
 
 const newAddress1 = "rZvBc5e2YR1A9otS3r9DyGh3NDP8XLLp4";
 
 addNotCreatedRippleMockAddress(newAddress1);
-
+const rippleUnit = getCryptoCurrencyById("ripple").units[0];
 const dataset: DatasetTest<Transaction> = {
   implementations: ["mock", "ripplejs"],
   currencies: {
@@ -49,7 +51,17 @@ const dataset: DatasetTest<Transaction> = {
                 amount: BigNumber("15000000"),
                 estimatedFees: BigNumber("1"),
                 errors: {
-                  amount: new NotEnoughSpendableBalance()
+                  amount: new NotEnoughSpendableBalance(null, {
+                    minimumAmount: formatCurrencyUnit(
+                      rippleUnit,
+                      BigNumber("20"),
+                      {
+                        disableRounding: true,
+                        useGrouping: false,
+                        showCode: true
+                      }
+                    )
+                  })
                 },
                 warnings: {},
                 totalSpent: BigNumber("15000001")


### PR DESCRIPTION
Due to the change in wording required by @dasilvarosa to solve LL-2015 we need to change the way we call the error to provide the dynamic parts (currency name and amount). Once this is merged we can bump live-common on desktop and mobile to benefit from this.

Currently waiting for confirmation on whether we want the unit to be included or not in the wording.
![image](https://user-images.githubusercontent.com/4631227/76316076-37fde480-62da-11ea-8968-501c6d9dde0c.png)

cc @dasilvarosa 
