### PR TITLE
bot: transaction to return a { transaction, updates }

### DIFF
--- a/mobile-test-app/package.json
+++ b/mobile-test-app/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@ledgerhq/errors": "^5.15.0",
-    "@ledgerhq/live-common": "^12.31.1",
-    "@ledgerhq/react-native-ledger-core": "^4.12.2",
+    "@ledgerhq/live-common": "^12.33.2",
+    "@ledgerhq/react-native-ledger-core": "^4.12.3",
     "@tradle/react-native-http": "^2.0.1",
     "assert": "^2.0.0",
     "axios": "^0.19.2",

--- a/mobile-test-app/yarn.lock
+++ b/mobile-test-app/yarn.lock
@@ -852,10 +852,10 @@
     "@ledgerhq/errors" "^5.15.0"
     events "^3.1.0"
 
-"@ledgerhq/live-common@^12.31.1":
-  version "12.31.1"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.31.1.tgz#3ade3bc0e340edb0f437a930b651d4b8e4224253"
-  integrity sha512-c2LGgGfuEHLFLgbyxibmfVkLGSfg0HfKTOSfLt4oIqPHpRLfOEQQ1fm7up8XH6IvPymNTpyqYPWAN8QDKZz1lg==
+"@ledgerhq/live-common@^12.33.2":
+  version "12.33.2"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/live-common/-/live-common-12.33.2.tgz#f1114683faa4c010a8999b07a0d49418be551567"
+  integrity sha512-wIe4dF6vkJSJMwjG3WEmReLXFYS+0RnTwH9H2yToUYRwWleqOwSp+/1PcdhRXojxK+KaizTw3KBnJ5Vpu0qUMQ==
   dependencies:
     "@ledgerhq/compressjs" "1.3.2"
     "@ledgerhq/devices" "5.15.0"
@@ -901,10 +901,10 @@
   resolved "https://registry.yarnpkg.com/@ledgerhq/logs/-/logs-5.15.0.tgz#870524ade408b50ce74971509aa170e9d85c0575"
   integrity sha512-QuAva3K3YFDtQidi8xAfOQcb+aExJus3p0GhPNscOE+r152klBdiZUHLp818zEeQZT7PRSm83gEknmeUYjGU9A==
 
-"@ledgerhq/react-native-ledger-core@^4.12.2":
-  version "4.12.2"
-  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.12.2.tgz#e90caee79ca51f041044f6d406d1523e4469ed0c"
-  integrity sha512-Rp+e44aULoqWAI8CZqaZeEirhOyT/NmO7mqMr7FwR3b7W18TUyYauThc5Zw7187KCHvZGNpdSNX8/+u1pX16BQ==
+"@ledgerhq/react-native-ledger-core@^4.12.3":
+  version "4.12.3"
+  resolved "https://registry.yarnpkg.com/@ledgerhq/react-native-ledger-core/-/react-native-ledger-core-4.12.3.tgz#f8bfa0772a42a9e49cdb42feb92a096809feeda2"
+  integrity sha512-gls4GIUm6skjHKYM6Y25G2XQd89/bSgoMjPowL/TgFkWeZSMV/Qbkm9T/4+jdG+L1dLFFSCrBivWmMHhXyutLQ==
 
 "@react-native-community/cli-debugger-ui@^3.0.0":
   version "3.0.0"

--- a/src/bot/types.js
+++ b/src/bot/types.js
@@ -45,9 +45,11 @@ export type TransactionArg<T> = {
   siblings: Account[],
   bridge: AccountBridge<T>,
   maxSpendable: BigNumber,
-  createTransaction: (Account) => T,
-  // if called, it will "record" intermediary txs to simulate user filling up the form incrementally
-  updateTransaction: (tx: T, patch?: $Shape<T>) => T,
+};
+
+export type TransactionRes<T> = {
+  transaction: T,
+  updates: Array<?$Shape<T>>,
 };
 
 export type MutationSpec<T: Transaction> = {
@@ -56,7 +58,8 @@ export type MutationSpec<T: Transaction> = {
   // The maximum number of times to execute this mutation for a given test run
   maxRun?: number,
   // Express the transaction to be done
-  transaction: (arg: TransactionArg<T>) => ?T,
+  // it returns either a transaction T, or an array with T and a list of patch to apply to it
+  transaction: (arg: TransactionArg<T>) => TransactionRes<T>,
   // if there is a status errors/warnings of the defined transaction, this function, if define, can try to recover from it
   recoverBadTransactionStatus?: ({
     transaction: T,

--- a/src/families/bitcoin/specs.js
+++ b/src/families/bitcoin/specs.js
@@ -50,21 +50,15 @@ const bitcoinLikeMutations = ({
   {
     name: "move ~50% to another account",
     maxRun: 2,
-    transaction: ({
-      account,
-      siblings,
-      createTransaction,
-      updateTransaction,
-      maxSpendable,
-    }) => {
+    transaction: ({ account, siblings, bridge, maxSpendable }) => {
       invariant(maxSpendable.gt(minimalAmount), "balance is too low");
-      let t = createTransaction(account);
       const sibling = pickSiblings(siblings, targetAccountSize);
       const recipient = sibling.freshAddress;
       const amount = maxSpendable.div(1.9 + 0.2 * Math.random()).integerValue();
-      t = updateTransaction(t, { recipient });
-      t = updateTransaction(t, { amount });
-      return t;
+      return {
+        transaction: bridge.createTransaction(account),
+        updates: [{ recipient }, { amount }],
+      };
     },
     recoverBadTransactionStatus,
     test: ({ account, accountBeforeTransaction, operation }) => {
@@ -82,20 +76,14 @@ const bitcoinLikeMutations = ({
   {
     name: "send max to another account",
     maxRun: 1,
-    transaction: ({
-      account,
-      siblings,
-      createTransaction,
-      updateTransaction,
-      maxSpendable,
-    }) => {
+    transaction: ({ account, siblings, bridge, maxSpendable }) => {
       invariant(maxSpendable.gt(minimalAmount), "balance is too low");
-      let t = createTransaction(account);
       const sibling = pickSiblings(siblings, targetAccountSize);
       const recipient = sibling.freshAddress;
-      t = updateTransaction(t, { recipient });
-      t = updateTransaction(t, { useAllAmount: true });
-      return t;
+      return {
+        transaction: bridge.createTransaction(account),
+        updates: [{ recipient }, { useAllAmount: true }],
+      };
     },
     recoverBadTransactionStatus,
     test: ({ account, operation }) => {

--- a/src/families/cosmos/specs.js
+++ b/src/families/cosmos/specs.js
@@ -51,24 +51,15 @@ const cosmos: AppSpec<Transaction> = {
     {
       name: "send some to another account",
       maxRun: 5,
-      transaction: ({
-        account,
-        siblings,
-        createTransaction,
-        maxSpendable,
-        updateTransaction,
-      }) => {
-        let t = createTransaction(account);
-        t = updateTransaction(t, {
-          recipient: pickSiblings(siblings, 30).freshAddress,
-        });
-        t = updateTransaction(t, {
-          amount: maxSpendable.div(2).integerValue(),
-        });
-        if (Math.random() < 0.5) {
-          t = updateTransaction(t, { memo: "LedgerLiveBot" });
-        }
-        return t;
+      transaction: ({ account, siblings, bridge, maxSpendable }) => {
+        return {
+          transaction: bridge.createTransaction(account),
+          updates: [
+            { recipient: pickSiblings(siblings, 30).freshAddress },
+            { amount: maxSpendable.div(2).integerValue() },
+            Math.random() < 0.5 ? { memo: "LedgerLiveBot" } : null,
+          ],
+        };
       },
       test: ({ account, accountBeforeTransaction, status, transaction }) => {
         expect(account.operations.length).toBe(
@@ -95,18 +86,16 @@ const cosmos: AppSpec<Transaction> = {
     {
       name: "send max to another account",
       maxRun: 1,
-      transaction: ({
-        account,
-        siblings,
-        createTransaction,
-        updateTransaction,
-      }) => {
-        let t = createTransaction(account);
-        t = updateTransaction(t, {
-          recipient: pickSiblings(siblings, 30).freshAddress,
-        });
-        t = updateTransaction(t, { useAllAmount: true });
-        return t;
+      transaction: ({ account, siblings, bridge }) => {
+        return {
+          transaction: bridge.createTransaction(account),
+          updates: [
+            {
+              recipient: pickSiblings(siblings, 30).freshAddress,
+            },
+            { useAllAmount: true },
+          ],
+        };
       },
       test: ({ account }) => {
         expect(account.spendableBalance.toString()).toBe("0");
@@ -116,7 +105,7 @@ const cosmos: AppSpec<Transaction> = {
     {
       name: "delegate new validators",
       maxRun: 3,
-      transaction: ({ account, createTransaction, updateTransaction }) => {
+      transaction: ({ account, bridge }) => {
         invariant(
           account.index % 10 > 0,
           "one out of 10 accounts is not going to delegate"
@@ -154,15 +143,18 @@ const cosmos: AppSpec<Transaction> = {
           })
           .filter((v) => v.amount.gt(0));
         invariant(validators.length > 0, "no possible delegation found");
-        let t = createTransaction(account);
-        t = updateTransaction(t, {
-          memo: "LedgerLiveBot",
-          mode: "delegate",
-        });
-        validators.forEach((_, i) => {
-          t = updateTransaction(t, { validators: validators.slice(0, i + 1) });
-        });
-        return t;
+        return {
+          transaction: bridge.createTransaction(account),
+          updates: [
+            {
+              memo: "LedgerLiveBot",
+              mode: "delegate",
+            },
+            ...validators.map((_, i) => ({
+              validators: validators.slice(0, i + 1),
+            })),
+          ],
+        };
       },
       test: ({ account, transaction }) => {
         const { cosmosResources } = account;
@@ -186,7 +178,7 @@ const cosmos: AppSpec<Transaction> = {
     {
       name: "undelegate",
       maxRun: 2,
-      transaction: ({ account, createTransaction, updateTransaction }) => {
+      transaction: ({ account, bridge }) => {
         invariant(canUndelegate(account), "can undelegate");
         const { cosmosResources } = account;
         invariant(cosmosResources, "cosmos");
@@ -208,23 +200,26 @@ const cosmos: AppSpec<Transaction> = {
           )
         );
         invariant(undelegateCandidate, "already pending");
-        let t = createTransaction(account);
-        t = updateTransaction(t, {
-          mode: "undelegate",
-          memo: "LedgerLiveBot",
-        });
-        t = updateTransaction(t, {
-          validators: [
+        return {
+          transaction: bridge.createTransaction(account),
+          updates: [
             {
-              address: undelegateCandidate.validatorAddress,
-              amount: undelegateCandidate.amount
-                // most of the time, undelegate all
-                .times(Math.random() > 0.3 ? 1 : Math.random())
-                .integerValue(),
+              mode: "undelegate",
+              memo: "LedgerLiveBot",
+            },
+            {
+              validators: [
+                {
+                  address: undelegateCandidate.validatorAddress,
+                  amount: undelegateCandidate.amount
+                    // most of the time, undelegate all
+                    .times(Math.random() > 0.3 ? 1 : Math.random())
+                    .integerValue(),
+                },
+              ],
             },
           ],
-        });
-        return t;
+        };
       },
       test: ({ account, transaction }) => {
         const { cosmosResources } = account;
@@ -248,7 +243,7 @@ const cosmos: AppSpec<Transaction> = {
     {
       name: "redelegate",
       maxRun: 2,
-      transaction: ({ account, createTransaction, updateTransaction }) => {
+      transaction: ({ account, bridge }) => {
         const { cosmosResources } = account;
         invariant(cosmosResources, "cosmos");
         const sourceDelegation = sample(
@@ -260,26 +255,29 @@ const cosmos: AppSpec<Transaction> = {
             (d) => d.validatorAddress !== sourceDelegation.validatorAddress
           )
         );
-        let t = createTransaction(account);
-        t = updateTransaction(t, {
-          mode: "redelegate",
-          memo: "LedgerLiveBot",
-          cosmosSourceValidator: sourceDelegation.validatorAddress,
-        });
-        t = updateTransaction(t, {
-          validators: [
+        return {
+          transaction: bridge.createTransaction(account),
+          updates: [
             {
-              address: delegation.validatorAddress,
-              amount: sourceDelegation.amount
-                .times(
-                  // most of the time redelegate all
-                  Math.random() > 0.3 ? 1 : Math.random()
-                )
-                .integerValue(),
+              mode: "redelegate",
+              memo: "LedgerLiveBot",
+              cosmosSourceValidator: sourceDelegation.validatorAddress,
+            },
+            {
+              validators: [
+                {
+                  address: delegation.validatorAddress,
+                  amount: sourceDelegation.amount
+                    .times(
+                      // most of the time redelegate all
+                      Math.random() > 0.3 ? 1 : Math.random()
+                    )
+                    .integerValue(),
+                },
+              ],
             },
           ],
-        });
-        return t;
+        };
       },
       test: ({ account, transaction }) => {
         const { cosmosResources } = account;
@@ -303,25 +301,28 @@ const cosmos: AppSpec<Transaction> = {
     {
       name: "claim rewards",
       maxRun: 2,
-      transaction: ({ account, createTransaction, updateTransaction }) => {
+      transaction: ({ account, bridge }) => {
         const { cosmosResources } = account;
         invariant(cosmosResources, "cosmos");
         const delegation = sample(
           cosmosResources.delegations.filter((d) => canClaimRewards(account, d))
         );
         invariant(delegation, "no delegation to claim");
-        let t = createTransaction(account);
-        t = updateTransaction(t, {
-          mode: "claimReward",
-          memo: "LedgerLiveBot",
-          validators: [
+        return {
+          transaction: bridge.createTransaction(account),
+          updates: [
             {
-              address: delegation.validatorAddress,
-              amount: delegation.pendingRewards,
+              mode: "claimReward",
+              memo: "LedgerLiveBot",
+              validators: [
+                {
+                  address: delegation.validatorAddress,
+                  amount: delegation.pendingRewards,
+                },
+              ],
             },
           ],
-        });
-        return t;
+        };
       },
       test: ({ account, transaction, operation }) => {
         const { cosmosResources } = account;

--- a/src/families/cosmos/specs.js
+++ b/src/families/cosmos/specs.js
@@ -305,7 +305,9 @@ const cosmos: AppSpec<Transaction> = {
         const { cosmosResources } = account;
         invariant(cosmosResources, "cosmos");
         const delegation = sample(
-          cosmosResources.delegations.filter((d) => canClaimRewards(account, d))
+          cosmosResources.delegations.filter(
+            (d) => canClaimRewards(account, d) && d.pendingRewards.gt(2000)
+          )
         );
         invariant(delegation, "no delegation to claim");
         return {
@@ -324,13 +326,9 @@ const cosmos: AppSpec<Transaction> = {
           ],
         };
       },
-      test: ({ account, transaction, operation }) => {
+      test: ({ account, transaction }) => {
         const { cosmosResources } = account;
         invariant(cosmosResources, "cosmos");
-        invariant(
-          Date.now() - operation.date > 20000,
-          "enough time has passed to assert no longer claimable"
-        );
         transaction.validators.forEach((v) => {
           const d = cosmosResources.delegations.find(
             (d) => d.validatorAddress === v.address


### PR DESCRIPTION
In light of recent bugs, we need to improve the type of a AppSpec transaction function:

instead of building up a transaction like this:

```
transaction: ({ account, siblings, createTransaction, maxSpendable, updateTransaction, }) => {
        let t = createTransaction(account);
        const sibling = pickSiblings(siblings, 30);
        const recipient = sibling.freshAddress;
        const amount = maxSpendable.div(2).integerValue();
        t = updateTransaction(t, { recipient });
        t = updateTransaction(t, { amount });
        if (Math.random() < 0.5) {
          t = updateTransaction(t, { memo: "LedgerLiveBot" });
        }
        return t;
      }
```

we will essentially make this function this:

```
{ transaction: bridge.createTransaction(amount),
  updates: [ {recipient}, {amount}, {memo} ] }
```

that way we can effectively implement a replay mecanism of the incremental "updateTransaction" and "prepareTransaction" that would happen in normal phases of LLD.