### PR TITLE
Optimize TRON sync

### DIFF
--- a/cli/src/scan.js
+++ b/cli/src/scan.js
@@ -132,6 +132,10 @@ export const inferManagerApp = (keyword: string): string => {
   }
 };
 
+const implTypePerFamily = {
+  tron: "js"
+};
+
 export const inferCurrency = <
   T: {
     device: string,
@@ -230,7 +234,10 @@ export function scan(arg: ScanCommonOpts): Observable<Account> {
               seedIdentifier: xpub,
               starred: true,
               id: encodeAccountId({
-                type: getEnv("BRIDGE_FORCE_IMPLEMENTATION") || "libcore",
+                type:
+                  getEnv("BRIDGE_FORCE_IMPLEMENTATION") ||
+                  implTypePerFamily[cur.family] ||
+                  "libcore",
                 version: "1",
                 currencyId: cur.id,
                 xpubOrAddress: xpub,

--- a/src/account/helpers.js
+++ b/src/account/helpers.js
@@ -91,6 +91,10 @@ export function clearAccount<T: AccountLike>(account: T): T {
 
   return {
     ...account,
+    tronResources: account.tronResources && {
+      ...account.tronResources,
+      cacheTransactionInfoById: {}
+    },
     lastSyncDate: new Date(0),
     operations: [],
     pendingOperations: [],

--- a/src/account/serialization.js
+++ b/src/account/serialization.js
@@ -144,12 +144,23 @@ export const toTronResourcesRaw = ({
   tronPower,
   energy,
   bandwidth,
-  unwithdrawnReward
+  unwithdrawnReward,
+  cacheTransactionInfoById: cacheTx
 }: TronResources): TronResourcesRaw => {
   const frozenBandwidth = frozen.bandwidth;
   const frozenEnergy = frozen.energy;
   const delegatedFrozenBandwidth = delegatedFrozen.bandwidth;
   const delegatedFrozenEnergy = delegatedFrozen.energy;
+  const cacheTransactionInfoById = {};
+  for (let k in cacheTx) {
+    const { fee, blockNumber, withdraw_amount, unfreeze_amount } = cacheTx[k];
+    cacheTransactionInfoById[k] = [
+      fee,
+      blockNumber,
+      withdraw_amount,
+      unfreeze_amount
+    ];
+  }
 
   return {
     frozen: {
@@ -189,7 +200,8 @@ export const toTronResourcesRaw = ({
       gainedUsed: bandwidth.gainedUsed.toString(),
       gainedLimit: bandwidth.gainedLimit.toString()
     },
-    unwithdrawnReward: unwithdrawnReward.toString()
+    unwithdrawnReward: unwithdrawnReward.toString(),
+    cacheTransactionInfoById
   };
 };
 
@@ -200,12 +212,30 @@ export const fromTronResourcesRaw = ({
   tronPower,
   energy,
   bandwidth,
-  unwithdrawnReward
+  unwithdrawnReward,
+  cacheTransactionInfoById: cacheTransactionInfoByIdRaw
 }: TronResourcesRaw): TronResources => {
   const frozenBandwidth = frozen.bandwidth;
   const frozenEnergy = frozen.energy;
   const delegatedFrozenBandwidth = delegatedFrozen.bandwidth;
   const delegatedFrozenEnergy = delegatedFrozen.energy;
+  const cacheTransactionInfoById = {};
+  if (cacheTransactionInfoByIdRaw) {
+    for (let k in cacheTransactionInfoByIdRaw) {
+      const [
+        fee,
+        blockNumber,
+        withdraw_amount,
+        unfreeze_amount
+      ] = cacheTransactionInfoByIdRaw[k];
+      cacheTransactionInfoById[k] = {
+        fee,
+        blockNumber,
+        withdraw_amount,
+        unfreeze_amount
+      };
+    }
+  }
   return {
     frozen: {
       bandwidth: frozenBandwidth
@@ -244,7 +274,8 @@ export const fromTronResourcesRaw = ({
       gainedUsed: BigNumber(bandwidth.gainedUsed),
       gainedLimit: BigNumber(bandwidth.gainedLimit)
     },
-    unwithdrawnReward: BigNumber(unwithdrawnReward)
+    unwithdrawnReward: BigNumber(unwithdrawnReward),
+    cacheTransactionInfoById
   };
 };
 

--- a/src/bridge/jsHelpers.js
+++ b/src/bridge/jsHelpers.js
@@ -29,7 +29,7 @@ import getAddress from "../hw/getAddress";
 import { open } from "../hw";
 
 type GetAccountShape = (
-  { address: string, id: string },
+  { address: string, id: string, initialAccount?: Account },
   SyncConfig
 ) => Promise<$Shape<Account>>;
 
@@ -59,7 +59,8 @@ export const makeSync = (
         const shape = await getAccountShape(
           {
             id: initial.id,
-            address: initial.freshAddress
+            address: initial.freshAddress,
+            initialAccount: initial
           },
           syncConfig
         );

--- a/src/families/tron/bridge/js.js
+++ b/src/families/tron/bridge/js.js
@@ -246,9 +246,23 @@ const getAccountShape = async info => {
   const acc = tronAcc[0];
   const spendableBalance = acc.balance ? BigNumber(acc.balance) : BigNumber(0);
 
-  const txs = await fetchTronAccountTxs(info.address, txs => txs.length < 1000);
+  const cacheTransactionInfoById = {
+    ...(info.initialAccount &&
+      info.initialAccount.tronResources &&
+      info.initialAccount.tronResources.cacheTransactionInfoById)
+  };
 
-  const tronResources = await getTronResources(acc, txs);
+  const txs = await fetchTronAccountTxs(
+    info.address,
+    txs => txs.length < 1000,
+    cacheTransactionInfoById
+  );
+
+  const tronResources = await getTronResources(
+    acc,
+    txs,
+    cacheTransactionInfoById
+  );
 
   const balance = spendableBalance
     .plus(

--- a/src/families/tron/test-dataset.js
+++ b/src/families/tron/test-dataset.js
@@ -27,6 +27,7 @@ const dataset: DatasetTest<Transaction> = {
   currencies: {
     tron: {
       FIXME_ignoreAccountFields: [
+        "tronResources.cacheTransactionInfoById", // this is a cache, don't save it
         "tronResources.unwithdrawnReward" // it changes every vote cycles
       ],
       scanAccounts: [

--- a/src/families/tron/types.js
+++ b/src/families/tron/types.js
@@ -178,7 +178,8 @@ export type TronResources = {|
   tronPower: number,
   energy: BigNumber,
   bandwidth: BandwidthInfo,
-  unwithdrawnReward: BigNumber
+  unwithdrawnReward: BigNumber,
+  cacheTransactionInfoById: { [_: string]: TronTransactionInfo }
 |};
 
 export type TronResourcesRaw = {|
@@ -194,7 +195,8 @@ export type TronResourcesRaw = {|
   tronPower: number,
   energy: string,
   bandwidth: BandwidthInfoRaw,
-  unwithdrawnReward: string
+  unwithdrawnReward: string,
+  cacheTransactionInfoById?: { [_: string]: TronTransactionInfoRaw }
 |};
 
 export type Vote = {|
@@ -225,3 +227,12 @@ export type BandwidthInfoRaw = {|
   gainedUsed: string,
   gainedLimit: string
 |};
+
+export type TronTransactionInfo = {|
+  fee: number,
+  blockNumber: number,
+  withdraw_amount: number,
+  unfreeze_amount: number
+|};
+
+export type TronTransactionInfoRaw = [number, number, number, number];


### PR DESCRIPTION
before this PR, the TRON sync logic have no "reconciliation" mechanism and it completely resync everything from scratch. This has shown to be not optimized especially on one part: the gettransactionbyid calls, we seem to need to fetch each individual tx at the moment which is very bad for performance. The solution provided here store in the account a cache that avoid fetching again for the second synchronisation. **it still makes the first sync really slow and it's something we absolutely need to address by backend**

To test and measure that, i've used one of the biggest public account, this one only have 152 transactions but it still take 52 seconds to sync the first time. the optim will make the second sync go to 9s. 

```sh
VERBOSE_FILE=trace BRIDGE_FORCE_IMPLEMENTATION=js ledger-live sync -c tron --xpub TKTWiCfNyitRiA31eiMLTTFYah6m2aLkup --format json > account.json

# first sync takes 52s

ledger-live sync -c tron --file account.json --format summary

# second sync now takes 9s   (used to be 52s)
```

It stores in the account raw a compressed cache object, that looks like this:

```js
"3a8afc3f9052dcd6c660453a20af6d98a0c81fde7251fc008d2c3403bbde01ba":[null,13562675,null],"bfd1053548fbcc903ead63746006749911bc7be56ed6a45bb3c32d22a54a768d":[null,13540030,null],"bb96ac10558c1cbc0a031387aafc541670ea4f6f3092f3ade341752728aa3ce3":[null,13548724,null],"4b27cc4afe55d855819daea4a90ebedc1d8cf55bb6603a0951f53f1fd8b1a6eb":[null,13534657,null],"fab086178c65fa2aa868cc487c025a8503492adfe6ef0d4560785de254203926":[null,13539961,null],"30665688d23bee0b8429ae33e0caf0fd21000f5d1fb05dcdeb0c87cc7cf12240":[null,13515774,null],"938712a111f1f8ebd37f224e9fb33bcc44ba076f67da150c270b659be6328902":...
```

for this examlpe shared about, the memory of the JSON data is an addition of **66K**. negligible.

## fetch by 100

the second optim is to move away from default of fetch by 20, but to fetch by 100 transactions. we might even go higher in future.