### PR TITLE
[Stellar] use modeAccept for network fees

### DIFF
--- a/src/families/stellar/libcore-getAccountNetworkInfo.js
+++ b/src/families/stellar/libcore-getAccountNetworkInfo.js
@@ -14,12 +14,12 @@ type Output = Promise<NetworkInfo>;
 
 async function stellar({ coreAccount }: Input): Output {
   const stellarLikeAccount: CoreStellarLikeAccount = await coreAccount.asStellarLikeAccount();
-  // const baseFees = await stellarLikeAccount.getFeeStats();
-  // const fees = await baseFees.getModeAcceptedFee();
+  const baseFees = await stellarLikeAccount.getFeeStats();
+  const fees = await baseFees.getModeAcceptedFee();
 
   return {
     family: "stellar",
-    fees: BigNumber("100"),
+    fees: BigNumber(fees),
     baseReserve: await libcoreAmountToBigNumber(
       await stellarLikeAccount.getBaseReserve()
     )


### PR DESCRIPTION
We were used an hard-coded fees because Daemon Block fees wasn't working properly so we had to hotfix it.

Now that libcore got the right value it should be okay !