### PR TITLE
split fimware hash

### DIFF
--- a/src/families/algorand/deviceTransactionConfig.js
+++ b/src/families/algorand/deviceTransactionConfig.js
@@ -9,7 +9,7 @@ import type { Transaction } from "./types";
 import type { DeviceTransactionField } from "../../transaction";
 import { getAccountUnit } from "../../account";
 import { formatCurrencyUnit, findTokenById } from "../../currencies";
-import { extractTokenId, addPrefixToken } from "./tokens";
+import { extractTokenId } from "./tokens";
 
 export const displayTokenValue = (token: TokenCurrency) =>
   `${token.name} (#${extractTokenId(token.id)})`;


### PR DESCRIPTION
LL-3066

adds a new way to display the hash format during firmware update, to look like what the nano S|X displays

![image](https://user-images.githubusercontent.com/671786/91562675-df7cdb00-e93d-11ea-91f7-4c4d188a4bb2.png)
