### PR TITLE
Fixes bug in qr export with missing swapHistory

### DIFF
--- a/src/__tests__/cross.js
+++ b/src/__tests__/cross.js
@@ -57,6 +57,28 @@ test("encode/decode", () => {
   expect(exp.accounts).toMatchObject(data.accounts.map(accountToAccountData));
 });
 
+test("encode/decode swapHistory", () => {
+  const accountWithHistory = genAccount("account_with_swapHistory", {
+    swapHistorySize: 2,
+  });
+  const data = accountToAccountData(accountWithHistory);
+  const res = accountToAccountData(accountDataToAccount(data));
+  expect(res).toMatchObject(data);
+  expect(res.swapHistory?.length).toBe(2);
+});
+
+test("encode/decode swapHistory resilience", () => {
+  // swapHistory should be added even if the source doesn't have it
+  const accountWithoutHistory = genAccount("account_without_swapHistory");
+  // $FlowFixMe
+  accountWithoutHistory.swapHistory = undefined;
+  const data = accountToAccountData(accountWithoutHistory);
+  const res = accountToAccountData(accountDataToAccount(data));
+
+  expect(res).toMatchObject(data);
+  expect(res.swapHistory?.length).toBe(0);
+});
+
 test("encode/decode", () => {
   const accounts = Array(3)
     .fill(null)

--- a/src/mock/account.js
+++ b/src/mock/account.js
@@ -274,6 +274,7 @@ type GenAccountOptions = {
   operationsSize?: number,
   currency?: CryptoCurrency,
   subAccountsCount?: number,
+  swapHistorySize?: number,
 };
 
 function genTokenAccount(
@@ -323,6 +324,7 @@ export function genAccount(
   const rng = new Prando(id);
   const currency = opts.currency || rng.nextArrayItem(currencies);
   const operationsSize = opts.operationsSize || rng.nextInt(1, 200);
+  const swapHistorySize = opts.swapHistorySize || 0;
   const address = genAddress(currency, rng);
   const derivationPath = runDerivationScheme(
     getDerivationScheme({ currency, derivationMode: "" }),
@@ -357,7 +359,18 @@ export function genAccount(
     pendingOperations: [],
     lastSyncDate: new Date(),
     creationDate: new Date(),
-    swapHistory: [],
+    swapHistory: Array(swapHistorySize)
+      .fill(null)
+      .map((_, i) => ({
+        provider: "changelly",
+        swapId: `swap-id-${i}`,
+        status: "finished",
+        receiverAccountId: "receiver-id",
+        operationId: "operation-id",
+        tokenId: "token-id",
+        fromAmount: BigNumber("1000"),
+        toAmount: BigNumber("2000"),
+      })),
   };
 
   if (currency.id === "cosmos") {


### PR DESCRIPTION
There is currently a bug where scanning a live qr export of accounts would yield no accounts due to the missing `swapHistory` after encoding/decoding. This addresses that issue and adds a few tests to check that we don't break it in the future. Ideally, the tests would also check if the linked operations and accounts exist but I'm leaving that as a nice to have for the future.