### PR TITLE
LL-2774 fix pending operation ordering

### DIFF
--- a/src/account/pending.js
+++ b/src/account/pending.js
@@ -25,7 +25,7 @@ const appendPendingOp = (ops: Operation[], op: Operation) => {
   const filtered: Operation[] = ops.filter(
     (o) => o.transactionSequenceNumber === op.transactionSequenceNumber
   );
-  filtered.push(op);
+  filtered.unshift(op);
   return filtered;
 };
 


### PR DESCRIPTION
Adding two or more operations will result in the oldest one showing above the newer one, this addresses the issue. It will **not** order already existing pending operations but it will address future pending operations.

### Example of wrong behaviour
<img width="1742" alt="Screenshot 2020-06-16 at 15 46 47" src="https://user-images.githubusercontent.com/4631227/84785422-c37ac600-afeb-11ea-91f3-ac214694f4ea.png">

### Type

Bug Fix

### Context

https://ledgerhq.atlassian.net/browse/LL-2774

### Parts of the app affected / Test plan

Cast two vote operations (or any other operation) on a different branch and see that the last one appears with wrong sorting, below the first one. Move to this branch and see that multiple pending operations will appear correctly sorted.