### PR TITLE
bot: Add bitcoin_testnet spec + handle inconsistency w/ device units

### DIFF
--- a/src/data/cryptocurrencies.js
+++ b/src/data/cryptocurrencies.js
@@ -2428,6 +2428,7 @@ const cryptocurrenciesById: { [name: string]: CryptoCurrency } = {
     color: "#00ff00",
     symbol: "Ƀ",
     units: bitcoinUnits.map(makeTestnetUnit),
+    deviceTicker: "TEST",
     supportsSegwit: true,
     supportsNativeSegwit: true,
     isTestnetFor: "bitcoin",

--- a/src/families/bitcoin/specs.js
+++ b/src/families/bitcoin/specs.js
@@ -95,6 +95,22 @@ const bitcoin: AppSpec<Transaction> = {
   mutations: bitcoinLikeMutations(),
 };
 
+const bitcoinTestnet: AppSpec<Transaction> = {
+  name: "Bitcoin Testnet",
+  currency: getCryptoCurrencyById("bitcoin_testnet"),
+  dependency: "Bitcoin",
+  appQuery: {
+    model: "nanoS",
+    appName: "Bitcoin Test",
+  },
+  mutations: bitcoinLikeMutations({
+    minimalAmount: parseCurrencyUnit(
+      getCryptoCurrencyById("bitcoin_testnet").units[0],
+      "0.001"
+    ),
+  }),
+};
+
 const bitcoinGold: AppSpec<Transaction> = {
   name: "Bitcoin Gold",
   currency: getCryptoCurrencyById("bitcoin_gold"),
@@ -310,6 +326,7 @@ const stealthcoin: AppSpec<Transaction> = {
 
 export default {
   bitcoin,
+  bitcoinTestnet,
   bitcoinCash,
   bitcoinGold,
   digibyte,

--- a/src/families/bitcoin/speculos-deviceActions.js
+++ b/src/families/bitcoin/speculos-deviceActions.js
@@ -42,10 +42,17 @@ const acceptTransaction: DeviceAction<Transaction, {}> = ({
   }
 
   if (s.screen === "fees") {
-    let expectedText = formatCurrencyUnit(account.unit, status.estimatedFees, {
-      showCode: true,
-      disableRounding: true,
-    }).replace(/\s/g, " ");
+    let expectedText = formatCurrencyUnit(
+      {
+        ...account.unit,
+        code: account.currency.deviceTicker || account.unit.code,
+      },
+      status.estimatedFees,
+      {
+        showCode: true,
+        disableRounding: true,
+      }
+    ).replace(/\s/g, " ");
     let text = event.text;
 
     if (account.currency.id === "pivx" && text.startsWith("PIV ")) {
@@ -79,10 +86,17 @@ const acceptTransaction: DeviceAction<Transaction, {}> = ({
     s.amount += event.text;
     return s;
   } else if (s.amount) {
-    let expectedText = formatCurrencyUnit(account.unit, status.amount, {
-      showCode: true,
-      disableRounding: true,
-    }).replace(/\s/g, " ");
+    let expectedText = formatCurrencyUnit(
+      {
+        ...account.unit,
+        code: account.currency.deviceTicker || account.unit.code,
+      },
+      status.amount,
+      {
+        showCode: true,
+        disableRounding: true,
+      }
+    ).replace(/\s/g, " ");
 
     if (account.currency.id === "pivx" && s.amount.startsWith("PIV ")) {
       expectedText = expectedText.replace("PIVX", "PIV");

--- a/src/types/currencies.js
+++ b/src/types/currencies.js
@@ -80,6 +80,7 @@ export type CryptoCurrency = CurrencyCommon & {
   terminated?: {
     link: string,
   },
+  deviceTicker?: string,
 };
 
 export type Currency = FiatCurrency | CryptoCurrency | TokenCurrency;


### PR DESCRIPTION
### Note on handling device units

Since the device can only display ASCII characters, the screen shows `TEST` instead of `𝚝BTC`.

~This PR is about handling the above case, by introducing a new field to `CryptoCurrency` type called `deviceUnits`. If in future, the device starts displaying `TEST BTC` instead of just `TEST`, a simple change to `makeDeviceTestnetUnit` should be enough.~

This PR is about handling the above case, by introducing a new field to `CryptoCurrency` type called `deviceTicker`.

### Cute picture of animal

![](https://media.tenor.com/images/a4dfa55f4aa31622a1685502a35190b9/tenor.gif)