### PR TITLE
LL-1382 Fix broken reconciliation in balanceHistory

### DIFF
--- a/src/account/helpers.js
+++ b/src/account/helpers.js
@@ -98,7 +98,8 @@ export function clearAccount<T: AccountLike>(account: T): T {
     lastSyncDate: new Date(0),
     operations: [],
     pendingOperations: [],
-    subAccounts: account.subAccounts && account.subAccounts.map(clearAccount)
+    subAccounts: account.subAccounts && account.subAccounts.map(clearAccount),
+    balanceHistory: {}
   };
 }
 

--- a/src/libcore/buildAccount/index.js
+++ b/src/libcore/buildAccount/index.js
@@ -159,9 +159,6 @@ export async function buildAccount({
 
   const balanceHistory = {};
 
-  // FIXME we are having bug TECHSUPPORT-598
-  // TBD what we do next, @juan-cortes to create a LL- task to fix this impl
-  /*
   if (!libcoreNoGoBalanceHistory().includes(currency.id)) {
     await Promise.all(
       getRanges().map(async range => {
@@ -178,7 +175,6 @@ export async function buildAccount({
       })
     );
   }
-  */
 
   log("libcore", `sync(${logId}) DONE balanceHistory`);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/78511017-a038cc80-7799-11ea-9507-6375ad496c9c.png)

Following on the investigations that led to disabling the libcore implementation of the balance history for an account we've identified what could be the cause of the balance history not being updated. It seems that the way we checked in https://github.com/LedgerHQ/ledger-live-common/blob/6bce8ba5c431d6d2acbe764e8f4a91e18f77e324/src/reconciliation.js#L232-L233 if a patch was needed meant that we would only update the `balanceHistory` for an account **if** and only if the balance had changed.

If the balance hadn't changed we would be left with the old balance history. This on its own should be ok, but [we are then relying on the balance history's datapoint's `date` ](https://github.com/LedgerHQ/ledger-live-common/blob/f016dcbad04f0ba8d1887a1cc3598486574f0836/src/portfolio/index.js#L134)to fetch the counter value for a given amount, meaning that the values we were showing were, in fact, the last week/month/year from the last time we synchronized our account after our balance had changed.
https://github.com/LedgerHQ/ledger-live-common/blob/f016dcbad04f0ba8d1887a1cc3598486574f0836/src/portfolio/index.js#L134
Where `calc` is the local implementation in desktop (maybe on mobile too) calling `calculateWithIntermediarySelector` with the wrong date.

I've tested this fix while keeping the Libcore's implementation enabled *and* loading the original app.json that we received from our colleague from tech-support and after syncing the account balance would automatically reflect the correct value. Meaning it wouldn't even require a cache drop or any other action by the user.

Basically, following the drawing above, the graph was using the counter value from the dates of `A` range to display the balance values of the `C` range, or something like that. Where `B` is the last time the user's balance changed (received, send, etc).


