### PR TITLE
Swap mobile compatibility and export operations

### DIFF
--- a/cli/src/commands/swap.js
+++ b/cli/src/commands/swap.js
@@ -33,7 +33,10 @@ type SwapJobOpts = ScanCommonOpts & {
 const exec = async (opts: SwapJobOpts) => {
   const { amount, useAllAmount, tokenId, deviceId = "" } = opts;
 
-  invariant(amount, "amount in satoshis is needed");
+  invariant(
+    amount || useAllAmount,
+    "amount in satoshis is needed or --useAllAmount "
+  );
   invariant(opts._unknown, "second account information is missing");
 
   //Remove suffix from arguments before passing them to sync.
@@ -158,12 +161,12 @@ const exec = async (opts: SwapJobOpts) => {
   console.log("OPEN EXCHANGE APP");
   await delay(10000);
 
-  const initSwapResult = await initSwap(
+  const initSwapResult = await initSwap({
     exchange,
-    exchangeRates[0],
+    exchangeRate: exchangeRates[0],
     transaction,
-    deviceId
-  )
+    deviceId,
+  })
     .pipe(
       tap((e) => console.log(e)),
       filter((e) => e.type === "init-swap-result"),

--- a/src/swap/csvExport.js
+++ b/src/swap/csvExport.js
@@ -1,0 +1,97 @@
+// @flow
+
+import { formatCurrencyUnit } from "../currencies";
+import { getAccountCurrency, getMainAccount } from "../account";
+import type { SwapHistorySection, MappedSwapOperation } from "./types";
+type Field = {
+  title: string,
+  cell: (MappedSwapOperation) => string,
+};
+
+const newLine = "\r\n";
+
+const fields: Field[] = [
+  {
+    title: "Operator",
+    cell: ({ provider }) => provider,
+  },
+  {
+    title: "Swap ID",
+    cell: ({ swapId }) => swapId,
+  },
+  {
+    title: "From",
+    cell: ({ fromAccount }) => getAccountCurrency(fromAccount).ticker,
+  },
+  {
+    title: "To",
+    cell: ({ toAccount }) => getAccountCurrency(toAccount).ticker,
+  },
+  {
+    title: "From Value",
+    cell: ({ fromAccount, fromAmount }) =>
+      formatCurrencyUnit(getAccountCurrency(fromAccount).units[0], fromAmount, {
+        disableRounding: true,
+        useGrouping: false,
+      }),
+  },
+  {
+    title: "To Value",
+    cell: ({ toAccount, toAmount }) =>
+      formatCurrencyUnit(getAccountCurrency(toAccount).units[0], toAmount, {
+        disableRounding: true,
+        useGrouping: false,
+      }),
+  },
+  {
+    title: "Status",
+    cell: ({ status }) => status,
+  },
+  {
+    title: "Date",
+    cell: ({ operation }) => operation.date.toISOString(),
+  },
+  {
+    title: "From account",
+    cell: ({ fromAccount, fromParentAccount }) =>
+      getMainAccount(fromAccount, fromParentAccount).name,
+  },
+  {
+    title: "From account address",
+    cell: ({ fromAccount, fromParentAccount }) => {
+      const main = getMainAccount(fromAccount, fromParentAccount);
+      return main.freshAddress;
+    },
+  },
+  {
+    title: "To account",
+    cell: ({ toAccount, toParentAccount }) =>
+      getMainAccount(toAccount, toParentAccount).name,
+  },
+  {
+    title: "To account address",
+    cell: ({ toAccount, toParentAccount }) => {
+      const main = getMainAccount(toAccount, toParentAccount);
+      return main.freshAddress;
+    },
+  },
+];
+
+export const mappedSwapOperationsToCSV = (
+  swapHistorySections: SwapHistorySection[]
+) => {
+  const mappedSwapOperations = [];
+  for (const section of swapHistorySections) {
+    mappedSwapOperations.push(...section.data);
+  }
+
+  return (
+    fields.map((field) => field.title).join(",") +
+    newLine +
+    mappedSwapOperations
+      .map((op) =>
+        fields.map((field) => field.cell(op).replace(/[,\n\r]/g, "")).join(",")
+      )
+      .join(newLine)
+  );
+};

--- a/src/swap/types.js
+++ b/src/swap/types.js
@@ -10,7 +10,6 @@ import type {
   CryptoCurrency,
   TokenCurrency,
 } from "../types";
-import { Observable } from "rxjs";
 
 export type Exchange = {
   fromParentAccount: ?Account,

--- a/src/swap/types.js
+++ b/src/swap/types.js
@@ -51,16 +51,6 @@ export type InitSwapResult = {
   swapId: string,
 };
 
-// init a swap with the Exchange app
-// throw if TransactionStatus have errors
-// you get at the end a final Transaction to be done (it's not yet signed, nor broadcasted!) and a swapId
-export type InitSwap = (
-  exchange: Exchange,
-  exchangeRate: ExchangeRate,
-  transaction: Transaction,
-  deviceId: string
-) => Observable<SwapRequestEvent>;
-
 export type SwapCurrencyNameAndSignature = {
   config: Buffer,
   signature: Buffer,


### PR DESCRIPTION
Introduces the changes needed to the `initSwap` device action and implements the export operations feature that will be triggered from desktop. This is the result of the peer programming done with @gre that identified a mismatch between the action and command signatures. It also introduces the fix to make cli swap command work again.