### PR TITLE
Move device transaction logic to live-common

### DIFF
--- a/scripts/sync-families-dispatch.sh
+++ b/scripts/sync-families-dispatch.sh
@@ -76,14 +76,18 @@ done
 genDeviceTransactionConfig () {
   for family in $families; do
     if [ -f $family/deviceTransactionConfig.js ]; then
-      echo 'import type { ExtraDeviceTransactionField as ExtraDeviceTransactionField_'$family' } from "../families/'$family'/deviceTransactionConfig";'
+      if grep -q "export type ExtraDeviceTransactionField" "$family/deviceTransactionConfig.js"; then
+        echo 'import type { ExtraDeviceTransactionField as ExtraDeviceTransactionField_'$family' } from "../families/'$family'/deviceTransactionConfig";'
+      fi
     fi
   done
 
   echo 'export type ExtraDeviceTransactionField ='
   for family in $families; do
     if [ -f $family/deviceTransactionConfig.js ]; then
-      echo '| ExtraDeviceTransactionField_'$family
+      if grep -q "export type ExtraDeviceTransactionField" "$family/deviceTransactionConfig.js"; then
+        echo '| ExtraDeviceTransactionField_'$family
+      fi
     fi
   done
 }

--- a/src/families/bitcoin/deviceTransactionConfig.js
+++ b/src/families/bitcoin/deviceTransactionConfig.js
@@ -1,0 +1,35 @@
+// @flow
+
+import type { AccountLike, Account, TransactionStatus } from "../../types";
+import type { Transaction } from "./types";
+import type { DeviceTransactionField } from "../../transaction";
+
+function getDeviceTransactionConfig({
+  status
+}: {
+  account: AccountLike,
+  parentAccount: ?Account,
+  transaction: Transaction,
+  status: TransactionStatus
+}): Array<DeviceTransactionField> {
+  const { amount, estimatedFees } = status;
+  const fields = [];
+
+  if (!amount.isZero()) {
+    fields.push({
+      type: "amount",
+      label: "Amount"
+    });
+  }
+
+  if (estimatedFees && !estimatedFees.isZero()) {
+    fields.push({
+      type: "fees",
+      label: "Fees"
+    });
+  }
+
+  return fields;
+}
+
+export default getDeviceTransactionConfig;

--- a/src/families/ethereum/deviceTransactionConfig.js
+++ b/src/families/ethereum/deviceTransactionConfig.js
@@ -1,0 +1,35 @@
+// @flow
+
+import type { DeviceTransactionField } from "../../transaction";
+import type { Account, AccountLike, TransactionStatus } from "../../types";
+import type { Transaction } from "../bitcoin/types";
+
+function getDeviceTransactionConfig({
+  status
+}: {
+  account: AccountLike,
+  parentAccount: ?Account,
+  transaction: Transaction,
+  status: TransactionStatus
+}): Array<DeviceTransactionField> {
+  const { amount, estimatedFees } = status;
+  const fields = [];
+
+  if (!amount.isZero()) {
+    fields.push({
+      type: "amount",
+      label: "Amount"
+    });
+  }
+
+  if (estimatedFees && !estimatedFees.isZero()) {
+    fields.push({
+      type: "fees",
+      label: "Max fees"
+    });
+  }
+
+  return fields;
+}
+
+export default getDeviceTransactionConfig;

--- a/src/families/ripple/deviceTransactionConfig.js
+++ b/src/families/ripple/deviceTransactionConfig.js
@@ -1,0 +1,46 @@
+// @flow
+
+import type { AccountLike, Account, TransactionStatus } from "../../types";
+import type { Transaction } from "./types";
+import type { DeviceTransactionField } from "../../transaction";
+
+function getDeviceTransactionConfig({
+  transaction,
+  status
+}: {
+  account: AccountLike,
+  parentAccount: ?Account,
+  transaction: Transaction,
+  status: TransactionStatus
+}): Array<DeviceTransactionField> {
+  const { amount, tag } = transaction;
+  const { estimatedFees } = status;
+
+  const fields = [];
+
+  if (!amount.isZero()) {
+    fields.push({
+      type: "amount",
+      label: "Amount"
+    });
+  }
+
+  if (!estimatedFees.isZero()) {
+    fields.push({
+      type: "fees",
+      label: "Fees"
+    });
+  }
+
+  if (tag) {
+    fields.push({
+      type: "text",
+      label: "Tag",
+      value: tag ? String(tag) : ""
+    });
+  }
+
+  return fields;
+}
+
+export default getDeviceTransactionConfig;

--- a/src/families/stellar/deviceTransactionConfig.js
+++ b/src/families/stellar/deviceTransactionConfig.js
@@ -1,0 +1,47 @@
+// @flow
+
+import type { AccountLike, Account, TransactionStatus } from "../../types";
+import type { Transaction } from "./types";
+import type { DeviceTransactionField } from "../../transaction";
+
+export type ExtraDeviceTransactionField =
+  | { type: "stellar.memo", label: string }
+  | { type: "stellar.network", label: string };
+
+function getDeviceTransactionConfig({
+  transaction,
+  status
+}: {
+  account: AccountLike,
+  parentAccount: ?Account,
+  transaction: Transaction,
+  status: TransactionStatus
+}): Array<DeviceTransactionField> {
+  const { amount } = transaction;
+  const { estimatedFees } = status;
+
+  const fields = [{ type: "stellar.network", label: "Network" }];
+
+  if (!amount.isZero()) {
+    fields.push({
+      type: "amount",
+      label: "Amount"
+    });
+  }
+
+  fields.push({
+    type: "stellar.memo",
+    label: "Memo"
+  }); //NB device displays [none] for an empty memo
+
+  if (estimatedFees && !estimatedFees.isZero()) {
+    fields.push({
+      type: "fees",
+      label: "Fees"
+    });
+  }
+
+  return fields;
+}
+
+export default getDeviceTransactionConfig;

--- a/src/families/tezos/deviceTransactionConfig.js
+++ b/src/families/tezos/deviceTransactionConfig.js
@@ -1,0 +1,76 @@
+// @flow
+
+import type { AccountLike, Account, TransactionStatus } from "../../types";
+import type { Transaction } from "./types";
+import type { DeviceTransactionField } from "../../transaction";
+import { getMainAccount } from "../../account";
+
+export type ExtraDeviceTransactionField =
+  | { type: "tezos.delegateValidator", label: string }
+  | { type: "tezos.storageLimit", label: string };
+
+function getDeviceTransactionConfig({
+  account,
+  parentAccount,
+  transaction,
+  status
+}: {
+  account: AccountLike,
+  parentAccount: ?Account,
+  transaction: Transaction,
+  status: TransactionStatus
+}): Array<DeviceTransactionField> {
+  const { amount } = transaction;
+  const { estimatedFees } = status;
+  const mainAccount = getMainAccount(account, parentAccount);
+  const source =
+    account.type === "ChildAccount"
+      ? account.address
+      : mainAccount.freshAddress;
+  const isDelegateOperation = transaction.mode === "delegate";
+
+  const fields = [
+    {
+      type: "address",
+      label: "Source",
+      address: source
+    }
+  ];
+
+  if (isDelegateOperation) {
+    fields.push(
+      {
+        type: "tezos.delegateValidator",
+        label: "Validator"
+      },
+      {
+        type: "address",
+        label: "Delegate",
+        address: transaction.recipient
+      }
+    );
+  }
+
+  if (!amount.isZero()) {
+    fields.push({
+      type: "amount",
+      label: "Amount"
+    });
+  }
+
+  if (!estimatedFees.isZero()) {
+    fields.push({
+      type: "fees",
+      label: "Fees"
+    });
+  }
+
+  fields.push({
+    type: "tezos.storageLimit",
+    label: "Storage Limit"
+  });
+
+  return fields;
+}
+
+export default getDeviceTransactionConfig;

--- a/src/families/tron/deviceTransactionConfig.js
+++ b/src/families/tron/deviceTransactionConfig.js
@@ -6,7 +6,7 @@ import { getMainAccount } from "../../account";
 import type { DeviceTransactionField } from "../../transaction";
 
 export type ExtraDeviceTransactionField =
-  | { type: "tron.resources", label: string, value: string }
+  | { type: "tron.resource", label: string, value: string }
   | { type: "tron.votes", label: string };
 
 function getDeviceTransactionConfig({
@@ -20,8 +20,7 @@ function getDeviceTransactionConfig({
   status: TransactionStatus
 }): Array<DeviceTransactionField> {
   const mainAccount = getMainAccount(account, parentAccount);
-  const { votes, resource, mode } = transaction;
-  const { amount } = transaction;
+  const { amount, votes, resource, mode } = transaction;
   const fields = [];
 
   if (resource) {

--- a/src/generated/deviceTransactionConfig.js
+++ b/src/generated/deviceTransactionConfig.js
@@ -1,9 +1,23 @@
 // @flow
+import bitcoin from "../families/bitcoin/deviceTransactionConfig.js";
+import ethereum from "../families/ethereum/deviceTransactionConfig.js";
+import ripple from "../families/ripple/deviceTransactionConfig.js";
+import stellar from "../families/stellar/deviceTransactionConfig.js";
+import tezos from "../families/tezos/deviceTransactionConfig.js";
 import tron from "../families/tron/deviceTransactionConfig.js";
 
 export default {
+  bitcoin,
+  ethereum,
+  ripple,
+  stellar,
+  tezos,
   tron,
 };
+import type { ExtraDeviceTransactionField as ExtraDeviceTransactionField_stellar } from "../families/stellar/deviceTransactionConfig";
+import type { ExtraDeviceTransactionField as ExtraDeviceTransactionField_tezos } from "../families/tezos/deviceTransactionConfig";
 import type { ExtraDeviceTransactionField as ExtraDeviceTransactionField_tron } from "../families/tron/deviceTransactionConfig";
 export type ExtraDeviceTransactionField =
+| ExtraDeviceTransactionField_stellar
+| ExtraDeviceTransactionField_tezos
 | ExtraDeviceTransactionField_tron

--- a/src/transaction/deviceTransactionConfig.js
+++ b/src/transaction/deviceTransactionConfig.js
@@ -12,7 +12,8 @@ import { getMainAccount } from "../account";
 export type CommonDeviceTransactionField =
   | { type: "amount", label: string }
   | { type: "address", label: string, address: string }
-  | { type: "fees", label: string };
+  | { type: "fees", label: string }
+  | { type: "text", label: string, value: string };
 
 export type DeviceTransactionField =
   | CommonDeviceTransactionField


### PR DESCRIPTION
Brings to live-common the logic that determines whether a field is displayed or not on the device confirmation steps. This is renderer agnostic and needs a companion component with matching names on the desktop/mobile implementation for it to work.

### Context
https://ledgerhq.atlassian.net/browse/LL-2423