### PR TITLE
Make compatibleMCUForDeviceInfo to filter by provider

### DIFF
--- a/src/api/Manager.js
+++ b/src/api/Manager.js
@@ -149,12 +149,14 @@ const getMcus: () => Promise<*> = makeLRUCache(
 
 const compatibleMCUForDeviceInfo = (
   mcus: McuVersion[],
-  deviceInfo: DeviceInfo
+  deviceInfo: DeviceInfo,
+  provider: number
 ): McuVersion[] =>
   mcus.filter(
     (m) =>
-      deviceInfo.majMin === m.from_bootloader_version ||
-      deviceInfo.version === m.from_bootloader_version
+      (deviceInfo.majMin === m.from_bootloader_version ||
+        deviceInfo.version === m.from_bootloader_version) &&
+      m.providers.includes(provider)
   );
 
 const findBestMCU = (compatibleMCU: McuVersion[]) => {

--- a/src/hw/firmwareUpdate-repair.js
+++ b/src/hw/firmwareUpdate-repair.js
@@ -5,6 +5,7 @@ import { Observable, from, of, empty, concat, throwError } from "rxjs";
 import { concatMap, delay, filter, map, throttleTime } from "rxjs/operators";
 import ManagerAPI from "../api/Manager";
 import { withDevicePolling, withDevice } from "./deviceAccess";
+import { getProviderId } from "../manager/provider";
 import getDeviceInfo from "./getDeviceInfo";
 import {
   mcuOutdated,
@@ -86,7 +87,11 @@ const repair = (
             return from(mcusPromise).pipe(
               concatMap((mcus) => {
                 const next = ManagerAPI.findBestMCU(
-                  ManagerAPI.compatibleMCUForDeviceInfo(mcus, deviceInfo)
+                  ManagerAPI.compatibleMCUForDeviceInfo(
+                    mcus,
+                    deviceInfo,
+                    getProviderId(deviceInfo)
+                  )
                 );
                 if (next) return installMcu(next.name);
                 return empty();


### PR DESCRIPTION
an issue in our "select a mcu to install" logic was found: Live can possibly select a MCU to install that is still in staging provider.

This logic is involved both when flashing the firmware (limited because we still pick one of `finalFirmware.mcu_versions`) and when repairing (on that case, we select the highest version that is compatible with the current bootloader version via `from_bootloader_version`).

The fix of this PR involves always filtering the provider (according to the same logic used at other places to determine that provider)