### PR TITLE
feat: send trc20 to smart contract

### DIFF
--- a/src/api/Tron.js
+++ b/src/api/Tron.js
@@ -271,14 +271,21 @@ export async function fetchTronAccountTxs(
 export const getContractUserEnergyRatioConsumption = async (
   address: string
 ): Promise<number> => {
-  const { consume_user_resource_percent = 0 } = await post(
-    `${getBaseApiUrl()}/wallet/getcontract`,
-    {
-      value: decode58Check(address),
-    }
+  const { consume_user_resource_percent = 0 } = await fetchTronContract(
+    address
   );
-
   return consume_user_resource_percent;
+};
+
+export const fetchTronContract = async (addr: string): Promise<Object> => {
+  try {
+    const data = await post(`${getBaseApiUrl()}/wallet/getcontract`, {
+      value: decode58Check(addr),
+    });
+    return data;
+  } catch (e) {
+    return undefined;
+  }
 };
 
 export const getTronAccountNetwork = async (

--- a/src/families/tron/test-dataset.js
+++ b/src/families/tron/test-dataset.js
@@ -351,6 +351,28 @@ const dataset: DatasetTest<Transaction> = {
               },
             },
             {
+              name: "tronSendTrc20ToContractAddressSuccess",
+              transaction: fromTransactionRaw({
+                family: "tron",
+                recipient: "TYmGYpY3LuHHge9jmTtq2aQmSpUpqKcZtJ", // corresponds to a valid deposit contract address
+                subAccountId:
+                  "tronjs:2:tron:THAe4BNVxp293qgyQEqXEkHMpPcqtG73bi:+TLa2f6VPqDgRE67v1736s7bJ8Ray5wYjU7",
+                amount: "1000000",
+                networkInfo: null,
+                mode: "send",
+                duration: undefined,
+                resource: undefined,
+                votes: [],
+              }),
+              expectedStatus: {
+                amount: BigNumber("1000000"),
+                errors: {},
+                warnings: {},
+                totalSpent: BigNumber("1000000"),
+                estimatedFees: BigNumber("0"),
+              },
+            },
+            {
               name: "tronSendTrc20ToNewAccountForbidden",
               transaction: fromTransactionRaw({
                 family: "tron",


### PR DESCRIPTION
Poloniex deposit addresses for TRC20 are contracts, not bare addresses.
The PR adds the support of sending TRC20 funds to a smart contract.

For testing, you can try to send trc20 tokens to these contract deposit addresses:
- https://tronscan.org/#/contract/TYmGYpY3LuHHge9jmTtq2aQmSpUpqKcZtJ
- https://tronscan.org/#/contract/TCMUcuyNYt8ods9zeRGu5casHnX2jHhhBC