### PR TITLE
[Stellar] update snapshot, remote transactionSequenceNumber

### DIFF
--- a/src/families/stellar/libcore-signOperation.js
+++ b/src/families/stellar/libcore-signOperation.js
@@ -4,8 +4,8 @@ import Stellar from "@ledgerhq/hw-app-str";
 import type { CoreStellarLikeTransaction, Transaction } from "./types";
 import { makeSignOperation } from "../../libcore/signOperation";
 import {
-  libcoreAmountToBigNumber
-  // libcoreBigIntToBigNumber
+  libcoreAmountToBigNumber,
+  libcoreBigIntToBigNumber
 } from "../../libcore/buildBigNumber";
 import buildTransaction from "./libcore-buildTransaction";
 import { checkRecipientExist } from "./bridge/libcore";
@@ -15,7 +15,7 @@ async function signTransaction({
   transport,
   transaction,
   coreTransaction,
-  // coreAccount,
+  coreAccount,
   isCancelled,
   onDeviceSignatureGranted,
   onDeviceSignatureRequested
@@ -50,11 +50,11 @@ async function signTransaction({
   const fee = await libcoreAmountToBigNumber(feesRaw);
   if (isCancelled()) return;
 
-  // const stellarLikeAccount = await coreAccount.asStellarLikeAccount();
-  // const transactionSequenceNumberRaw = await stellarLikeAccount.getSequence();
-  // const transactionSequenceNumber = await libcoreBigIntToBigNumber(
-  //   transactionSequenceNumberRaw
-  // );
+  const stellarLikeAccount = await coreAccount.asStellarLikeAccount();
+  const transactionSequenceNumberRaw = await stellarLikeAccount.getSequence();
+  const transactionSequenceNumber = await libcoreBigIntToBigNumber(
+    transactionSequenceNumberRaw
+  );
 
   const op = {
     id: `${id}--OUT`,
@@ -71,9 +71,8 @@ async function signTransaction({
     recipients,
     accountId: id,
     date: new Date(),
-    // Javascript number is not precise, so we desactivated it since the
-    // transactionSequenceNumber was always the same
-    // transactionSequenceNumber: transactionSequenceNumber.plus(1).toNumber(),
+    // Warning: Javascript number is not precise
+    transactionSequenceNumber: transactionSequenceNumber.plus(1).toNumber(),
     extra: {}
   };
 

--- a/src/families/stellar/libcore-signOperation.js
+++ b/src/families/stellar/libcore-signOperation.js
@@ -4,8 +4,8 @@ import Stellar from "@ledgerhq/hw-app-str";
 import type { CoreStellarLikeTransaction, Transaction } from "./types";
 import { makeSignOperation } from "../../libcore/signOperation";
 import {
-  libcoreAmountToBigNumber,
-  libcoreBigIntToBigNumber
+  libcoreAmountToBigNumber
+  // libcoreBigIntToBigNumber
 } from "../../libcore/buildBigNumber";
 import buildTransaction from "./libcore-buildTransaction";
 import { checkRecipientExist } from "./bridge/libcore";
@@ -15,6 +15,7 @@ async function signTransaction({
   transport,
   transaction,
   coreTransaction,
+  // coreAccount,
   isCancelled,
   onDeviceSignatureGranted,
   onDeviceSignatureRequested
@@ -49,10 +50,11 @@ async function signTransaction({
   const fee = await libcoreAmountToBigNumber(feesRaw);
   if (isCancelled()) return;
 
-  const transactionSequenceNumberRaw = await coreTransaction.getSourceAccountSequence();
-  const transactionSequenceNumber = (
-    await libcoreBigIntToBigNumber(transactionSequenceNumberRaw)
-  ).toNumber();
+  // const stellarLikeAccount = await coreAccount.asStellarLikeAccount();
+  // const transactionSequenceNumberRaw = await stellarLikeAccount.getSequence();
+  // const transactionSequenceNumber = await libcoreBigIntToBigNumber(
+  //   transactionSequenceNumberRaw
+  // );
 
   const op = {
     id: `${id}--OUT`,
@@ -69,7 +71,9 @@ async function signTransaction({
     recipients,
     accountId: id,
     date: new Date(),
-    transactionSequenceNumber,
+    // Javascript number is not precise, so we desactivated it since the
+    // transactionSequenceNumber was always the same
+    // transactionSequenceNumber: transactionSequenceNumber.plus(1).toNumber(),
     extra: {}
   };
 

--- a/src/libcore/signOperation.js
+++ b/src/libcore/signOperation.js
@@ -40,7 +40,6 @@ export type Arg<T, CT> = {
     currency: CryptoCurrency,
     derivationMode: DerivationMode,
     coreCurrency: CoreCurrency,
-    coreAccount: CoreAccount,
     transaction: T,
     coreTransaction: CT,
     coreAccount: CoreAccount,


### PR DESCRIPTION
Sorry did some transactions to test but it was on my test device which contains the snapshot so I updated it

also remove the transactionSequenceNumber because of javascript number type and Stellar big sequence number.