### PR TITLE
Add support for v1 of cosmos FW app

### DIFF
--- a/src/families/cosmos/ledger-app/helpersV1.js
+++ b/src/families/cosmos/ledger-app/helpersV1.js
@@ -1,0 +1,20 @@
+// @flow
+export function serializePathv1(path) {
+  if (path == null || path.length < 3) {
+    throw new Error("Invalid path.");
+  }
+  if (path.length > 10) {
+    throw new Error("Invalid path. Length should be <= 10");
+  }
+  const buf = Buffer.alloc(1 + 4 * path.length);
+  buf.writeUInt8(path.length, 0);
+  for (let i = 0; i < path.length; i += 1) {
+    let v = path[i];
+    if (i < 3) {
+      // eslint-disable-next-line no-bitwise
+      v |= 0x80000000; // Harden
+    }
+    buf.writeInt32LE(v, 1 + i * 4);
+  }
+  return buf;
+}

--- a/src/families/cosmos/ledger-app/helpersV2.js
+++ b/src/families/cosmos/ledger-app/helpersV2.js
@@ -1,0 +1,15 @@
+// @flow
+
+export function serializePathv2(path) {
+  const buf = Buffer.alloc(20);
+  // HACK : without the >>>,
+  // the bitwise implicitly casts the result to be a signed int32,
+  // which fails the internal type check of Buffer in case of overload.
+  buf.writeUInt32LE((0x80000000 | path[0]) >>> 0, 0);
+  buf.writeUInt32LE((0x80000000 | path[1]) >>> 0, 4);
+  buf.writeUInt32LE((0x80000000 | path[2]) >>> 0, 8);
+  buf.writeUInt32LE(path[3], 12);
+  buf.writeUInt32LE(path[4], 16);
+
+  return buf;
+}


### PR DESCRIPTION
The only code that is not common and that is used in this layer is the
serializePath function