### PR TITLE
Bitcoin model to include some coin control features

### DIFF
--- a/cli/src/commands/estimateMaxSpendable.js
+++ b/cli/src/commands/estimateMaxSpendable.js
@@ -14,8 +14,11 @@ import type { ScanCommonOpts } from "../scan";
 const format = (account, value) => {
   const unit = getAccountUnit(account);
   const name = getAccountName(account);
-  const amount = formatCurrencyUnit(unit, value, { showCode: true });
-  return `${name} can spend ${amount}`;
+  const amount = formatCurrencyUnit(unit, value, {
+    showCode: true,
+    disableRounding: true,
+  });
+  return `${name}: ${amount}`;
 };
 
 export default {

--- a/src/account/serialization.js
+++ b/src/account/serialization.js
@@ -20,6 +20,10 @@ import type {
 } from "../types";
 import type { TronResources, TronResourcesRaw } from "../families/tron/types";
 import {
+  toBitcoinResourcesRaw,
+  fromBitcoinResourcesRaw,
+} from "../families/bitcoin/serialization";
+import {
   toCosmosResourcesRaw,
   fromCosmosResourcesRaw,
 } from "../families/cosmos/serialization";
@@ -30,6 +34,7 @@ import {
 } from "../currencies";
 
 export { toCosmosResourcesRaw, fromCosmosResourcesRaw };
+export { toBitcoinResourcesRaw, fromBitcoinResourcesRaw };
 
 export function toBalanceHistoryRaw(b: BalanceHistory): BalanceHistoryRaw {
   return b.map(({ date, value }) => [date.toISOString(), value.toString()]);
@@ -477,6 +482,7 @@ export function fromAccountRaw(rawAccount: AccountRaw): Account {
     subAccounts: subAccountsRaw,
     tronResources,
     cosmosResources,
+    bitcoinResources,
   } = rawAccount;
 
   const subAccounts =
@@ -548,6 +554,10 @@ export function fromAccountRaw(rawAccount: AccountRaw): Account {
     res.cosmosResources = fromCosmosResourcesRaw(cosmosResources);
   }
 
+  if (bitcoinResources) {
+    res.bitcoinResources = fromBitcoinResourcesRaw(bitcoinResources);
+  }
+
   return res;
 }
 
@@ -577,6 +587,7 @@ export function toAccountRaw({
   endpointConfig,
   tronResources,
   cosmosResources,
+  bitcoinResources,
 }: Account): AccountRaw {
   const res: $Exact<AccountRaw> = {
     id,
@@ -616,6 +627,9 @@ export function toAccountRaw({
   }
   if (cosmosResources) {
     res.cosmosResources = toCosmosResourcesRaw(cosmosResources);
+  }
+  if (bitcoinResources) {
+    res.bitcoinResources = toBitcoinResourcesRaw(bitcoinResources);
   }
   return res;
 }

--- a/src/env.js
+++ b/src/env.js
@@ -92,6 +92,11 @@ const envDefinitions = {
     desc:
       "gasLimit * gasPrice to determine the fees price. A too low GAS_PRICE will get rejected before the transaction is broadcast",
   },
+  DEBUG_UTXO_DISPLAY: {
+    def: 4,
+    parser: intParser,
+    desc: "define maximum number of utxos to display in CLI",
+  },
   DEBUG_HTTP_RESPONSE: {
     def: false,
     parser: boolParser,

--- a/src/families/bitcoin/account.js
+++ b/src/families/bitcoin/account.js
@@ -1,0 +1,46 @@
+// @flow
+import type { Account } from "../../types";
+import type { BitcoinOutput, BitcoinInput } from "./types";
+import { formatCurrencyUnit } from "../../currencies";
+import { getEnv } from "../../env";
+
+const sortUTXO = (a, b) => b.value.minus(a.value).toNumber();
+
+export function formatInput(account: Account, input: BitcoinInput) {
+  return `${(input.value
+    ? formatCurrencyUnit(account.unit, input.value, {
+        showCode: false,
+      })
+    : ""
+  ).padEnd(12)} ${input.address || ""} ${input.previousTxHash || ""}@${
+    input.previousOutputIndex
+  }`;
+}
+
+export function formatOutput(account: Account, o: BitcoinOutput) {
+  return `${formatCurrencyUnit(account.unit, o.value, {
+    showCode: false,
+  }).padEnd(12)} ${o.address || ""} ${o.path || ""} ${o.hash}@${
+    o.outputIndex
+  } (${o.blockHeight ? account.blockHeight - o.blockHeight : 0})`;
+}
+
+function formatAccountSpecifics(account: Account): string {
+  if (!account.bitcoinResources) return "";
+  const { utxos } = account.bitcoinResources;
+  let str = `\n${utxos.length} UTXOs`;
+  const n = getEnv("DEBUG_UTXO_DISPLAY");
+  const displayAll = utxos.length <= n;
+  str += utxos
+    .slice(0)
+    .sort(sortUTXO)
+    .slice(0, displayAll ? utxos.length : n)
+    .map((utxo) => `\n${formatOutput(account, utxo)}`)
+    .join("");
+  if (!displayAll) {
+    str += "\n...";
+  }
+  return str;
+}
+
+export default { formatAccountSpecifics };

--- a/src/families/bitcoin/bridge/mock.js
+++ b/src/families/bitcoin/bridge/mock.js
@@ -27,6 +27,12 @@ const createTransaction = (): Transaction => ({
   feePerByte: BigNumber(10),
   networkInfo: null,
   useAllAmount: false,
+  rbf: false,
+  utxoStrategy: {
+    strategy: 0,
+    pickUnconfirmedRBF: false,
+    excludeUTXOs: [],
+  },
 });
 
 const updateTransaction = (t, patch) => ({ ...t, ...patch });

--- a/src/families/bitcoin/datasets/bitcoin.js
+++ b/src/families/bitcoin/datasets/bitcoin.js
@@ -32,6 +32,12 @@ const dataset: CurrenciesData<Transaction> = {
             amount: "999",
             feePerByte: "1",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             amount: BigNumber("999"),
@@ -52,6 +58,12 @@ const dataset: CurrenciesData<Transaction> = {
             amount: "998",
             feePerByte: "1",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             amount: BigNumber("998"),
@@ -72,6 +84,12 @@ const dataset: CurrenciesData<Transaction> = {
             amount: "997",
             feePerByte: "1",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             amount: BigNumber("997"),

--- a/src/families/bitcoin/datasets/digibyte.js
+++ b/src/families/bitcoin/datasets/digibyte.js
@@ -32,6 +32,12 @@ const dataset: CurrenciesData<Transaction> = {
             amount: "500000000",
             feePerByte: "1",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             amount: BigNumber("500000000"),
@@ -49,6 +55,12 @@ const dataset: CurrenciesData<Transaction> = {
             amount: "500000000",
             feePerByte: "1",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             amount: BigNumber("500000000"),
@@ -66,6 +78,12 @@ const dataset: CurrenciesData<Transaction> = {
             amount: "500000000",
             feePerByte: "1",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             amount: BigNumber("500000000"),

--- a/src/families/bitcoin/datasets/litecoin.js
+++ b/src/families/bitcoin/datasets/litecoin.js
@@ -33,6 +33,12 @@ const dataset: CurrenciesData<Transaction> = {
             family: "bitcoin",
             feePerByte: "39",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             errors: {},
@@ -51,6 +57,12 @@ const dataset: CurrenciesData<Transaction> = {
             family: "bitcoin",
             feePerByte: "39",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             errors: {},
@@ -69,6 +81,12 @@ const dataset: CurrenciesData<Transaction> = {
             family: "bitcoin",
             feePerByte: "39",
             networkInfo,
+            rbf: false,
+            utxoStrategy: {
+              strategy: 0,
+              pickUnconfirmedRBF: false,
+              excludeUTXOs: [],
+            },
           }),
           expectedStatus: {
             errors: {},

--- a/src/families/bitcoin/libcore-getFeesForTransaction.js
+++ b/src/families/bitcoin/libcore-getFeesForTransaction.js
@@ -3,6 +3,9 @@
 import { BigNumber } from "bignumber.js";
 import { libcoreAmountToBigNumber } from "../../libcore/buildBigNumber";
 import buildTransaction from "./libcore-buildTransaction";
+import { parseBitcoinOutput, parseBitcoinInput } from "./transaction";
+import { promiseAllBatched } from "../../promise";
+import type { BitcoinInput, BitcoinOutput } from "./types";
 
 async function bitcoin(arg: *) {
   const builded = await buildTransaction(arg);
@@ -14,7 +17,20 @@ async function bitcoin(arg: *) {
   const estimatedFees = await libcoreAmountToBigNumber(feesAmount);
   // TODO we don't have a getValue on bitcoin
   const value = BigNumber(0);
-  return { estimatedFees, value };
+  const inputs = await builded.getInputs();
+  const txInputs: BitcoinInput[] = await promiseAllBatched(
+    4,
+    inputs,
+    parseBitcoinInput
+  );
+  const outputs = await builded.getOutputs();
+  const txOutputs: BitcoinOutput[] = await promiseAllBatched(
+    4,
+    outputs,
+    parseBitcoinOutput
+  );
+
+  return { estimatedFees, value, txInputs, txOutputs };
 }
 
 export default bitcoin;

--- a/src/families/bitcoin/libcore-postBuildAccount.js
+++ b/src/families/bitcoin/libcore-postBuildAccount.js
@@ -1,0 +1,25 @@
+// @flow
+import { log } from "@ledgerhq/logs";
+import type { Account } from "../../types";
+import type { CoreAccount } from "../../libcore/types";
+import { promiseAllBatched } from "../../promise";
+import { parseBitcoinOutput } from "./transaction";
+
+const postBuildAccount = async ({
+  account,
+  coreAccount,
+}: {
+  account: Account,
+  coreAccount: CoreAccount,
+}): Promise<Account> => {
+  log("bitcoin/post-buildAccount", "bitcoinResources");
+  const bitcoinLikeAccount = await coreAccount.asBitcoinLikeAccount();
+  const count = await bitcoinLikeAccount.getUTXOCount();
+  const objects = await bitcoinLikeAccount.getUTXO(0, count);
+  const utxos = await promiseAllBatched(6, objects, parseBitcoinOutput);
+  account.bitcoinResources = { utxos };
+  log("bitcoin/post-buildAccount", "bitcoinResources DONE");
+  return account;
+};
+
+export default postBuildAccount;

--- a/src/families/bitcoin/serialization.js
+++ b/src/families/bitcoin/serialization.js
@@ -1,0 +1,95 @@
+// @flow
+
+import { BigNumber } from "bignumber.js";
+import type {
+  BitcoinResourcesRaw,
+  BitcoinResources,
+  BitcoinInputRaw,
+  BitcoinInput,
+  BitcoinOutputRaw,
+  BitcoinOutput,
+} from "./types";
+
+export function toBitcoinInputRaw({
+  address,
+  value,
+  previousTxHash,
+  previousOutputIndex,
+}: BitcoinInput): BitcoinInputRaw {
+  return [
+    address,
+    value ? value.toString() : undefined,
+    previousTxHash,
+    previousOutputIndex,
+  ];
+}
+
+export function fromBitcoinInputRaw([
+  address,
+  value,
+  previousTxHash,
+  previousOutputIndex,
+]: BitcoinInputRaw): BitcoinInput {
+  return {
+    address: address || undefined,
+    value: value ? BigNumber(value) : undefined,
+    previousTxHash: previousTxHash || undefined,
+    previousOutputIndex,
+  };
+}
+
+export function toBitcoinOutputRaw({
+  hash,
+  outputIndex,
+  blockHeight,
+  address,
+  path,
+  value,
+  rbf,
+}: BitcoinOutput): BitcoinOutputRaw {
+  return [
+    hash,
+    outputIndex,
+    blockHeight,
+    address,
+    path,
+    value.toString(),
+    Number(rbf),
+  ];
+}
+
+export function fromBitcoinOutputRaw([
+  hash,
+  outputIndex,
+  blockHeight,
+  address,
+  path,
+  value,
+  rbf,
+]: BitcoinOutputRaw): BitcoinOutput {
+  return {
+    hash,
+    outputIndex,
+    blockHeight: blockHeight || undefined,
+    address: address || undefined,
+    path: path || undefined,
+    value: BigNumber(value),
+    rbf: !!rbf,
+  };
+}
+
+export function toBitcoinResourcesRaw(
+  r: BitcoinResources
+): BitcoinResourcesRaw {
+  return {
+    utxos: r.utxos.map(toBitcoinOutputRaw),
+  };
+}
+
+export function fromBitcoinResourcesRaw(
+  r: BitcoinResourcesRaw
+): BitcoinResources {
+  return {
+    utxos: r.utxos.map(fromBitcoinOutputRaw),
+  };
+}

--- a/src/families/bitcoin/transaction.js
+++ b/src/families/bitcoin/transaction.js
@@ -5,6 +5,11 @@ import type {
   TransactionRaw,
   FeeItems,
   FeeItemsRaw,
+  BitcoinOutput,
+  UtxoStrategy,
+  CoreBitcoinLikeOutput,
+  CoreBitcoinLikeInput,
+  BitcoinInput,
 } from "./types";
 import type { Account } from "../../types";
 import {
@@ -13,6 +18,73 @@ import {
 } from "../../transaction/common";
 import { getAccountUnit } from "../../account";
 import { formatCurrencyUnit } from "../../currencies";
+import { libcoreAmountToBigNumber } from "../../libcore/buildBigNumber";
+
+export type UTXOStatus =
+  | {
+      excluded: true,
+      reason: "pickUnconfirmedRBF" | "userExclusion",
+    }
+  | {
+      excluded: false,
+    };
+
+export async function parseBitcoinInput(
+  input: CoreBitcoinLikeInput
+): Promise<BitcoinInput> {
+  const address = await input.getAddress();
+  const rawValue = await input.getValue();
+  const value = rawValue ? await libcoreAmountToBigNumber(rawValue) : null;
+  const previousTxHash = await input.getPreviousTxHash();
+  const previousOutputIndex = await input.getPreviousOutputIndex();
+  return { address, value, previousTxHash, previousOutputIndex };
+}
+
+export async function parseBitcoinOutput(
+  output: CoreBitcoinLikeOutput
+): Promise<BitcoinOutput> {
+  let blockHeight = await output.getBlockHeight();
+  if (!blockHeight || blockHeight < 0) {
+    blockHeight = undefined;
+  }
+  const hash = await output.getTransactionHash();
+  const outputIndex = await output.getOutputIndex();
+  const address = await output.getAddress();
+  const derivationPath = await output.getDerivationPath();
+  let path;
+  if (derivationPath) {
+    const isDerivationPathNull = await derivationPath.isNull();
+    if (!isDerivationPathNull) {
+      path = await derivationPath.toString();
+    }
+  }
+  const value = await libcoreAmountToBigNumber(await output.getValue());
+  const rbf = false; // FIXME
+  return { hash, outputIndex, blockHeight, address, path, value, rbf };
+}
+
+export function getUTXOStatus(
+  utxo: BitcoinOutput,
+  utxoStrategy: UtxoStrategy
+): UTXOStatus {
+  if (!utxoStrategy.pickUnconfirmedRBF && utxo.rbf && !utxo.blockHeight) {
+    return { excluded: true, reason: "pickUnconfirmedRBF" };
+  }
+  if (
+    utxoStrategy.excludeUTXOs.some(
+      (u) => u.hash === utxo.hash && u.outputIndex === utxo.outputIndex
+    )
+  ) {
+    return { excluded: true, reason: "userExclusion" };
+  }
+  return { excluded: false };
+}
+
+export function isChangeOutput(output: BitcoinOutput): boolean {
+  if (!output.path) return false;
+  const p = output.path.split("/");
+  return p[p.length - 2] === "1";
+}
 
 const fromFeeItemsRaw = (fir: FeeItemsRaw): FeeItems => ({
   items: fir.items.map((fi) => ({
@@ -36,6 +108,8 @@ export const fromTransactionRaw = (tr: TransactionRaw): Transaction => {
   const common = fromTransactionCommonRaw(tr);
   return {
     ...common,
+    rbf: tr.rbf,
+    utxoStrategy: tr.utxoStrategy,
     family: tr.family,
     feePerByte: tr.feePerByte ? BigNumber(tr.feePerByte) : null,
     networkInfo: tr.networkInfo && {
@@ -49,6 +123,8 @@ export const toTransactionRaw = (t: Transaction): TransactionRaw => {
   const common = toTransactionCommonRaw(t);
   return {
     ...common,
+    rbf: t.rbf,
+    utxoStrategy: t.utxoStrategy,
     family: t.family,
     feePerByte: t.feePerByte ? t.feePerByte.toString() : null,
     networkInfo: t.networkInfo && {

--- a/src/generated/account.js
+++ b/src/generated/account.js
@@ -1,6 +1,8 @@
 // @flow
+import bitcoin from "../families/bitcoin/account.js";
 import cosmos from "../families/cosmos/account.js";
 
 export default {
+  bitcoin,
   cosmos,
 };

--- a/src/generated/libcore-postBuildAccount.js
+++ b/src/generated/libcore-postBuildAccount.js
@@ -1,6 +1,8 @@
 // @flow
+import bitcoin from "../families/bitcoin/libcore-postBuildAccount.js";
 import cosmos from "../families/cosmos/libcore-postBuildAccount.js";
 
 export default {
+  bitcoin,
   cosmos,
 };

--- a/src/libcore/getFeesForTransaction.js
+++ b/src/libcore/getFeesForTransaction.js
@@ -6,6 +6,7 @@ import { withLibcoreF } from "./access";
 import { remapLibcoreErrors } from "./errors";
 import { getCoreAccount } from "./getCoreAccount";
 import byFamily from "../generated/libcore-getFeesForTransaction";
+import type { BitcoinInput, BitcoinOutput } from "../families/bitcoin/types";
 
 export type Input = {
   account: Account,
@@ -16,6 +17,8 @@ type F = (Input) => Promise<{
   estimatedFees: BigNumber,
   estimatedGas: ?BigNumber, // Note: Use in Cosmos
   value: BigNumber,
+  txInputs?: BitcoinInput[],
+  txOutputs?: BitcoinOutput[],
 }>;
 
 export const getFeesForTransaction: F = withLibcoreF(

--- a/src/libcore/syncAccount.js
+++ b/src/libcore/syncAccount.js
@@ -132,6 +132,7 @@ export function sync(
           shouldRetainPendingOperation(syncedAccount, op)
         ),
         cosmosResources: syncedAccount.cosmosResources,
+        bitcoinResources: syncedAccount.bitcoinResources,
       })
     )
   );

--- a/src/mock/account.js
+++ b/src/mock/account.js
@@ -371,6 +371,12 @@ export function genAccount(
     };
   }
 
+  if (currency.family === "bitcoin") {
+    account.bitcoinResources = {
+      utxos: [],
+    };
+  }
+
   if (["ethereum", "ethereum_ropsten", "tron"].includes(currency.id)) {
     const tokenCount =
       typeof opts.subAccountsCount === "number"

--- a/src/reconciliation.js
+++ b/src/reconciliation.js
@@ -19,6 +19,7 @@ import {
   fromSubAccountRaw,
   fromTronResourcesRaw,
   fromCosmosResourcesRaw,
+  fromBitcoinResourcesRaw,
   fromBalanceHistoryRawMap,
 } from "./account";
 
@@ -175,6 +176,18 @@ const shouldRefreshBalanceHistory = (
   );
 };
 
+function shouldRefreshBitcoinResources(updatedRaw, account) {
+  if (!updatedRaw.bitcoinResources) return false;
+  if (account.bitcoinResources === updatedRaw.bitcoinResources) return false;
+  if (!account.bitcoinResources) return true;
+  if (updatedRaw.blockHeight !== account.blockHeight) return true;
+  if (updatedRaw.operations.length !== account.operations.length) return true;
+  return (
+    updatedRaw.bitcoinResources.utxos.length !==
+    account.bitcoinResources.utxos.length
+  );
+}
+
 export function patchAccount(
   account: Account,
   updatedRaw: AccountRaw
@@ -302,6 +315,16 @@ export function patchAccount(
     account.cosmosResources !== updatedRaw.cosmosResources
   ) {
     next.cosmosResources = fromCosmosResourcesRaw(updatedRaw.cosmosResources);
+    changed = true;
+  }
+
+  if (
+    updatedRaw.bitcoinResources &&
+    shouldRefreshBitcoinResources(updatedRaw, account)
+  ) {
+    next.bitcoinResources = fromBitcoinResourcesRaw(
+      updatedRaw.bitcoinResources
+    );
     changed = true;
   }
 

--- a/src/types/account.js
+++ b/src/types/account.js
@@ -4,6 +4,10 @@ import type { BigNumber } from "bignumber.js";
 import type { CryptoCurrency, TokenCurrency, Unit } from "./currencies";
 import type { OperationRaw, Operation } from "./operation";
 import type { DerivationMode } from "../derivation";
+import type {
+  BitcoinResources,
+  BitcoinResourcesRaw,
+} from "../families/bitcoin/types";
 import type { TronResources, TronResourcesRaw } from "../families/tron/types";
 import type {
   CosmosResources,
@@ -167,6 +171,7 @@ export type Account = {
   balanceHistory?: BalanceHistoryMap,
 
   // On some blockchain, an account can have resources (gained, delegated, ...)
+  bitcoinResources?: BitcoinResources,
   tronResources?: TronResources,
   cosmosResources?: CosmosResources,
 };
@@ -234,6 +239,7 @@ export type AccountRaw = {
   endpointConfig?: ?string,
   subAccounts?: SubAccountRaw[],
   balanceHistory?: BalanceHistoryRawMap,
+  bitcoinResources?: BitcoinResourcesRaw,
   tronResources?: TronResourcesRaw,
   cosmosResources?: CosmosResourcesRaw,
 };

--- a/src/types/transaction.js
+++ b/src/types/transaction.js
@@ -2,6 +2,12 @@
 
 import type { BigNumber } from "bignumber.js";
 import type { Operation, OperationRaw } from "./operation";
+import type {
+  BitcoinInput,
+  BitcoinOutput,
+  BitcoinInputRaw,
+  BitcoinOutputRaw,
+} from "../families/bitcoin/types";
 
 export type SignedOperation = {|
   // prepared version of Operation before it's even broadcasted
@@ -70,6 +76,8 @@ export type TransactionStatus = {|
   totalSpent: BigNumber,
   // should the recipient be non editable
   recipientIsReadOnly?: boolean,
+  txInputs?: BitcoinInput[],
+  txOutputs?: BitcoinOutput[],
 |};
 
 export type TransactionStatusRaw = {|
@@ -80,4 +88,6 @@ export type TransactionStatusRaw = {|
   totalSpent: string,
   useAllAmount?: boolean,
   recipientIsReadOnly?: boolean,
+  txInputs?: BitcoinInputRaw[],
+  txOutputs?: BitcoinOutputRaw[],
 |};


### PR DESCRIPTION
## Changes

- transactions are no longer RBF enabled.
- by default, unconfirmed RBF are excluded.
- we have finer coin control.

## QA implications

- must carefully test bitcoin and its forks and especially Send flow. This is especially relevant as the total to spend / amount / error validation have changed its logic.
- use coin control feature as a way to test more transaction scenarios but don't test the feature itself, it's a dev only thing for now until we make it stable. (only consider testing what user will see with the checkbox)

## Type additions

- Bitcoin#bitcoinResources.utxos
- TransactionStatus#txInputs
- TransactionStatus#txOutputs
- Transaction#utxoStrategy

## CLI options

- transaction commands have a `--excludeUTXO, -E` that allows to exclude specific utxo (format is `hash@index`)
- transaction commands have a `--rbf` that allows to enable rbf
- transaction commands have a `--bitcoin-picking-strategy` that allows to change the picking strategy
- account formatter will display the utxo list, up to DEBUG_UTXO_DISPLAY items. (set to a low 4 at the moment)
- status formatter will display the inputs / outputs

## bot benefit the better formatting

```
▬ BitcoinTest 1.4.2 on nanoS 1.6.0
→ FROM Bitcoin Testnet 1 (segwit): 𝚝BTC 0.0025849 (97ops) (2Mvo6Xa4erKPVuia4mwV9gEe7X4KDdPswbk on 49'/1'/0'/0/43) segwit#0 tpubDCCwTfyqhTqVbrVhMeLb8SJ3ynshMXhRV3NBj911r1FFPEmNf42boJBT4gqVDzM2DAbiQXmDaostdX3Zui9sGj48KxEP8VF69Hv2Wxv4GnF
3 UTXOs
0.0015774    2N5MXVcB6ZyyvnzJru32T9RhUvdxN7iB2rj  6c7477f474169a94db9c5bcce2ee496c15d2876cab8867f6adbaac8a752b2dcf@0 (9)
0.0006482    2N2QEz3bC6juAgB1RWj6qLr3cEXtucwDazh  19d8e763afea50418cf8fd8366d1e055a31c28bff100e770b88ce0c02dbe7252@0 (83)
0.0003594    2NCGwJb68FoY5BVt2Ft3LwKhKbYaLFXj47N  06cfb75015e4b832fc46ba8f951f4a76ba0337cb91beef1a0bf548dc3715eb6b@1 (58)
max spendable ~0.0025535
★ using mutation 'move ~50%'
→ TO Bitcoin Testnet 2 (segwit): 𝚝BTC 0.006726 (74ops) (2MsbettPMD6sLcR8vxaWC6gSLxBFp8tjH54 on 49'/1'/1'/0/32) segwit#1 tpubDCCwTfyqhTqVf8mA1JG5CUdaoweqfjo8ZyhdxsiWKCNqQQtW788ihp5xMBekkMPw32Vg2JC9WWcUvGN7YLqXJuoH2FcEYg1XyoR5dD1hkri
✔️ transaction 
SEND 𝚝BTC 0.00123394
TO 2MsbettPMD6sLcR8vxaWC6gSLxBFp8tjH54
with feePerByte=10 (network fees: 0=10, 1=10, 2=1)
STATUS (2245ms)
  tx inputs:
0.0006482    2N2QEz3bC6juAgB1RWj6qLr3cEXtucwDazh 19d8e763afea50418cf8fd8366d1e055a31c28bff100e770b88ce0c02dbe7252@0
0.0003594    2NCGwJb68FoY5BVt2Ft3LwKhKbYaLFXj47N 06cfb75015e4b832fc46ba8f951f4a76ba0337cb91beef1a0bf548dc3715eb6b@1
0.0015774    2N5MXVcB6ZyyvnzJru32T9RhUvdxN7iB2rj 6c7477f474169a94db9c5bcce2ee496c15d2876cab8867f6adbaac8a752b2dcf@0
  tx outputs:
0.0012339    2MsbettPMD6sLcR8vxaWC6gSLxBFp8tjH54  @0 (1773506)
0.0013162    2N8TUdZktgpa9AfGiPEswETrK8CpbHun7E6 49'/1'/0'/1/39 @1 (1773506)
  amount: 𝚝BTC 0.0012339
  estimated fees: 𝚝BTC 0.0000348
  total spent: 𝚝BTC 0.0012687
✔️ has been signed! (11.7s) 
✔️ broadcasted! (4.1s) optimistic operation: 
  - 𝚝BTC 0.0012687  OUT        0ad269b2a2de6a30fea5c0da853dbe6747be98c4b0c2927e53fe65b90dbe2f4a 2020-06-24T20:49
✔️ operation confirmed (27.8s): 
  - 𝚝BTC 0.0012687  OUT        0ad269b2a2de6a30fea5c0da853dbe6747be98c4b0c2927e53fe65b90dbe2f4a 2020-06-24T20:49
✔️ Bitcoin Testnet 1 (segwit): 𝚝BTC 0.0013162 (98ops) (2Mvo6Xa4erKPVuia4mwV9gEe7X4KDdPswbk on 49'/1'/0'/0/43) segwit#0 tpubDCCwTfyqhTqVbrVhMeLb8SJ3ynshMXhRV3NBj911r1FFPEmNf42boJBT4gqVDzM2DAbiQXmDaostdX3Zui9sGj48KxEP8VF69Hv2Wxv4GnF
1 UTXOs
0.0013162    2N8TUdZktgpa9AfGiPEswETrK8CpbHun7E6  0ad269b2a2de6a30fea5c0da853dbe6747be98c4b0c2927e53fe65b90dbe2f4a@1 (1773506)
(final state reached in 27.8s)
```
