### PR TITLE
Fixes connectManager to handle DeviceOnDashboardExpected case

### DIFF
--- a/src/hw/connectManager.js
+++ b/src/hw/connectManager.js
@@ -2,7 +2,10 @@
 
 import { Observable, concat, from, of, throwError } from "rxjs";
 import { concatMap, catchError, delay } from "rxjs/operators";
-import { TransportStatusError } from "@ledgerhq/errors";
+import {
+  TransportStatusError,
+  DeviceOnDashboardExpected,
+} from "@ledgerhq/errors";
 import type { DeviceInfo } from "../types/manager";
 import type { ListAppsEvent } from "../apps";
 import { listApps } from "../apps/hw";
@@ -48,9 +51,10 @@ const cmd = ({ devicePath }: Input): Observable<ConnectManagerEvent> =>
           }),
           catchError((e: Error) => {
             if (
-              e &&
-              e instanceof TransportStatusError &&
-              [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode)
+              e instanceof DeviceOnDashboardExpected ||
+              (e &&
+                e instanceof TransportStatusError &&
+                [0x6e00, 0x6d00, 0x6e01, 0x6d01, 0x6d02].includes(e.statusCode))
             ) {
               return of({ type: "appDetected" });
             }


### PR DESCRIPTION
small regression that was showing this:

<img width="1136" alt="Capture d’écran 2020-07-20 à 18 22 42" src="https://user-images.githubusercontent.com/211411/87961956-c1a69580-cab6-11ea-8a77-8dbf45eaf197.png">

instead of **"Quit App"** asset.
