### PR TITLE
Disable rounding for amounts in cosmos tx fields

### DIFF
--- a/src/families/cosmos/deviceTransactionConfig.js
+++ b/src/families/cosmos/deviceTransactionConfig.js
@@ -28,6 +28,7 @@ const getSendFields = (transaction, status, account, source) => {
       label: "Amount",
       value: formatCurrencyUnit(getAccountUnit(account), amount, {
         showCode: true,
+        disableRounding: true,
       }),
     });
   }
@@ -91,6 +92,7 @@ function getDeviceTransactionConfig({
           validators[0].amount,
           {
             showCode: true,
+            disableRounding: true,
           }
         ),
       });
@@ -114,6 +116,7 @@ function getDeviceTransactionConfig({
           validators[0].amount,
           {
             showCode: true,
+            disableRounding: true,
           }
         ),
       });


### PR DESCRIPTION
Let's just make sure that every amount related filed uses similar formatting options in the future release.