### PR TITLE
Stellar: Fixes false negative broadcast error

### DIFF
--- a/src/account/pending.js
+++ b/src/account/pending.js
@@ -7,6 +7,17 @@ export function shouldRetainPendingOperation(
   op: Operation
 ): boolean {
   const delay = new Date() - op.date;
+
+  const last = account.operations[0];
+  if (
+    last &&
+    last.transactionSequenceNumber &&
+    op.transactionSequenceNumber &&
+    op.transactionSequenceNumber >= last.transactionSequenceNumber
+  ) {
+    return false;
+  }
+
   return delay < getEnv("OPERATION_OPTIMISTIC_RETENTION");
 }
 

--- a/src/errors.js
+++ b/src/errors.js
@@ -61,4 +61,8 @@ export const StellarWrongMemoFormat = createCustomErrorClass(
   "StellarWrongMemoFormat"
 );
 
+export const AccountAwaitingSendPendingOperations = createCustomErrorClass(
+  "AccountAwaitingSendPendingOperations"
+);
+
 export const SourceHasMultiSign = createCustomErrorClass("SourceHasMultiSign");

--- a/src/families/stellar/bridge/libcore.js
+++ b/src/families/stellar/bridge/libcore.js
@@ -12,7 +12,8 @@ import {
 import {
   StellarWrongMemoFormat,
   SourceHasMultiSign,
-  StellarMemoRecommended
+  StellarMemoRecommended,
+  AccountAwaitingSendPendingOperations
 } from "../../../errors";
 import { validateRecipient } from "../../../bridge/shared";
 import type { AccountBridge, CurrencyBridge, Account } from "../../../types";
@@ -114,10 +115,14 @@ const isAccountIsMultiSign = async account =>
     return signers.length > 1;
   });
 
-const getTransactionStatus = async (a, t) => {
+const getTransactionStatus = async (a: Account, t) => {
   const errors = {};
   const warnings = {};
   const useAllAmount = !!t.useAllAmount;
+
+  if (a.pendingOperations.length > 0) {
+    throw new AccountAwaitingSendPendingOperations();
+  }
 
   if (a.freshAddress === t.recipient) {
     errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();

--- a/src/families/stellar/libcore-broadcast.js
+++ b/src/families/stellar/libcore-broadcast.js
@@ -1,14 +1,33 @@
 // @flow
+import { log } from "@ledgerhq/logs";
 import type { Operation } from "../../types";
 import { makeBroadcast } from "../../libcore/broadcast";
 import { patchOperationWithHash } from "../../operation";
+
+const THRESHOLD_FALSE_NEGATIVE_BROADCAST_FAILURE = 20 * 1000;
 
 async function broadcast({
   coreAccount,
   signedOperation: { operation, signature }
 }): Promise<Operation> {
   const stellarLikeAccount = await coreAccount.asStellarLikeAccount();
-  const hash = await stellarLikeAccount.broadcastRawTransaction(signature);
+  let hash = "";
+  let startTime = Date.now();
+  try {
+    hash = await stellarLikeAccount.broadcastRawTransaction(signature);
+  } catch (e) {
+    // sometimes a failing broadcast still means the tx went out so we must assume it's a success.
+    // FIXME when mobile have the e.status again, we should match for 504 http code too
+    if (Date.now() - startTime > THRESHOLD_FALSE_NEGATIVE_BROADCAST_FAILURE) {
+      log(
+        "stellar-error",
+        "error occurred but was long enough to assume it's a success. " +
+          String(e)
+      );
+    } else {
+      throw e;
+    }
+  }
   return patchOperationWithHash(operation, hash);
 }
 

--- a/src/families/stellar/libcore-buildOperation.js
+++ b/src/families/stellar/libcore-buildOperation.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { CoreOperation } from "../../libcore/types";
+import { libcoreBigIntToBigNumber } from "../../libcore/buildBigNumber";
 
 async function stellarBuildOperation({
   coreOperation
@@ -8,9 +9,17 @@ async function stellarBuildOperation({
   coreOperation: CoreOperation
 }) {
   const stellarLikeOperation = await coreOperation.asStellarLikeOperation();
-  const stellarLikeTransaction = await stellarLikeOperation.getRecord();
-  const hash = await stellarLikeTransaction.getTransactionHash();
-  return { hash };
+  const stellarLikeRecord = await stellarLikeOperation.getRecord();
+  const stellarLikeTransaction = await stellarLikeOperation.getTransaction();
+  const hash = await stellarLikeRecord.getTransactionHash();
+  const transactionSequenceNumberRaw = await stellarLikeTransaction.getSourceAccountSequence();
+  const transactionSequenceNumber = await libcoreBigIntToBigNumber(
+    transactionSequenceNumberRaw
+  );
+  return {
+    hash,
+    transactionSequenceNumber: transactionSequenceNumber.toNumber()
+  };
 }
 
 export default stellarBuildOperation;


### PR DESCRIPTION
## The problem

A Stellar transaction can fail at broadcast time but in fact still eventually passed. This is a high risk of double sending funds in current status of Ledger Live.

More precisely, you can have a long period of `Broadcasting...` which eventually falls into a HTTP 504 error which makes user think you have to try to do it again. In fact, if you go back to account and wait for a few minutes, it's very likely the operation eventually will appear.

## The current proposal solution

If we see a broadcast error and that the broadcasting time was long enough (20s threshold), we assume it's a success.
This should make Ledger Live correctly creating the pending operations and replacing it as soon as a network operation appear thanks to `transactionSequenceNumber`.

As it was also discussed, we MUST also prevent a successive transaction to be done so we introduce an ERROR in case you do a send again too quickly.

### The tradeoff of that solution

- on Mobile, we can't know the error status code (which is another task in our sprint to fix in future) so we can't refine the error case to specifically 504, for now we catch all errors, including potential case it would take forever to broadcast like VERY slow network. it's a compromise here. By default, Ledger Live keep an operation pending only for 30mn.
- on Desktop, when you do a Send, stay on the modal and do a `< BACK` **it seems we do not refresh the account model** you will not see the new error. it's an potential problem we'll need to track internally. Also we must not be able to `< BACK` during broadcast.
- there is an imprecision in the represensation of `transactionSequenceNumber` of about +- 10 ledger at the moment. this is not a blocker and will be improved in future.

<img src="https://media.giphy.com/media/bvFESs4QyreBa/giphy.gif" />

> A great master once said, “ça plante mais en fait ça plante pas”.