### PR TITLE
perform more cosmos tests + improve bot engine

### DIFF
--- a/src/bot/engine.js
+++ b/src/bot/engine.js
@@ -262,13 +262,15 @@ export async function runOnAccount<T: Transaction>({
           "maximum mutation run reached (%s)",
           count
         );
-        const tx = mutation.transaction({
+        const arg = {
           appCandidate,
           account,
           bridge: accountBridge,
           siblings: accounts.filter((a) => a !== account),
           maxSpendable,
-        });
+        };
+        if (spec.transactionCheck) spec.transactionCheck(arg);
+        const tx = mutation.transaction(arg);
         if (tx) {
           candidates.push({ mutation, tx });
         }
@@ -402,14 +404,16 @@ export async function runOnAccount<T: Transaction>({
 
       if (operation && mutation.test) {
         try {
-          mutation.test({
+          const arg = {
             accountBeforeTransaction,
             transaction,
             status,
             optimisticOperation,
             operation,
             account,
-          });
+          };
+          if (spec.test) spec.test(arg);
+          mutation.test(arg);
           report.testDuration = now() - testBefore;
         } catch (e) {
           // We never reach the final test success

--- a/src/bot/types.js
+++ b/src/bot/types.js
@@ -77,6 +77,23 @@ export type AppSpec<T: Transaction> = {
     appVersion?: string,
   },
   mutations: MutationSpec<T>[],
+  // can implement generic invariants for a mutation transaction to be possible
+  transactionCheck?: ({
+    appCandidate: AppCandidate,
+    account: Account,
+    siblings: Account[],
+    bridge: AccountBridge<T>,
+    maxSpendable: BigNumber,
+  }) => void,
+  // Implement a test that also runs on each mutation after the operation is applied to the account
+  test?: ({
+    account: Account,
+    accountBeforeTransaction: Account,
+    transaction: T,
+    status: TransactionStatus,
+    optimisticOperation: Operation,
+    operation: Operation,
+  }) => void,
 };
 
 export type SpecReport<T: Transaction> = {

--- a/src/load/speculos.js
+++ b/src/load/speculos.js
@@ -226,12 +226,12 @@ export type AppCandidate = {
 
 const modelMap: { [_: string]: DeviceModelId } = {
   nanos: "nanoS",
-  nanox: "nanoX",
+  // nanox: "nanoX",
   blue: "blue",
 };
 const modelMapPriority: { [_: string]: number } = {
   nanos: 3,
-  nanox: 2,
+  // nanox: 2,
   blue: 1,
 };
 


### PR DESCRIPTION
bot engine got two additions in the Spec level:
- optional `transactionCheck` that is same signature of a mutation transaction except it doesn't return a transaction but simply do pre-checks for all mutations (common invariants)
- optional `test` that is same signature of a mutation test and will run for ALL mutations to assert common tests.

Refine the cosmos test with more cases and tests.