### PR TITLE
LL-2356 Prevent signOperation if wrong device

### DIFF
--- a/src/hw/actions/transaction.js
+++ b/src/hw/actions/transaction.js
@@ -115,12 +115,12 @@ export const createAction = (
       account: mainAccount
     });
 
-    const { device, opened } = appState;
+    const { device, opened, inWrongDeviceForAccount, error } = appState;
 
     const [state, setState] = useState(initialState);
 
     useEffect(() => {
-      if (!device || !opened) {
+      if (!device || !opened || inWrongDeviceForAccount || error) {
         setState(initialState);
         return;
       }
@@ -143,7 +143,14 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [device, mainAccount, transaction, opened]);
+    }, [
+      device,
+      mainAccount,
+      transaction,
+      opened,
+      inWrongDeviceForAccount,
+      error
+    ]);
 
     return {
       ...appState,


### PR DESCRIPTION
We weren't checking whether the connected device was the correct one before triggering a `signOperation` meaning that, even though we would see the error on the modal saying that the device was the wrong one, the user would still get the action on the device to sign. This pr adds a check to see if we have the `inWrongDeviceForAccount` flag or errors and prevents the signing request.