### PR TITLE
If getAddress of root path fail, pass to next derivation

### DIFF
--- a/src/libcore/scanAccounts.js
+++ b/src/libcore/scanAccounts.js
@@ -3,7 +3,7 @@
 import { Observable } from "rxjs";
 import Transport from "@ledgerhq/hw-transport";
 import { log } from "@ledgerhq/logs";
-import { TransportStatusError } from "@ledgerhq/errors";
+import { TransportStatusError, UserRefusedAddress } from "@ledgerhq/errors";
 import semver from "semver";
 import {
   getDerivationModesForCurrency,
@@ -202,17 +202,12 @@ export const scanAccounts = ({
               });
             } catch (e) {
               // feature detection: some old app will specifically returns this code for segwit case and we ignore it
+              // we also feature detect any denying case that could happen
               if (
-                derivationMode === "segwit" &&
-                e instanceof TransportStatusError &&
-                e.statusCode === 0x6f04
+                e instanceof TransportStatusError ||
+                e instanceof UserRefusedAddress
               ) {
-                log(
-                  "libcore",
-                  "scanAccounts ignore segwit paths because app don't support"
-                );
-              } else {
-                throw e;
+                log("scanAccounts", "ignore derivationMode=" + derivationMode);
               }
             }
 


### PR DESCRIPTION
Context: latest version of BCH app added a warning that display on device a `unusual derivation path` when we scan for "unsplit" accounts.

Previously: if you would REFUSE the "permission" it would have break the whole scan accounts feature.

With this PR: if you REFUSE the permission **or if any non 9000 status error happens for a getAddress** we will simply skip the derivation path and move to the next, so in present case, we would not bother scanning for unsplit case and directly move on to adding the normal path accounts. This mechanism is basically feature detection and this is to allow a potential future BCH app to throw an error directly instead of a RUNTIME PERMISSION. It would be way better UX if it was a global app settings rather than a permission