### PR TITLE
(csms): fix send status error not trigerring on the UI

### DIFF
--- a/src/families/cosmos/bridge/libcore.js
+++ b/src/families/cosmos/bridge/libcore.js
@@ -129,7 +129,7 @@ const getSendTransactionStatus = async (a, t) => {
 
   let amount = t.amount;
 
-  if (amount.eq(0) && t.useAllAmount !== true) {
+  if (amount.lte(0) && t.useAllAmount !== true) {
     errors.amount = new AmountRequired();
   }
 
@@ -142,11 +142,9 @@ const getSendTransactionStatus = async (a, t) => {
   if (
     !errors.recipient &&
     !errors.amount &&
-    (amount.lt(0) || totalSpent.gt(a.spendableBalance))
+    totalSpent.gt(a.spendableBalance)
   ) {
     errors.amount = new NotEnoughBalance();
-    totalSpent = BigNumber(0);
-    amount = BigNumber(0);
   }
 
   return Promise.resolve({


### PR DESCRIPTION
The transaction error status for send operation was mutating the amounts as well as the error thus messing with the UI not showing the notEnoughBalance error in the case of a zero amount.