### PR TITLE
Update XRPL node (s2.ripple.com » xrpl.ws)

### DIFF
--- a/src/api/Ripple.js
+++ b/src/api/Ripple.js
@@ -8,7 +8,7 @@ import {
 
 const rippleUnit = getCryptoCurrencyById("ripple").units[0];
 
-export const defaultEndpoint = "wss://s2.ripple.com";
+export const defaultEndpoint = "wss://xrpl.ws";
 
 export const apiForEndpointConfig = (
   RippleAPI: *, // you must provide {RippleAPI} from "ripple-lib"


### PR DESCRIPTION
The Ledger software uses the Ripple provided `s2.ripple.com` full history node. **This node is not for production use.**

Due to an expired root certificate, [Twitter is currently filling](https://twitter.com/search?q=certificate%20xrp&src=typed_query&f=live) up with messages from users complaining about a certificate warning.
https://twitter.com/WietseWind/status/1267019432196558850

XRP ledger community developers provide and maintain global, load balanced, geo redundant full history nodes (clustered) with live failover as well, at https://xrpl.ws/ (wss://xrpl.ws)

Many community apps already rely on xrpl.ws.