### PR TITLE
Mock - Add a migratable account for testing

### DIFF
--- a/src/__tests__/__snapshots__/cross.js.snap
+++ b/src/__tests__/__snapshots__/cross.js.snap
@@ -28,7 +28,7 @@ Object {
       "currencyId": "dogecoin",
       "derivationMode": "",
       "freshAddress": "1CWNKLfcukxxXRNRK1DpYwPA6Hb1h",
-      "id": "mock:1:dogecoin:export_2:",
+      "id": "mock:0:dogecoin:export_2:",
       "index": 1,
       "name": "s9dZEiOrwfEPOXbKgNKq88aQZ",
       "seedIdentifier": "mock",

--- a/src/__tests__/mocks/account.js
+++ b/src/__tests__/mocks/account.js
@@ -7,7 +7,7 @@ import { genAccount } from "../../mock/account";
 import { getBalanceHistory } from "../../portfolio";
 import { getEnv, setEnv } from "../../env";
 import { findCryptoCurrencyById } from "../../data/cryptocurrencies";
-import { canBeMigrated, decodeAccountId } from "../../account";
+import { canBeMigrated } from "../../account";
 
 test("generate an account from seed", () => {
   const a = genAccount("seed");
@@ -36,7 +36,7 @@ test("generate an account eligible to be migrated for mocked currencies", () => 
   expect(
     canBeMigrated(
       genAccount(`${mock}_2`, {
-        currency: findCryptoCurrencyById("dogecoin")
+        currency: findCryptoCurrencyById("ethereum_classic") // should ignore libcore's no-go
       })
     )
   ).toBeTruthy();

--- a/src/__tests__/mocks/account.js
+++ b/src/__tests__/mocks/account.js
@@ -6,6 +6,8 @@ import "../../load/tokens/tron/trc20";
 import { genAccount } from "../../mock/account";
 import { getBalanceHistory } from "../../portfolio";
 import { getEnv, setEnv } from "../../env";
+import { findCryptoCurrencyById } from "../../data/cryptocurrencies";
+import { canBeMigrated, decodeAccountId } from "../../account";
 
 test("generate an account from seed", () => {
   const a = genAccount("seed");
@@ -18,6 +20,78 @@ test("generate an account from different seed should generate a different accoun
   setEnv("MOCK", "çacestvraiça");
   const b = genAccount(getEnv("MOCK"));
   expect(a).not.toEqual(b);
+});
+
+test("generate an account eligible to be migrated for mocked currencies", () => {
+  setEnv("MOCK", "#-extexist");
+  const mock = getEnv("MOCK");
+
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_0`, {
+        currency: findCryptoCurrencyById("ethereum_classic")
+      })
+    )
+  ).toBeFalsy(); // only the third mock account should be
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_2`, {
+        currency: findCryptoCurrencyById("dogecoin")
+      })
+    )
+  ).toBeTruthy();
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_2`, {
+        currency: findCryptoCurrencyById("dogecoin")
+      })
+    )
+  ).toBeTruthy();
+});
+
+test("generate no migratable accounts for other currencies", () => {
+  setEnv("MOCK", "MOCK");
+  const mock = getEnv("MOCK");
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_2`, {
+        currency: findCryptoCurrencyById("bitcoin")
+      })
+    )
+  ).toBeFalsy();
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_2`, {
+        currency: findCryptoCurrencyById("ethereum")
+      })
+    )
+  ).toBeFalsy();
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_2`, {
+        currency: findCryptoCurrencyById("tezos")
+      })
+    )
+  ).toBeFalsy();
+});
+
+test("generate no migratable accounts if not mock", () => {
+  setEnv("MOCK", "");
+  const mock = getEnv("MOCK");
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_2`, {
+        currency: findCryptoCurrencyById("dogecoin")
+      })
+    )
+  ).toBeFalsy();
+  expect(
+    canBeMigrated(
+      genAccount(`${mock}_2`, {
+        currency: findCryptoCurrencyById("ethereum_classic")
+      })
+    )
+  ).toBeFalsy();
 });
 
 test("dont generate negative balance", () => {

--- a/src/account/support.js
+++ b/src/account/support.js
@@ -69,9 +69,10 @@ export function canSend(
 
 export function canBeMigrated(account: Account) {
   try {
-    const { type } = decodeAccountId(account.id);
-    if (libcoreNoGo.includes(account.currency.id)) return false;
-    return type === "ethereumjs";
+    const { type, version } = decodeAccountId(account.id);
+    const mock = getEnv("MOCK");
+    if (!mock && libcoreNoGo.includes(account.currency.id)) return false;
+    return type === "ethereumjs" || (mock && version === "0");
   } catch (e) {
     return false;
   }
@@ -84,7 +85,7 @@ export function findAccountMigration(
 ): ?Account {
   if (!canBeMigrated(account)) return;
   const { type } = decodeAccountId(account.id);
-  if (type === "ethereumjs") {
+  if (type === "ethereumjs" || getEnv("MOCK")) {
     return scannedAccounts.find(
       a =>
         a.id !== account.id && // a migration assume an id changes

--- a/src/mock/account.js
+++ b/src/mock/account.js
@@ -346,9 +346,14 @@ export function genAccount(
   );
   const freshAddress = { address, derivationPath };
 
+  // nb Make the third (ethereum_classic, dogecoin) account originally migratable
+  const outdated =
+    ["ethereum_classic", "dogecoin"].includes(currency.id) &&
+    `${id}`.endsWith("_2");
+
   const account: $Exact<Account> = {
     type: "Account",
-    id: `mock:1:${currency.id}:${id}:`,
+    id: `mock:${outdated ? 0 : 1}:${currency.id}:${id}:`,
     seedIdentifier: "mock",
     derivationMode: "",
     xpub: genHex(64, rng),


### PR DESCRIPTION
When scanning accounts for ethereum in mock mode we will now get the third account as migratable. We are using the `version` of the id as the discriminatory field. This allows us to complete the account migration flow on desktop with spectron.