### PR TITLE
LL-2404 Deterministic mock account/operation generation

### DIFF
--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -1004,9 +1004,9 @@
     node-pre-gyp-github "^1.4.3"
 
 "@ledgerhq/live-common@^12.16.1":
-  version "12.16.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.16.1.tgz#72140677c47cfce361f31a71f4bc8c47ccb510f6"
-  integrity sha512-i5AbIit8xiaAhKWgDy6h1UxaZcFrolN5dDmwHok0hEDdcRRMCl6xWP5CWKWP/cXQgTQDP608ZkCj2BRCL/utjw==
+  version "12.16.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.16.2.tgz#554b230ec827f60049da0b82d9fa705135c23a71"
+  integrity sha512-KaCOaKJ58iexW5wQ/qJBz8PECCGf9NCQq9iV14fCchebApXyfGcXygge6z08JJphSOfiwDvAs2pfCBgUpoaY1g==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.13.1"

--- a/src/__tests__/mocks/account.js
+++ b/src/__tests__/mocks/account.js
@@ -5,11 +5,19 @@ import "../../load/tokens/tron/trc20";
 
 import { genAccount } from "../../mock/account";
 import { getBalanceHistory } from "../../portfolio";
+import { getEnv, setEnv } from "../../env";
 
 test("generate an account from seed", () => {
   const a = genAccount("seed");
   const b = genAccount("seed");
   expect(a).toEqual(b);
+});
+
+test("generate an account from different seed should generate a different account", () => {
+  const a = genAccount(getEnv("MOCK"));
+  setEnv("MOCK", "çacestvraiça");
+  const b = genAccount(getEnv("MOCK"));
+  expect(a).not.toEqual(b);
 });
 
 test("dont generate negative balance", () => {

--- a/src/bridge/mockHelpers.js
+++ b/src/bridge/mockHelpers.js
@@ -11,8 +11,9 @@ import { validateNameEdition } from "../account";
 import { delay } from "../promise";
 import type { Operation } from "../types";
 import type { CurrencyBridge, AccountBridge } from "../types/bridge";
+import { getEnv } from "../env";
 
-const MOCK_DATA_SEED = process.env.MOCK_DATA_SEED || Math.random();
+const MOCK_DATA_SEED = getEnv("MOCK") || "MOCK";
 
 const broadcasted: { [_: string]: Operation[] } = {};
 

--- a/src/env.js
+++ b/src/env.js
@@ -238,9 +238,10 @@ const envDefinitions = {
     desc: "maximum size of account names"
   },
   MOCK: {
-    def: false,
-    parser: boolParser,
-    desc: "switch the app into a MOCK mode for test purpose"
+    def: "",
+    parser: stringParser,
+    desc:
+      "switch the app into a MOCK mode for test purpose, the value will be used as a seed for the rng. Avoid falsy values."
   },
   OPERATION_ADDRESSES_LIMIT: {
     def: 100,


### PR DESCRIPTION
Changing the `MOCK` env variable to be a string instead of a boolean we can use that as the seed for the pseudo-random number generator we use to generate accounts and operations in mock. This also providers a test to check if different mock seeds generate different accounts.

Note that providing a falsy value for the seed would effective (haven't tried it but it should be safe to assume) disable the mock.

This can be tested by running `MOCK=imarandom ledger-live sync -c eth --format summary` twice and seeing the output matches or simply running the new test.