### PR TITLE
[cosmos] Fetch sequenceNumber from explorer always

### DIFF
--- a/src/families/cosmos/libcore-buildTransaction.js
+++ b/src/families/cosmos/libcore-buildTransaction.js
@@ -13,6 +13,15 @@ import { getEnv } from "../../env";
 import { promiseAllBatched } from "../../promise";
 import { getMaxEstimatedBalance } from "./logic";
 
+async function fetch(url: string) {
+  const { data } = await network({
+    method: "GET",
+    url,
+  });
+
+  return data.result;
+}
+
 export async function cosmosBuildTransaction({
   account,
   core,
@@ -103,7 +112,10 @@ export async function cosmosBuildTransaction({
   );
 
   // Signature information
-  const seq = await cosmosLikeAccount.getSequence();
+  const accountData = await fetch(
+    `${getBaseApiUrl()}/auth/accounts/${account.freshAddress}`
+  );
+  const seq = accountData.value.sequence;
   const accNum = await cosmosLikeAccount.getAccountNumber();
 
   await transactionBuilder.setAccountNumber(accNum);

--- a/src/families/cosmos/libcore-buildTransaction.js
+++ b/src/families/cosmos/libcore-buildTransaction.js
@@ -12,6 +12,10 @@ import { cosmosCreateMessage } from "./message";
 import { getEnv } from "../../env";
 import { promiseAllBatched } from "../../promise";
 import { getMaxEstimatedBalance } from "./logic";
+import network from "../../network";
+
+const getBaseApiUrl = () =>
+  getEnv("API_COSMOS_BLOCKCHAIN_EXPLORER_API_ENDPOINT");
 
 async function fetch(url: string) {
   const { data } = await network({


### PR DESCRIPTION
This means that consecutive transaction won't fail with "Unauthorized signature" until next full account synchronization.

Sister PR : https://github.com/LedgerHQ/lib-ledger-core/pull/597