### PR TITLE
Swap production url + no longer selecting currencies for the user

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -322,6 +322,11 @@ const envDefinitions = {
     parser: boolParser,
     desc: "dev flag to skip onboarding flow",
   },
+  SWAP_API_BASE: {
+    def: "https://swap.aws.prd.ldg-tech.com",
+    parser: stringParser,
+    desc: "Swap API base",
+  },
   SYNC_ALL_INTERVAL: {
     def: 2 * 60 * 1000,
     parser: intParser,

--- a/src/swap/getExchangeRates.js
+++ b/src/swap/getExchangeRates.js
@@ -5,7 +5,7 @@ import type { Transaction } from "../types";
 import { getAccountCurrency, getAccountUnit } from "../account";
 import { mockGetExchangeRates } from "./mock";
 import network from "../network";
-import { swapAPIBaseURL } from "./";
+import { getSwapAPIBaseURL } from "./";
 import { getEnv } from "../env";
 import { BigNumber } from "bignumber.js";
 import { SwapExchangeRateOutOfBounds } from "../errors";
@@ -27,7 +27,7 @@ const getExchangeRates: GetExchangeRates = async (
 
   const res = await network({
     method: "POST",
-    url: `${swapAPIBaseURL}/rate/fixed`,
+    url: `${getSwapAPIBaseURL()}/rate/fixed`,
     data: [
       {
         from,

--- a/src/swap/getProviders.js
+++ b/src/swap/getProviders.js
@@ -2,7 +2,7 @@
 
 import type { GetProviders } from "./types";
 import network from "../network";
-import { swapAPIBaseURL } from "./";
+import { getSwapAPIBaseURL } from "./";
 import { getEnv } from "../env";
 import { mockGetProviders } from "./mock";
 import { SwapNoAvailableProviders } from "../errors";
@@ -12,7 +12,7 @@ const getProviders: GetProviders = async () => {
 
   const res = await network({
     method: "GET",
-    url: `${swapAPIBaseURL}/providers`,
+    url: `${getSwapAPIBaseURL()}/providers`,
   });
 
   if (!res.data.length) {

--- a/src/swap/getStatus.js
+++ b/src/swap/getStatus.js
@@ -1,7 +1,7 @@
 // @flow
 
 import network from "../network";
-import { swapAPIBaseURL } from "./";
+import { getSwapAPIBaseURL } from "./";
 import type { GetMultipleStatus, GetStatus } from "./types";
 import { getEnv } from "../env";
 import { mockGetStatus } from "./mock";
@@ -21,7 +21,7 @@ export const getMultipleStatus: GetMultipleStatus = async (statusList) => {
 
   const res = await network({
     method: "POST",
-    url: `${swapAPIBaseURL}/swap/status`,
+    url: `${getSwapAPIBaseURL()}/swap/status`,
     data: statusList,
   });
 

--- a/src/swap/index.js
+++ b/src/swap/index.js
@@ -11,9 +11,9 @@ import getStatus from "./getStatus";
 import getProviders from "./getProviders";
 import getCompleteSwapHistory from "./getCompleteSwapHistory";
 import initSwap from "./initSwap";
+import { getEnv } from "../env";
 
-const swapAPIBaseURL = "https://swap.staging.aws.ledger.fr";
-
+const getSwapAPIBaseURL: () => string = () => getEnv("SWAP_API_BASE");
 const swapProviders: {
   [string]: { nameAndPubkey: Buffer, signature: Buffer },
 } = {
@@ -59,7 +59,7 @@ const isCurrencySwapSupported = (
 };
 
 export {
-  swapAPIBaseURL,
+  getSwapAPIBaseURL,
   getProviderNameAndSignature,
   getProviders,
   getStatus,

--- a/src/swap/initSwap.js
+++ b/src/swap/initSwap.js
@@ -22,7 +22,7 @@ import { withDevice } from "../hw/deviceAccess";
 import {
   getCurrencySwapConfig,
   getProviderNameAndSignature,
-  swapAPIBaseURL,
+  getSwapAPIBaseURL,
 } from "./";
 import { getEnv } from "../env";
 
@@ -80,7 +80,7 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         try {
           res = await network({
             method: "POST",
-            url: `${swapAPIBaseURL}/swap`,
+            url: `${getSwapAPIBaseURL()}/swap`,
             data: [
               {
                 provider,

--- a/src/swap/logic.js
+++ b/src/swap/logic.js
@@ -13,24 +13,19 @@ export type CurrenciesStatus = { [string]: CurrencyStatus };
 
 export const initState: ({
   okCurrencies: (TokenCurrency | CryptoCurrency)[],
-}) => SwapState = ({ okCurrencies }) => {
-  const fromCurrency = okCurrencies[0];
-  const toCurrency = okCurrencies.find((c) => c !== fromCurrency);
-
-  return {
-    swap: {
-      exchange: {},
-      exchangeRate: undefined,
-    },
-    error: null,
-    isLoading: false,
-    useAllAmount: false,
-    okCurrencies,
-    fromCurrency,
-    toCurrency,
-    fromAmount: BigNumber(0),
-  };
-};
+}) => SwapState = ({ okCurrencies }) => ({
+  swap: {
+    exchange: {},
+    exchangeRate: undefined,
+  },
+  error: null,
+  isLoading: false,
+  useAllAmount: false,
+  okCurrencies,
+  fromCurrency: null,
+  toCurrency: null,
+  fromAmount: BigNumber(0),
+});
 
 export const canRequestRates = (state: SwapState) => {
   const { swap, error, fromAmount } = state;

--- a/src/swap/logic.js
+++ b/src/swap/logic.js
@@ -111,11 +111,8 @@ export const reducer = (
     }
     case "setFromCurrency": {
       let toCurrency = state.toCurrency;
-      if (
-        !state.toCurrency ||
-        state.toCurrency?.id === payload.fromCurrency?.id
-      ) {
-        toCurrency = state.okCurrencies.find((c) => c !== payload.fromCurrency);
+      if (state.toCurrency?.id === payload.fromCurrency?.id) {
+        toCurrency = null;
       }
       newState = {
         ...state,


### PR DESCRIPTION
We now use the production url by default allowing an override via an env variable.
We no longer preselect a currency pair for the user and in case of both currencies being the same, we reset the To, to null.