### PR TITLE
(csms): amount required on send flow error issue

### DIFF
--- a/src/families/cosmos/bridge/libcore.js
+++ b/src/families/cosmos/bridge/libcore.js
@@ -130,7 +130,7 @@ const getSendTransactionStatus = async (a, t) => {
 
   let amount = t.amount;
 
-  if (amount.lte(0) && t.useAllAmount !== true) {
+  if (amount.lte(0)) {
     errors.amount = new AmountRequired();
   }
 


### PR DESCRIPTION
Issue on send amountRequired error not activating in the case of a useAllAmount and no spendable balance available.