### PR TITLE
experimental polling of actions/app.js

### DIFF
--- a/src/hw/actions/app.js
+++ b/src/hw/actions/app.js
@@ -113,6 +113,7 @@ const reducer = (state: State, e: Event): State => {
     case "error":
       return {
         ...getInitialState(e.device),
+        device: e.device || null,
         error: e.error,
         isLoading: false,
       };

--- a/src/hw/actions/app.js
+++ b/src/hw/actions/app.js
@@ -120,28 +120,67 @@ const reducer = (state: State, e: Event): State => {
 
     case "ask-open-app":
       return {
-        ...state,
+        isLoading: false,
+        requestQuitApp: false,
+        requiresAppInstallation: null,
+        allowOpeningRequestedWording: null,
+        allowOpeningGranted: false,
+        device: state.device,
+        opened: false,
+        appAndVersion: null,
+        error: null,
+        derivation: null,
+        displayUpgradeWarning: false,
         unresponsive: false,
         requestOpenApp: e.appName,
       };
 
     case "ask-quit-app":
       return {
-        ...state,
+        isLoading: false,
+        requestOpenApp: null,
+        requiresAppInstallation: null,
+        allowOpeningRequestedWording: null,
+        allowOpeningGranted: false,
+        device: state.device,
+        opened: false,
+        appAndVersion: null,
+        error: null,
+        derivation: null,
+        displayUpgradeWarning: false,
         unresponsive: false,
         requestQuitApp: true,
       };
 
     case "device-permission-requested":
       return {
-        ...state,
+        isLoading: false,
+        requestQuitApp: false,
+        requestOpenApp: null,
+        requiresAppInstallation: null,
+        allowOpeningGranted: false,
+        device: state.device,
+        opened: false,
+        appAndVersion: null,
+        error: null,
+        derivation: null,
+        displayUpgradeWarning: false,
         unresponsive: false,
         allowOpeningRequestedWording: e.wording,
       };
 
     case "device-permission-granted":
       return {
-        ...state,
+        isLoading: false,
+        requestQuitApp: false,
+        requestOpenApp: null,
+        requiresAppInstallation: null,
+        device: state.device,
+        opened: false,
+        appAndVersion: null,
+        error: null,
+        derivation: null,
+        displayUpgradeWarning: false,
         unresponsive: false,
         allowOpeningRequestedWording: null,
         allowOpeningGranted: true,
@@ -149,7 +188,15 @@ const reducer = (state: State, e: Event): State => {
 
     case "app-not-installed":
       return {
-        ...state,
+        requestQuitApp: false,
+        requestOpenApp: null,
+        allowOpeningGranted: false,
+        device: state.device,
+        opened: false,
+        appAndVersion: null,
+        error: null,
+        derivation: null,
+        displayUpgradeWarning: false,
         isLoading: false,
         unresponsive: false,
         allowOpeningRequestedWording: null,
@@ -158,7 +205,13 @@ const reducer = (state: State, e: Event): State => {
 
     case "opened":
       return {
-        ...state,
+        requestQuitApp: false,
+        requestOpenApp: null,
+        requiresAppInstallation: null,
+        allowOpeningRequestedWording: null,
+        allowOpeningGranted: false,
+        device: state.device,
+        error: null,
         isLoading: false,
         unresponsive: false,
         opened: true,

--- a/src/hw/actions/app.js
+++ b/src/hw/actions/app.js
@@ -67,7 +67,7 @@ export type AppResult = {|
 type AppAction = Action<AppRequest, AppState, AppResult>;
 
 type Event =
-  | { type: "error", error: Error }
+  | { type: "error", error: Error, device?: ?Device }
   | { type: "deviceChange", device: ?Device }
   | ConnectAppEvent
   | { type: "display-upgrade-warning", displayUpgradeWarning: boolean };
@@ -112,7 +112,7 @@ const reducer = (state: State, e: Event): State => {
 
     case "error":
       return {
-        ...getInitialState(),
+        ...getInitialState(e.device),
         error: e.error,
         isLoading: false,
       };
@@ -251,7 +251,11 @@ const implementations = {
         }
         connectSub = connectApp(device, params).subscribe({
           next: (event) => {
-            o.next(event);
+            if (event.type === "error") {
+              o.next({ ...event, device });
+            } else {
+              o.next(event);
+            }
           },
           complete: () => {
             timeout = setTimeout(loop, POLLING);


### PR DESCRIPTION
- Introduces two different implementation for actions/app : one that is event based, the second that is polling based. at the moment we do the switch GLOBALLY, but in practice event based is for node-hid et polling based is for when we don't have usb events (like on bluetooth or mobile hid)
- Makes the actions/app no longer active when it have landed once into the "opened" state. This might fixes situation when we rarely saw a "double transaction" problem, but also will help ongoing development.

---

to be used with the device actions mobile poc.

```
import { setDeviceMode } from "@ledgerhq/live-common/lib/hw/actions/app";
setDeviceMode("polling");
```


---

**NB: we will need to do the same for actions/manager.js** and there is no easy factorization.