### PR TITLE
Add tx formatters

### DIFF
--- a/cli/src/commands/generateTestScanAccounts.js
+++ b/cli/src/commands/generateTestScanAccounts.js
@@ -2,7 +2,7 @@
 
 import { listen } from "@ledgerhq/logs";
 import { map, reduce } from "rxjs/operators";
-import accountFormatters from "../accountFormatters";
+import { accountFormatters } from "@ledgerhq/live-common/lib/account";
 import { scan, scanCommonOpts } from "../scan";
 import type { ScanCommonOpts } from "../scan";
 

--- a/cli/src/commands/getTransactionStatus.js
+++ b/cli/src/commands/getTransactionStatus.js
@@ -4,8 +4,9 @@ import { from, defer, concat, empty } from "rxjs";
 import { map, mergeMap, concatMap } from "rxjs/operators";
 import { getAccountBridge } from "@ledgerhq/live-common/lib/bridge";
 import {
-  toTransactionStatusRaw,
   toTransactionRaw,
+  formatTransactionStatus,
+  formatTransaction,
 } from "@ledgerhq/live-common/lib/transaction";
 import { scan, scanCommonOpts } from "../scan";
 import type { ScanCommonOpts } from "../scan";
@@ -13,10 +14,13 @@ import type { InferTransactionsOpts } from "../transaction";
 import { inferTransactions, inferTransactionsOpts } from "../transaction";
 
 const getTransactionStatusFormatters = {
-  json: ({ status, transaction }) => ({
-    status: JSON.stringify(toTransactionStatusRaw(status)),
-    transaction: JSON.stringify(toTransactionRaw(transaction)),
-  }),
+  json: ({ status, transaction, account }) =>
+    "TRANSACTION " +
+    (formatTransaction(transaction, account) ||
+      JSON.stringify(toTransactionRaw(transaction))) +
+    "\n" +
+    "STATUS " +
+    formatTransactionStatus(transaction, status, account),
 };
 
 export default {
@@ -46,7 +50,7 @@ export default {
                     defer(() =>
                       getAccountBridge(account)
                         .getTransactionStatus(account, transaction)
-                        .then((status) => ({ transaction, status }))
+                        .then((status) => ({ transaction, status, account }))
                     )
                   )
                 ),

--- a/cli/src/commands/sync.js
+++ b/cli/src/commands/sync.js
@@ -1,7 +1,7 @@
 // @flow
 
 import { map } from "rxjs/operators";
-import accountFormatters from "../accountFormatters";
+import { accountFormatters } from "@ledgerhq/live-common/lib/account";
 import { scan, scanCommonOpts } from "../scan";
 import type { ScanCommonOpts } from "../scan";
 

--- a/src/account/formatters.js
+++ b/src/account/formatters.js
@@ -1,18 +1,18 @@
 // @flow
 
+import invariant from "invariant";
 import { BigNumber } from "bignumber.js";
 import {
   toAccountRaw,
   getAccountCurrency,
   getAccountName,
   getAccountUnit,
-} from "@ledgerhq/live-common/lib/account";
-import type { Account } from "@ledgerhq/live-common/lib/types";
-import { getOperationAmountNumberWithInternals } from "@ledgerhq/live-common/lib/operation";
-import { formatCurrencyUnit } from "@ledgerhq/live-common/lib/currencies";
-import { getOperationAmountNumber } from "@ledgerhq/live-common/lib/operation";
+} from ".";
+import type { Account } from "../types";
+import { getOperationAmountNumberWithInternals } from "../operation";
+import { formatCurrencyUnit } from "../currencies";
+import { getOperationAmountNumber } from "../operation";
 
-// TODO move to live common
 const isSignificantAccount = (acc) =>
   acc.balance.gt(10 ** (getAccountUnit(acc).magnitude - 6));
 
@@ -142,7 +142,7 @@ const stats = (account) => {
   };
 };
 
-const all: { [_: string]: (Account) => any } = {
+export const accountFormatters: { [_: string]: (Account) => any } = {
   json: (account) => JSON.stringify(toAccountRaw(account)),
   default: (account) => cliFormat(account),
   summary: (account) => cliFormat(account, true),
@@ -154,4 +154,11 @@ const all: { [_: string]: (Account) => any } = {
       .join("\n"),
 };
 
-export default all;
+export function formatAccount(
+  account: Account,
+  format: string = "default"
+): string {
+  const f = accountFormatters[format];
+  invariant(f, "missing account formatter=" + format);
+  return f(account);
+}

--- a/src/account/index.js
+++ b/src/account/index.js
@@ -10,3 +10,4 @@ export * from "./accountName";
 export * from "./ordering";
 export * from "./groupOperations";
 export * from "./pending";
+export * from "./formatters";

--- a/src/families/bitcoin/transaction.js
+++ b/src/families/bitcoin/transaction.js
@@ -6,10 +6,13 @@ import type {
   FeeItems,
   FeeItemsRaw,
 } from "./types";
+import type { Account } from "../../types";
 import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
 
 const fromFeeItemsRaw = (fir: FeeItemsRaw): FeeItems => ({
   items: fir.items.map((fi) => ({
@@ -55,4 +58,22 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+const formatNetworkInfo = (networkInfo: ?{ feeItems: FeeItems }) => {
+  if (!networkInfo) return "network info not loaded";
+  return `network fees: ${networkInfo.feeItems.items
+    .map((i) => i.key + "=" + i.feePerByte.toString())
+    .join(", ")}`;
+};
+
+export const formatTransaction = (t: Transaction, account: Account): string =>
+  `
+  SEND ${formatCurrencyUnit(getAccountUnit(account), t.amount, {
+    showCode: true,
+    disableRounding: true,
+  })}
+  TO ${t.recipient}
+  with feePerByte=${
+    t.feePerByte ? t.feePerByte.toString() : "?"
+  } (${formatNetworkInfo(t.networkInfo)})`;
+
+export default { fromTransactionRaw, toTransactionRaw, formatTransaction };

--- a/src/families/cosmos/transaction.js
+++ b/src/families/cosmos/transaction.js
@@ -5,6 +5,52 @@ import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import type { Account } from "../../types";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
+
+export const formatTransaction = (
+  {
+    mode,
+    amount,
+    fees,
+    recipient,
+    validators,
+    memo,
+    cosmosSourceValidator,
+  }: Transaction,
+  account: Account
+): string =>
+  `
+  ${mode.toUpperCase()} ${
+    amount.isZero()
+      ? ""
+      : " " +
+        formatCurrencyUnit(getAccountUnit(account), amount, {
+          showCode: true,
+          disableRounding: true,
+        })
+  }${
+    !validators
+      ? ""
+      : " " +
+        validators
+          .map(
+            (v) =>
+              formatCurrencyUnit(getAccountUnit(account), v.amount) +
+              "->" +
+              v.address
+          )
+          .join(" ")
+  }${
+    !cosmosSourceValidator
+      ? ""
+      : "\n  source validator=" + cosmosSourceValidator
+  }
+  TO ${recipient}
+  with fees=${fees ? formatCurrencyUnit(getAccountUnit(account), fees) : "?"}${
+    !memo ? "" : `\n  memo=${memo}`
+  }`;
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
@@ -54,4 +100,4 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+export default { formatTransaction, fromTransactionRaw, toTransactionRaw };

--- a/src/families/ethereum/transaction.js
+++ b/src/families/ethereum/transaction.js
@@ -5,6 +5,31 @@ import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import type { Account } from "../../types";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
+
+export const formatTransaction = (
+  t: Transaction,
+  mainAccount: Account
+): string => {
+  const gasLimit = getGasLimit(t);
+  const account =
+    (t.subAccountId &&
+      (mainAccount.subAccounts || []).find((a) => a.id === t.subAccountId)) ||
+    mainAccount;
+  return `
+  SEND ${formatCurrencyUnit(getAccountUnit(account), t.amount, {
+    showCode: true,
+    disableRounding: true,
+  })}
+  TO ${t.recipient}
+  with gasPrice=${formatCurrencyUnit(
+    mainAccount.currency.units[1],
+    t.gasPrice || BigNumber(0)
+  )}
+  with gasLimit=${gasLimit.toString()}`;
+};
 
 const defaultGasLimit = BigNumber(0x5208);
 
@@ -49,4 +74,4 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+export default { formatTransaction, fromTransactionRaw, toTransactionRaw };

--- a/src/families/neo/transaction.js
+++ b/src/families/neo/transaction.js
@@ -4,6 +4,17 @@ import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import type { Account } from "../../types";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
+
+export const formatTransaction = (t: Transaction, account: Account): string =>
+  `
+  SEND ${formatCurrencyUnit(getAccountUnit(account), t.amount, {
+    showCode: true,
+    disableRounding: true,
+  })}
+  TO ${t.recipient}`;
 
 const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
@@ -21,4 +32,4 @@ const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+export default { formatTransaction, fromTransactionRaw, toTransactionRaw };

--- a/src/families/ripple/transaction.js
+++ b/src/families/ripple/transaction.js
@@ -5,6 +5,28 @@ import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import type { Account } from "../../types";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
+
+export const formatTransaction = (
+  { amount, recipient, fee, tag }: Transaction,
+  account: Account
+): string =>
+  `
+  SEND ${formatCurrencyUnit(getAccountUnit(account), amount, {
+    showCode: true,
+    disableRounding: true,
+  })}
+  TO ${recipient}
+  with fee=${
+    !fee
+      ? "?"
+      : formatCurrencyUnit(getAccountUnit(account), fee, {
+          showCode: true,
+          disableRounding: true,
+        })
+  }${tag ? "\n  tag=" + tag : ""}`;
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
@@ -40,4 +62,4 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+export default { formatTransaction, fromTransactionRaw, toTransactionRaw };

--- a/src/families/stellar/transaction.js
+++ b/src/families/stellar/transaction.js
@@ -5,6 +5,28 @@ import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import type { Account } from "../../types";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
+
+export const formatTransaction = (
+  { amount, recipient, fees, memoValue }: Transaction,
+  account: Account
+): string =>
+  `
+    SEND ${formatCurrencyUnit(getAccountUnit(account), amount, {
+      showCode: true,
+      disableRounding: true,
+    })}
+    TO ${recipient}
+    with fees=${
+      !fees
+        ? "?"
+        : formatCurrencyUnit(getAccountUnit(account), fees, {
+            showCode: true,
+            disableRounding: true,
+          })
+    }${memoValue ? "\n  memo=" + memoValue : ""}`;
 
 const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
@@ -45,4 +67,4 @@ const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+export default { formatTransaction, fromTransactionRaw, toTransactionRaw };

--- a/src/families/tezos/transaction.js
+++ b/src/families/tezos/transaction.js
@@ -5,6 +5,36 @@ import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import type { Account } from "../../types";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
+
+export const formatTransaction = (
+  {
+    mode,
+    subAccountId,
+    amount,
+    recipient,
+    gasLimit,
+    storageLimit,
+    fees,
+  }: Transaction,
+  mainAccount: Account
+): string => {
+  const account =
+    (subAccountId &&
+      (mainAccount.subAccounts || []).find((a) => a.id === subAccountId)) ||
+    mainAccount;
+  return `
+  ${mode.toUpperCase()} ${formatCurrencyUnit(getAccountUnit(account), amount, {
+    showCode: true,
+    disableRounding: true,
+  })}
+  TO ${recipient}
+  with fees=${!fees ? "?" : formatCurrencyUnit(mainAccount.unit, fees)}
+  with gasLimit=${!gasLimit ? "?" : gasLimit.toString()}
+  with storageLimit=${!storageLimit ? "?" : storageLimit.toString()}`;
+};
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
@@ -40,4 +70,4 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+export default { formatTransaction, fromTransactionRaw, toTransactionRaw };

--- a/src/families/tron/transaction.js
+++ b/src/families/tron/transaction.js
@@ -5,6 +5,9 @@ import {
   fromTransactionCommonRaw,
   toTransactionCommonRaw,
 } from "../../transaction/common";
+import type { Account } from "../../types";
+import { getAccountUnit } from "../../account";
+import { formatCurrencyUnit } from "../../currencies";
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
@@ -50,4 +53,29 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   };
 };
 
-export default { fromTransactionRaw, toTransactionRaw };
+export const formatTransaction = (
+  t: Transaction,
+  mainAccount: Account
+): string => {
+  const account =
+    (t.subAccountId &&
+      (mainAccount.subAccounts || []).find((a) => a.id === t.subAccountId)) ||
+    mainAccount;
+  return `
+  ${t.mode.toUpperCase()}${t.resource ? " " + t.resource : ""} ${
+    t.amount.isZero()
+      ? ""
+      : " " +
+        formatCurrencyUnit(getAccountUnit(account), t.amount, {
+          showCode: true,
+          disableRounding: true,
+        })
+  }${
+    !t.votes
+      ? ""
+      : " " + t.votes.map((v) => v.voteCount + "->" + v.address).join(" ")
+  }
+  TO ${t.recipient}`;
+};
+
+export default { formatTransaction, fromTransactionRaw, toTransactionRaw };

--- a/src/transaction/index.js
+++ b/src/transaction/index.js
@@ -4,7 +4,7 @@ export * from "./common";
 export * from "./status";
 export * from "./signOperation";
 export * from "./deviceTransactionConfig";
-import type { Transaction, TransactionRaw } from "../types";
+import type { Account, Transaction, TransactionRaw } from "../types";
 import transactionModulePerFamily from "../generated/transaction";
 
 export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
@@ -17,4 +17,10 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   const TM = transactionModulePerFamily[t.family];
   // $FlowFixMe i don't know how to prove this to flow
   return TM.toTransactionRaw(t);
+};
+
+export const formatTransaction = <T: Transaction>(t: T, a: Account): string => {
+  const TM = transactionModulePerFamily[t.family];
+  // $FlowFixMe prove to flow that T is the one from family
+  return TM.formatTransaction ? TM.formatTransaction(t, a) : "";
 };

--- a/src/transaction/status.js
+++ b/src/transaction/status.js
@@ -4,9 +4,13 @@ import mapValues from "lodash/mapValues";
 import { BigNumber } from "bignumber.js";
 import { deserializeError, serializeError } from "@ledgerhq/errors";
 import type {
+  TransactionCommon,
   TransactionStatusRaw,
   TransactionStatus,
 } from "../types/transaction";
+import type { Account } from "../types";
+import { getAccountUnit } from "../account";
+import { formatCurrencyUnit } from "../currencies";
 
 const fromErrorRaw = (raw: string): Error => {
   return deserializeError(JSON.parse(raw));
@@ -36,3 +40,48 @@ export const toTransactionStatusRaw = (
   totalSpent: ts.totalSpent.toString(),
   recipientIsReadOnly: ts.recipientIsReadOnly,
 });
+
+const formatErrorSmall = (e: Error): string =>
+  e.name === "Error" ? e.message : e.name;
+
+export const formatTransactionStatus = (
+  t: TransactionCommon,
+  { errors, warnings, estimatedFees, amount, totalSpent }: TransactionStatus,
+  mainAccount: Account
+): string => {
+  let str = "";
+  const account =
+    (t.subAccountId &&
+      (mainAccount.subAccounts || []).find((a) => a.id === t.subAccountId)) ||
+    mainAccount;
+
+  str +=
+    "\n  amount: " +
+    formatCurrencyUnit(getAccountUnit(account), amount, { showCode: true });
+
+  str +=
+    "\n  estimated fees: " +
+    formatCurrencyUnit(getAccountUnit(mainAccount), estimatedFees, {
+      showCode: true,
+    });
+
+  str +=
+    "\n  total spent: " +
+    formatCurrencyUnit(getAccountUnit(account), totalSpent, { showCode: true });
+
+  const errorKeys = Object.keys(errors);
+  if (errorKeys.length) {
+    str +=
+      "\n  errors: " +
+      errorKeys.map((k) => `${k}: ${formatErrorSmall(errors[k])}`).join(", ");
+  }
+  const warningKeys = Object.keys(warnings);
+  if (warningKeys.length) {
+    str +=
+      "\n  warnings: " +
+      warningKeys
+        .map((k) => `${k}: ${formatErrorSmall(warnings[k])}`)
+        .join(", ");
+  }
+  return str;
+};


### PR DESCRIPTION
for console rendering purpose

- add `formatAccount`
- add `formatTransactionStatus`
- add `formatTransaction` to be implemented by integrations



Examples

```
TRANSACTION
  SEND ZRX 0.001
  TO 0xabf06640f8ca8fC5e0Ed471b10BeFCDf65A33e43
  with gasPrice=0
  with gasLimit=300000
STATUS
  amount: ZRX 0.001
  estimated fees: ETH 0
  total spent: ZRX 0.001

TRANSACTION
  SEND BTC 0.001
  TO bc1qut73c7wj8nsqx45ztfp4sar0c54hfqf567x4l5
  with feePerByte=1 (network fees: 0=166, 1=166, 2=157)
STATUS
  amount: BTC 0.001
  estimated fees: BTC 0
  total spent: BTC 0.001
  errors: amount: NotEnoughBalance

TRANSACTION
  SEND BTC 0.001
  TO bc1qx367g0m2wkga8zffzsskuft99l662nkrax9577
  with feePerByte=1 (network fees: 0=166, 1=166, 2=157)
STATUS
  amount: BTC 0.001
  estimated fees: BTC 0
  total spent: BTC 0.001
  errors: amount: NotEnoughBalance
```