### PR TITLE
Merge Fees in other Operations

### DIFF
--- a/src/families/cosmos/libcore-postBuildAccount.js
+++ b/src/families/cosmos/libcore-postBuildAccount.js
@@ -21,13 +21,13 @@ const addCoreOperationToAccountOperations = async (
   }>,
   newCoreOp: Operation
 ): Promise<{
-  ops: { [id: string]: [Operation] },
-  fees: { [tx_hash: string]: BigNumber },
+  ops: { [tx_hash: string]: [Operation] }, // List of operations matching this transaction hash
+  fees: { [tx_hash: string]: BigNumber }, // Value of fees on that transaction hash
 }> => {
   let result = await accountOpsFeeStore;
   const id = newCoreOp.id;
   // This split comes from the code in src/families/cosmos/libcore-buildOperation.js
-  const txHash = id.split("-")[1];
+  const txHash = newCoreOp.hash;
   const index = newCoreOp.extra.id;
   if (!(txHash in result.ops)) {
     result.ops[txHash] = [];


### PR DESCRIPTION
The Fees aren't included in the operations list given by Ledger Live
Common. A fold is accomplished over the list of transactions given by
LibCore that includes the fees in all the other operations that match
the transaction Hash, and therefore the fees operations can be ignored
in the end result.