### PR TITLE
[cosmos] Change broadcast mode from block to sync

### DIFF
--- a/src/families/cosmos/libcore-signOperation.js
+++ b/src/families/cosmos/libcore-signOperation.js
@@ -34,7 +34,7 @@ async function signTransaction({
   //        "block"(return after tx commit), (https://docs.cosmos.network/master/basics/tx-lifecycle.html#commit)
   //        "sync"(return afer CheckTx), (https://docs.cosmos.network/master/basics/tx-lifecycle.html#types-of-checks) and
   //        "async"(return right away).
-  const hex = await coreTransaction.serializeForBroadcast("block");
+  const hex = await coreTransaction.serializeForBroadcast("sync");
 
   if (isCancelled()) return;
 


### PR DESCRIPTION
This change has been tested on LedgerLiveBot and doesn't trigger any
issues regarding synchronizing and optimistic updates / finding the
operations.

This change, as stated by the comment above the patch, moves the
broadcast call to "intermediate" level of blocking. It basically returns
just before the transaction enters the mempool, but the backend node
will still verify the transaction in a stateless manner and send an
error if anything wrong happens.

It is done to mitigate the "RPC timeout issues" we might encounter