### PR TITLE
Ctrl+C to kill process if done after 3s again

### DIFF
--- a/cli/src/cli.ts
+++ b/cli/src/cli.ts
@@ -101,6 +101,15 @@ from(cmd.job(options)).subscribe({
   },
 });
 
+let sigIntSent;
 process.on("SIGINT", () => {
-  closeAllDevices();
+  if (!sigIntSent) {
+    sigIntSent = Date.now();
+    closeAllDevices();
+  } else {
+    if (Date.now() - sigIntSent > 3000) {
+      console.error("was not able to terminate gracefully. exiting");
+      process.exit(1);
+    }
+  }
 });


### PR DESCRIPTION
some transports fails to properly terminate which makes the CLI hanging forever even if you do Ctrl+C.

this allows to send a second Ctrl+C 3 seconds after to close the process regardless of if it was gracefully exited.

<img width="465" alt="Capture d’écran 2020-07-07 à 09 39 35" src="https://user-images.githubusercontent.com/211411/86739257-0998d780-c036-11ea-8a03-74bdaf447a2a.png">
