### PR TITLE
Algo device transaction opt-in token name issue

### DIFF
--- a/src/families/algorand/deviceTransactionConfig.js
+++ b/src/families/algorand/deviceTransactionConfig.js
@@ -98,7 +98,7 @@ function getDeviceTransactionConfig({
       }
 
       if (assetId) {
-        const token = findTokenById(addPrefixToken(assetId));
+        const token = findTokenById(assetId);
         fields.push({
           type: "text",
           label: "Asset ID",


### PR DESCRIPTION
(Algo): device transaction config optin for asa token name should now be shown on confirmation step