### PR TITLE
Fixes fiat to not show all digits

### DIFF
--- a/src/__tests__/currencies.js
+++ b/src/__tests__/currencies.js
@@ -222,6 +222,19 @@ test("can format a currency unit", () => {
   ).toBe("+1.00000000 BTC");
 });
 
+test("do not consider 'showAllDigits: undefined' as false", () => {
+  expect(
+    formatCurrencyUnit(
+      getFiatCurrencyByTicker("USD").units[0],
+      BigNumber(-1234500),
+      {
+        showCode: true,
+        showAllDigits: undefined,
+      }
+    )
+  ).toBe("-$12,345.00");
+});
+
 test("can enable discreet mode", () => {
   const btc = getCryptoCurrencyById("bitcoin").units[0];
   expect(

--- a/src/currencies/formatCurrencyUnit.js
+++ b/src/currencies/formatCurrencyUnit.js
@@ -37,7 +37,7 @@ type FormatFragment =
 export function formatCurrencyUnitFragment(
   unit: Unit,
   value: BigNumber,
-  options?: $Shape<typeof defaultFormatOptions>
+  _options?: $Shape<typeof defaultFormatOptions>
 ): FormatFragment[] {
   if (!BigNumber.isBigNumber(value)) {
     console.warn("formatCurrencyUnit called with value=", value);
@@ -50,6 +50,13 @@ export function formatCurrencyUnitFragment(
   if (!value.isFinite()) {
     console.warn("formatCurrencyUnit called with infinite value=", value);
     return [];
+  }
+  const options = {};
+  for (let k in _options) {
+    // sanitize the undefined value
+    if (_options[k] !== undefined) {
+      options[k] = _options[k];
+    }
   }
   const {
     showCode,


### PR DESCRIPTION
fixes an issue that create bad formatting of fiat amounts on desktop by accepting `showAllDigits: undefined` as option and just making it behave like if the option was not passed (and not behave as a `false`)

<img width="269" alt="Capture d’écran 2020-08-18 à 10 20 50" src="https://user-images.githubusercontent.com/211411/90496422-17b63980-e146-11ea-8d0b-d80ae9b4695e.png">
