### PR TITLE
LL-2207 Blacklist tokens by ID on the sync

### DIFF
--- a/src/bridge/react/BridgeSync.js
+++ b/src/bridge/react/BridgeSync.js
@@ -38,7 +38,9 @@ export type Props = {
   // load all data needed for a currency (it's calling currencyBridge prepare mechanism)
   prepareCurrency: (currency: CryptoCurrency) => Promise<void>,
   // provide an implementation of hydrate (it preload from a local storage impl the data cached from a previous prepare)
-  hydrateCurrency: (currency: CryptoCurrency) => Promise<void>
+  hydrateCurrency: (currency: CryptoCurrency) => Promise<void>,
+  // an array of token ids to blacklist from the account sync
+  blacklistedTokenIds?: string[]
 };
 
 export const BridgeSync = ({
@@ -48,7 +50,8 @@ export const BridgeSync = ({
   recoverError,
   trackAnalytics,
   prepareCurrency,
-  hydrateCurrency
+  hydrateCurrency,
+  blacklistedTokenIds
 }: Props) => {
   useHydrate({
     accounts,
@@ -60,7 +63,8 @@ export const BridgeSync = ({
     prepareCurrency,
     recoverError,
     trackAnalytics,
-    updateAccountWithUpdater
+    updateAccountWithUpdater,
+    blacklistedTokenIds
   });
 
   const sync = useSync({
@@ -114,7 +118,8 @@ function useSyncQueue({
   prepareCurrency,
   recoverError,
   trackAnalytics,
-  updateAccountWithUpdater
+  updateAccountWithUpdater,
+  blacklistedTokenIds
 }) {
   const [bridgeSyncState, setBridgeSyncState]: [BridgeSyncState, *] = useState(
     {}
@@ -185,8 +190,8 @@ function useSyncQueue({
         };
 
         const syncConfig = {
-          // TODO paginationConfig will come from redux
-          paginationConfig: {}
+          paginationConfig: {},
+          blacklistedTokenIds
         };
 
         concat(
@@ -237,7 +242,8 @@ function useSyncQueue({
       recoverError,
       setAccountSyncState,
       trackAnalytics,
-      updateAccountWithUpdater
+      updateAccountWithUpdater,
+      blacklistedTokenIds
     ]
   );
 

--- a/src/libcore/buildAccount/buildSubAccounts.js
+++ b/src/libcore/buildAccount/buildSubAccounts.js
@@ -1,6 +1,11 @@
 // @flow
 
-import type { SubAccount, Account, CryptoCurrency } from "../../types";
+import type {
+  SubAccount,
+  Account,
+  CryptoCurrency,
+  SyncConfig
+} from "../../types";
 import type { CoreAccount } from "../types";
 import byFamily from "../../generated/libcore-buildSubAccounts";
 
@@ -8,7 +13,8 @@ export async function buildSubAccounts(arg: {
   currency: CryptoCurrency,
   coreAccount: CoreAccount,
   accountId: string,
-  existingAccount: ?Account
+  existingAccount: ?Account,
+  syncConfig: SyncConfig
 }): Promise<?(SubAccount[])> {
   const f = byFamily[arg.currency.family];
   if (f) {

--- a/src/libcore/buildAccount/index.js
+++ b/src/libcore/buildAccount/index.js
@@ -128,7 +128,8 @@ export async function buildAccount({
     coreAccount,
     accountId,
     existingAccount,
-    logId
+    logId,
+    syncConfig
   });
 
   // We have pre-fetched the operations in "partial" mode

--- a/src/types/pagination.js
+++ b/src/types/pagination.js
@@ -19,5 +19,6 @@ export type PaginationConfig = {
 export type SyncConfig = {
   paginationConfig: PaginationConfig,
   // allows to disable the synchronization part – typically to only paginate more
-  withoutSynchronize?: boolean
+  withoutSynchronize?: boolean,
+  blacklistedTokenIds?: string[]
 };


### PR DESCRIPTION
This allows us to pass a `blacklistedTokenIds` array when we do account sync that will filter out the token accounts with matching ids. I wonder if we should make it even more generic in the future to filter out more than token ids, but for now, this is what we got. With a test that took me x10 longer than the feature because I'm slow.