### PR TITLE
Add a way to specify the osu to cli firmwareUpdate

### DIFF
--- a/cli/src/commands/firmwareUpdate.js
+++ b/cli/src/commands/firmwareUpdate.js
@@ -1,7 +1,18 @@
 // @flow
 
+import invariant from "invariant";
+import URL from "url";
 import { from, of, concat } from "rxjs";
 import { mergeMap } from "rxjs/operators";
+import type {
+  DeviceInfo,
+  FirmwareUpdateContext,
+} from "@ledgerhq/live-common/lib/types/manager";
+import { UnknownMCU } from "@ledgerhq/errors";
+import ManagerAPI from "@ledgerhq/live-common/lib/api/Manager";
+import network from "@ledgerhq/live-common/lib/network";
+import { getEnv } from "@ledgerhq/live-common/lib/env";
+import { getProviderId } from "@ledgerhq/live-common/lib/manager/provider";
 import manager from "@ledgerhq/live-common/lib/manager";
 import { withDevice } from "@ledgerhq/live-common/lib/hw/deviceAccess";
 import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
@@ -9,21 +20,123 @@ import prepareFirmwareUpdate from "@ledgerhq/live-common/lib/hw/firmwareUpdate-p
 import mainFirmwareUpdate from "@ledgerhq/live-common/lib/hw/firmwareUpdate-main";
 import { deviceOpt } from "../scan";
 
+const listFirmwareOSU = async () => {
+  const { data } = await network({
+    method: "GET",
+    url: `${getEnv("MANAGER_API_BASE")}/firmware_osu_versions`,
+  });
+  return data;
+};
+
+const customGetLatestFirmwareForDevice = async (
+  deviceInfo: DeviceInfo,
+  osuVersion: string
+): Promise<?FirmwareUpdateContext> => {
+  const mcusPromise = ManagerAPI.getMcus();
+
+  // Get device infos from targetId
+  const deviceVersion = await ManagerAPI.getDeviceVersion(
+    deviceInfo.targetId,
+    getProviderId(deviceInfo)
+  );
+
+  let osu;
+
+  if (deviceInfo.isOSU) {
+    osu = await ManagerAPI.getCurrentOSU({
+      deviceId: deviceVersion.id,
+      provider: getProviderId(deviceInfo),
+      version: deviceInfo.version,
+    });
+  } else {
+    const data = await listFirmwareOSU();
+    osu = data.find(
+      (d) =>
+        d.device_versions.includes(deviceVersion.id) && d.name === osuVersion
+    );
+  }
+
+  if (!osu) {
+    return null;
+  }
+
+  const final = await ManagerAPI.getFinalFirmwareById(
+    osu.next_se_firmware_final_version
+  );
+
+  const mcus = await mcusPromise;
+
+  const currentMcuVersion = mcus.find(
+    (mcu) => mcu.name === deviceInfo.mcuVersion
+  );
+
+  if (!currentMcuVersion) throw new UnknownMCU();
+
+  const shouldFlashMCU = !final.mcu_versions.includes(currentMcuVersion.id);
+
+  return { final, osu, shouldFlashMCU };
+};
+
+const disclaimer =
+  "this is a developer feature that allow to flash anything, we are not responsible of your actions, by flashing your device you might reset your seed or block your device";
+
 export default {
   description: "Perform a firmware update",
-  args: [deviceOpt],
-  job: ({ device }: $Shape<{ device: string }>) =>
-    withDevice(device || "")((t) => from(getDeviceInfo(t))).pipe(
-      mergeMap(manager.getLatestFirmwareForDevice),
-      mergeMap((firmware) => {
-        if (!firmware) return of("already up to date");
-        return concat(
-          of(
-            `firmware: ${firmware.final.name}\nOSU: ${firmware.osu.name} (hash: ${firmware.osu.hash})`
-          ),
-          prepareFirmwareUpdate(device || "", firmware),
-          mainFirmwareUpdate(device || "", firmware)
-        );
-      })
+  args: [
+    deviceOpt,
+    {
+      name: "to-my-own-risk",
+      type: Boolean,
+      desc: disclaimer,
+    },
+    {
+      name: "osuVersion",
+      type: String,
+      desc:
+        "(to your own risk) provide yourself an OSU version to flash the device with",
+    },
+    {
+      name: "listOSUs",
+      type: Boolean,
+      desc: "list all available OSUs (for all devices, beta and prod versions)",
+    },
+  ],
+  job: ({
+    device,
+    osuVersion,
+    "to-my-own-risk": toMyOwnRisk,
+    listOSUs,
+  }: $Shape<{
+    device: string,
+    osuVersion: string,
+    "to-my-own-risk": boolean,
+    listOSUs: boolean,
+  }>) => (
+    invariant(
+      !osuVersion || toMyOwnRisk,
+      "--to-my-own-risk is required: " + disclaimer
     ),
+    listOSUs
+      ? from(listFirmwareOSU()).pipe(
+          mergeMap((d) => from(d.map((d) => d.name)))
+        )
+      : withDevice(device || "")((t) => from(getDeviceInfo(t))).pipe(
+          mergeMap(
+            osuVersion
+              ? (deviceInfo) =>
+                  customGetLatestFirmwareForDevice(deviceInfo, osuVersion)
+              : manager.getLatestFirmwareForDevice
+          ),
+          mergeMap((firmware) => {
+            if (!firmware) return of("already up to date");
+            return concat(
+              of(
+                `firmware: ${firmware.final.name}\nOSU: ${firmware.osu.name} (hash: ${firmware.osu.hash})`
+              ),
+              prepareFirmwareUpdate(device || "", firmware),
+              mainFirmwareUpdate(device || "", firmware)
+            );
+          })
+        )
+  ),
 };


### PR DESCRIPTION
allows `ledger-live firmwareUpdate` commands to flash any arbitrary firmware, even if not yet available in production app.

```
ledger-live firmwareUpdate --osuVersion 1.2.4-2-osu --to-my-own-risk
```