### PR TITLE
TRON: Fixes optimistic operation

### DIFF
--- a/src/__tests__/__snapshots__/all.libcore.js.snap
+++ b/src/__tests__/__snapshots__/all.libcore.js.snap
@@ -76981,7 +76981,7 @@ Array [
         "bandwidth": undefined,
         "energy": undefined,
       },
-      "energy": "1602",
+      "energy": "1600",
       "frozen": Object {
         "bandwidth": undefined,
         "energy": Object {
@@ -77197,7 +77197,7 @@ Array [
       },
       "lastVotedDate": undefined,
       "lastWithdrawnRewardDate": undefined,
-      "tronPower": 8.4,
+      "tronPower": 8,
       "votes": Array [],
     },
     "unitMagnitude": 6,
@@ -81606,7 +81606,7 @@ Array [
     Object {
       "accountId": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16110435,
       "extra": Object {},
       "fee": "0",
       "hash": "068ce945e4cf0bdd27fd4c3d7b632564ce7323844d25214b276b85f1fea0fcad",
@@ -81698,9 +81698,9 @@ Array [
     Object {
       "accountId": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 11593961,
       "extra": Object {},
-      "fee": "0",
+      "fee": "123110",
       "hash": "68cb2a4e6a600626afdeda8f07904b4e55a388c2b267d12176f9186727afdf68",
       "id": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7-68cb2a4e6a600626afdeda8f07904b4e55a388c2b267d12176f9186727afdf68-IN",
       "recipients": Array [
@@ -81715,7 +81715,7 @@ Array [
     Object {
       "accountId": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16110228,
       "extra": Object {},
       "fee": "0",
       "hash": "78e334e9e297120c054d849571f7c121380cc2494895e0d1331066a0578592fa",
@@ -81732,7 +81732,7 @@ Array [
     Object {
       "accountId": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16110394,
       "extra": Object {},
       "fee": "0",
       "hash": "a869e16565f3b73f3b4dd8554431469bdef1d452043c5cfd96686dad96eebd67",
@@ -81749,7 +81749,7 @@ Array [
     Object {
       "accountId": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16110326,
       "extra": Object {},
       "fee": "0",
       "hash": "bfc280056910bb0220d13876fff1023bb981e486c96697b2c0a5648dbd145334",
@@ -81826,7 +81826,7 @@ Array [
     Object {
       "accountId": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16335243,
       "extra": Object {},
       "fee": "0",
       "hash": "f5e423534ce66e37ae51e77196c25ac2b8ee92a4a8a46ac1ec38e47632d03381",
@@ -81858,7 +81858,7 @@ Array [
     Object {
       "accountId": "js:2:tron:TRqkRnAj6ceJFYAn2p1eE7aWrgBBwtdhS9:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16243678,
       "extra": Object {},
       "fee": "0",
       "hash": "fd7fdb42d69df344659746d482cabb6cfe34291fb594397e3742b64ca85f6530",
@@ -82483,7 +82483,7 @@ Array [
     Object {
       "accountId": "js:2:tron:THAe4BNVxp293qgyQEqXEkHMpPcqtG73bi:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16112143,
       "extra": Object {},
       "fee": "0",
       "hash": "f6551432995fc64e304f0ca205d12918873ebca880192f8f110c5cb93aa5cfe8",
@@ -82557,7 +82557,7 @@ Array [
     Object {
       "accountId": "js:2:tron:TWepUnyBzHx2aoEgNGotZHCybZJZe1AHdW:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
       "blockHash": null,
-      "blockHeight": undefined,
+      "blockHeight": 16138146,
       "extra": Object {},
       "fee": "0",
       "hash": "3f2e16fab36eab882dc64699c2593a6e4da8c184d2d32c100bf1aaf910b33ba4",

--- a/src/bridge/jsHelpers.js
+++ b/src/bridge/jsHelpers.js
@@ -48,7 +48,8 @@ export function mergeOps(
 }
 
 export const makeSync = (
-  getAccountShape: GetAccountShape
+  getAccountShape: GetAccountShape,
+  postSync: Account => Account = a => a
 ): $PropertyType<AccountBridge<any>, "sync"> => (
   initial,
   syncConfig
@@ -66,7 +67,7 @@ export const makeSync = (
         );
         o.next(a => {
           const operations = mergeOps(a.operations, shape.operations || []);
-          return {
+          return postSync({
             ...a,
             spendableBalance: shape.balance || a.balance,
             operationsCount: shape.operationsCount || operations.length,
@@ -76,7 +77,7 @@ export const makeSync = (
             pendingOperations: a.pendingOperations.filter(op =>
               shouldRetainPendingOperation(a, op)
             )
-          };
+          });
         });
         o.complete();
       } catch (e) {

--- a/src/families/tron/bridge/js.js
+++ b/src/families/tron/bridge/js.js
@@ -286,6 +286,8 @@ const getAccountShape = async (info, syncConfig) => {
     )
   );
 
+  // FIXME: this is not optional especially that we might already have info.initialAccount
+  // use minimalOperationsBuilderSync to reconciliate and KEEP REF
   const txs = await fetchTronAccountTxs(
     info.address,
     txs => txs.length < operationsPageSize,
@@ -337,6 +339,8 @@ const getAccountShape = async (info, syncConfig) => {
   });
 
   // TRC10 and TRC20 accounts
+  // FIXME: this is bad for perf: we should reconciliate with potential existing data
+  // we need to KEEP REF as much as possible & use minimalOperationsBuilderSync
   const subAccounts: SubAccount[] = compact(
     trc10Tokens.concat(trc20Tokens).map(({ type, key, value }) => {
       const { blacklistedTokenIds = [] } = syncConfig;
@@ -348,6 +352,10 @@ const getAccountShape = async (info, syncConfig) => {
       const operations = compact(
         tokenTxs.map(tx => txInfoToOperation(id, info.address, tx))
       );
+      const maybeExistingSubAccount =
+        info.initialAccount &&
+        info.initialAccount.subAccounts &&
+        info.initialAccount.subAccounts.find(a => a.id === id);
       const sub: TokenAccount = {
         type: "TokenAccount",
         id,
@@ -357,7 +365,9 @@ const getAccountShape = async (info, syncConfig) => {
         balance: BigNumber(value),
         operationsCount: operations.length,
         operations,
-        pendingOperations: []
+        pendingOperations: maybeExistingSubAccount
+          ? maybeExistingSubAccount.pendingOperations
+          : []
       };
       return sub;
     })
@@ -388,7 +398,29 @@ const getAccountShape = async (info, syncConfig) => {
 
 const scanAccounts = makeScanAccounts(getAccountShape);
 
-const sync = makeSync(getAccountShape);
+// the balance does not update straightaway so we should ignore recent operations if they are in pending for a bit
+const preferPendingOperationsUntilBlockValidation = 35;
+
+const postSync = parent => {
+  function evictRecentOpsIfPending(a) {
+    a.pendingOperations.forEach(pending => {
+      const i = a.operations.findIndex(o => o.id === pending.id);
+      if (i !== -1) {
+        const diff = parent.blockHeight - (a.operations[i].blockHeight || 0);
+        if (diff < preferPendingOperationsUntilBlockValidation) {
+          a.operations.splice(i, 1);
+        }
+      }
+    });
+  }
+
+  evictRecentOpsIfPending(parent);
+  parent.subAccounts && parent.subAccounts.forEach(evictRecentOpsIfPending);
+
+  return parent;
+};
+
+const sync = makeSync(getAccountShape, postSync);
 
 const currencyBridge: CurrencyBridge = {
   preload: async () => {


### PR DESCRIPTION
- the signOperation/broadcast optimistic operation was wrong for a few cases (especially for tokens)
- the pendingOperations was getting dropped for sub accounts. **on that note, i've discovered a very concerning fact: we do not keep any object reference for a sync, this is bad for performance, especially for mobile perf, it makes UI completely rerendering.**
- There were an obvious inconsistencies in that the operations appears **before** the account balance to update. This is very important for the global account consistency, everything must be consistency together. To fix that it is pretty easy: we must not create operations if they are too recent (currently I've found a value of 35 blocks to works well) and if there are equivalent version of them in the "pendingOperations" array. the UI will therefore just display the pendingOperations for ~1 minute and then around the time the balance updates, it will be an operation and the graph history will be consistent.