### PR TITLE
LL-2645 (Manager): add firmware unsupported helper

### DIFF
--- a/src/manager/index.js
+++ b/src/manager/index.js
@@ -66,6 +66,12 @@ const CacheAPI = {
   ): boolean =>
     deviceModel === "nanoS" && semver.lte(deviceInfo.version, "1.4.2"),
 
+  firmwareUnsupported: (
+    deviceModel: DeviceModelId,
+    deviceInfo: DeviceInfo
+  ): boolean =>
+    deviceModel === "nanoS" && semver.lt(deviceInfo.version, "1.3.0"),
+
   formatHashName: (
     input: string,
     // FIXME these will be made mandatory


### PR DESCRIPTION
Add function to check if firmware version is unsupported
 
currently applies to nanoS only on versions < 1.3.0