### PR TITLE
Fix listApps always returning Nano S `deviceModel` on any transport but RN BLE

### DIFF
--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -2,6 +2,7 @@
 
 import Transport from "@ledgerhq/hw-transport";
 import { getDeviceModel } from "@ledgerhq/devices";
+import type { DeviceModelId } from "@ledgerhq/devices";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { Observable, throwError } from "rxjs";
 import type { Exec, AppOp, ListAppsEvent, ListAppsResult } from "./types";
@@ -32,15 +33,18 @@ const appsThatKeepChangingHashes = ["Fido U2F"];
 
 export const listApps = (
   transport: Transport<*>,
-  deviceInfo: DeviceInfo
+  deviceInfo: DeviceInfo,
+  modelId?: DeviceModelId
 ): Observable<ListAppsEvent> => {
   if (deviceInfo.isOSU || deviceInfo.isBootloader) {
     return throwError(new UnexpectedBootloader(""));
   }
 
   const deviceModelId =
-    // $FlowFixMe
-    (transport.deviceModel && transport.deviceModel.id) || "nanoS";
+    modelId ||
+    // $FlowFixMe (deviceModel member is only found in RN BLE transport class and not part of Transport type)
+    (transport.deviceModel && transport.deviceModel.id) ||
+    "nanoS";
 
   return Observable.create(o => {
     let sub;


### PR DESCRIPTION
`listApps` tries to get current `deviceModel` from `transport` and fallbacks to Nano S if it's not there. The issue is, AFAIK, only `react-native-hw-transport-ble` exposes a `deviceModel` in its class, so any device connected through a different transport will be detected as a Nano S.

Counterintuitively, the issue doesn't stay confined to `listApps` as `useAppsRunner` uses the results from it to seed the `initState` and contaminates the whole manager on mobile. On desktop the app doesn't use this state at the top level of the manager but only in the nested app list, thus avoiding any breakage from the bug.

This PR adds a third optional parameter to `listApps` to enforce a specific `deviceModelId`.