### PR TITLE
Fixes #637

### DIFF
--- a/src/bridge/jsHelpers.js
+++ b/src/bridge/jsHelpers.js
@@ -26,7 +26,7 @@ import type {
 } from "../types";
 import type { CurrencyBridge, AccountBridge } from "../types/bridge";
 import getAddress from "../hw/getAddress";
-import { open } from "../hw";
+import { open, close } from "../hw";
 
 type GetAccountShape = (
   { address: string, id: string, initialAccount?: Account },
@@ -277,7 +277,9 @@ export const makeScanAccounts = (
       } catch (e) {
         o.error(e);
       } finally {
-        if (transport) transport.close();
+        if (transport) {
+          close(transport, deviceId);
+        }
       }
     }
 

--- a/src/families/ethereum/bridge/js.js
+++ b/src/families/ethereum/bridge/js.js
@@ -38,7 +38,7 @@ import type { Transaction } from "../types";
 import { getGasLimit } from "../transaction";
 import getAddress from "../../../hw/getAddress";
 import { withDevice } from "../../../hw/deviceAccess";
-import { open } from "../../../hw";
+import { open, close } from "../../../hw";
 import { apiForCurrency } from "../../../api/Ethereum";
 import { getEstimatedFees } from "../../../api/Fees";
 import type { Tx } from "../../../api/Ethereum";
@@ -402,7 +402,7 @@ const currencyBridge: CurrencyBridge = {
         } catch (e) {
           o.error(e);
         } finally {
-          if (transport) transport.close();
+          if (transport) close(transport, deviceId);
         }
       }
 

--- a/src/families/ripple/bridge/js.js
+++ b/src/families/ripple/bridge/js.js
@@ -35,7 +35,7 @@ import {
   getNewAccountPlaceholderName
 } from "../../../account";
 import getAddress from "../../../hw/getAddress";
-import { open } from "../../../hw";
+import { open, close } from "../../../hw";
 import {
   apiForEndpointConfig,
   parseAPIValue,
@@ -91,7 +91,7 @@ const signOperation = ({ account, transaction, deviceId }) =>
           );
           o.next({ type: "device-signature-granted" });
         } finally {
-          transport.close();
+          close(transport, deviceId);
         }
 
         const hash = computeBinaryTransactionHash(transaction);
@@ -492,7 +492,7 @@ const currencyBridge: CurrencyBridge = {
         } finally {
           api.disconnect();
           if (transport) {
-            await transport.close();
+            await close(transport, deviceId);
           }
         }
       }

--- a/src/families/tron/bridge/js.js
+++ b/src/families/tron/bridge/js.js
@@ -21,7 +21,7 @@ import {
 } from "../utils";
 import type { CurrencyBridge, AccountBridge } from "../../../types/bridge";
 import { findTokenById } from "../../../data/tokens";
-import { open } from "../../../hw";
+import { open, close } from "../../../hw";
 import signTransaction from "../../../hw/signTransaction";
 import { makeSync, makeScanAccounts } from "../../../bridge/jsHelpers";
 import { formatCurrencyUnit } from "../../../currencies";
@@ -236,7 +236,7 @@ const signOperation = ({ account, transaction, deviceId }) =>
           }
         });
       } finally {
-        transport.close();
+        close(transport, deviceId);
       }
     }
 

--- a/src/hw/deviceAccess.js
+++ b/src/hw/deviceAccess.js
@@ -16,7 +16,7 @@ import {
   DeviceHalted
 } from "@ledgerhq/errors";
 import { getEnv } from "../env";
-import { open } from ".";
+import { open, close } from ".";
 
 export type AccessHook = () => () => void;
 
@@ -91,8 +91,7 @@ export const withDevice = (deviceId: string) => <T>(
     const deviceQueue = deviceQueues[deviceId] || Promise.resolve();
 
     const finalize = (transport, cleanups) =>
-      transport
-        .close()
+      close(transport, deviceId)
         .catch(() => {})
         .then(() => {
           cleanups.forEach(c => c());

--- a/src/libcore/scanAccounts.js
+++ b/src/libcore/scanAccounts.js
@@ -259,10 +259,6 @@ export const scanAccounts = ({
         } catch (e) {
           o.error(remapLibcoreErrors(e));
         }
-
-        if (transport) {
-          await transport.close();
-        }
       });
 
       main();


### PR DESCRIPTION
This provides a way to override close of a registered transport.

it also remove a close that was unecessarily done in scan accounts for libcore (to be tested).