### PR TITLE
Swap - Fix bad BCH check + serialization bug (Object clone)

### DIFF
--- a/src/families/bitcoin/swap.js
+++ b/src/families/bitcoin/swap.js
@@ -18,7 +18,9 @@ const getSerializedAddressParameters = (
   addressFormat?: string
 ): { addressParameters: Buffer } => {
   const format =
-    addressFormat || getAddressFormatDerivationMode(derivationMode);
+    addressFormat && addressFormat in addressFormatMap
+      ? addressFormat
+      : getAddressFormatDerivationMode(derivationMode);
 
   invariant(
     Object.keys(addressFormatMap).includes(format),

--- a/src/hw/actions/initSwap.js
+++ b/src/hw/actions/initSwap.js
@@ -3,12 +3,15 @@ import { Observable, of, concat } from "rxjs";
 import { scan, tap, catchError } from "rxjs/operators";
 import { useEffect, useState } from "react";
 import type { ConnectAppEvent, Input as ConnectAppInput } from "../connectApp";
-import type { InitSwapInput } from "../../swap/initSwap";
+import type { InitSwapInputRaw } from "../../swap/types";
 import type { Action, Device } from "./types";
 import type { Transaction } from "../../types";
 import type { AppState } from "./app";
 import { log } from "@ledgerhq/logs";
 import { createAction as createAppAction } from "./app";
+import { toExchangeRaw, toExchangeRateRaw } from "../../swap/serialization";
+import { toTransactionRaw } from "../../transaction";
+
 import type {
   Exchange,
   ExchangeRate,
@@ -94,7 +97,7 @@ function useFrozenValue<T>(value: T, frozen: boolean): T {
 
 export const createAction = (
   connectAppExec: (ConnectAppInput) => Observable<ConnectAppEvent>,
-  initSwapExec: (InitSwapInput) => Observable<SwapRequestEvent>
+  initSwapExec: (InitSwapInputRaw) => Observable<SwapRequestEvent>
 ): InitSwapAction => {
   const useHook = (
     reduxDevice: ?Device,
@@ -126,10 +129,10 @@ export const createAction = (
       const sub = concat(
         of({ type: "init-swap" }),
         initSwapExec({
-          exchange,
-          exchangeRate,
+          exchange: toExchangeRaw(exchange),
+          exchangeRate: toExchangeRateRaw(exchangeRate),
+          transaction: toTransactionRaw(transaction),
           deviceId: device.deviceId,
-          transaction,
         })
       )
         .pipe(

--- a/src/swap/initSwap.js
+++ b/src/swap/initSwap.js
@@ -15,8 +15,7 @@ import network from "../network";
 import { getAccountBridge } from "../bridge";
 import { BigNumber } from "bignumber.js";
 import { SwapGenericAPIError, TransactionRefusedOnDevice } from "../errors";
-import type { Exchange, ExchangeRate, SwapRequestEvent } from "./types";
-import type { Transaction } from "../types";
+import type { SwapRequestEvent, InitSwapInput } from "./types";
 import { Observable } from "rxjs";
 import { withDevice } from "../hw/deviceAccess";
 import {
@@ -28,13 +27,6 @@ import { getEnv } from "../env";
 
 const withDevicePromise = (deviceId, fn) =>
   withDevice(deviceId)((transport) => from(fn(transport))).toPromise();
-
-export type InitSwapInput = {
-  exchange: Exchange,
-  exchangeRate: ExchangeRate,
-  transaction: Transaction,
-  deviceId: string,
-};
 
 // init a swap with the Exchange app
 // throw if TransactionStatus have errors

--- a/src/swap/serialization.js
+++ b/src/swap/serialization.js
@@ -1,6 +1,12 @@
 // @flow
 
-import type { Exchange, ExchangeRaw } from "./types";
+import { BigNumber } from "bignumber.js";
+import type {
+  Exchange,
+  ExchangeRaw,
+  ExchangeRate,
+  ExchangeRateRaw,
+} from "./types";
 import {
   fromAccountLikeRaw,
   fromAccountRaw,
@@ -41,5 +47,45 @@ export const toExchangeRaw = (exchange: Exchange): ExchangeRaw => {
       : null,
     toAccount: toAccountLikeRaw(toAccount),
     toParentAccount: toParentAccount ? toAccountRaw(toParentAccount) : null,
+  };
+};
+
+export const toExchangeRateRaw = (
+  exchangeRate: ExchangeRate
+): ExchangeRateRaw => {
+  const {
+    rate,
+    magnitudeAwareRate,
+    rateId,
+    provider,
+    providerURL,
+  } = exchangeRate;
+
+  return {
+    rate: rate.toString(),
+    magnitudeAwareRate: magnitudeAwareRate.toString(),
+    rateId,
+    provider,
+    providerURL,
+  };
+};
+
+export const fromExchangeRateRaw = (
+  exchangeRateRaw: ExchangeRateRaw
+): ExchangeRate => {
+  const {
+    rate,
+    magnitudeAwareRate,
+    rateId,
+    provider,
+    providerURL,
+  } = exchangeRateRaw;
+
+  return {
+    rate: new BigNumber(rate),
+    magnitudeAwareRate: new BigNumber(magnitudeAwareRate),
+    rateId,
+    provider,
+    providerURL,
   };
 };

--- a/src/swap/types.js
+++ b/src/swap/types.js
@@ -9,6 +9,7 @@ import type {
   Transaction,
   CryptoCurrency,
   TokenCurrency,
+  TransactionRaw,
 } from "../types";
 
 export type Exchange = {
@@ -31,7 +32,14 @@ export type ExchangeRate = {
   rateId: string,
   provider: string,
   providerURL?: ?string,
-  expirationDate?: ?Date, // FIXME not available? Asked channel where we get this from
+};
+
+export type ExchangeRateRaw = {
+  rate: string,
+  magnitudeAwareRate: string,
+  rateId: string,
+  provider: string,
+  providerURL?: ?string,
 };
 
 export type AvailableProvider = {
@@ -163,4 +171,18 @@ export type SwapState = {
   toCurrency: ?(CryptoCurrency | TokenCurrency),
   useAllAmount: boolean,
   fromAmount: BigNumber,
+};
+
+export type InitSwapInput = {
+  exchange: Exchange,
+  exchangeRate: ExchangeRate,
+  transaction: Transaction,
+  deviceId: string,
+};
+
+export type InitSwapInputRaw = {
+  exchange: ExchangeRaw,
+  exchangeRate: ExchangeRateRaw,
+  transaction: TransactionRaw,
+  deviceId: string,
 };


### PR DESCRIPTION
A bad serialization combination between the `icpRenderer` commands and the actions was triggering (albeit inconsistently) an obscure error about not being able to clone an object. This was actually well documented in the breaking changes for Electron 9 https://www.electronjs.org/docs/breaking-changes#behavior-changed-sending-non-js-objects-over-ipc-now-throws-an-exception and has now been addressed. In addition to this, there was a bad check on the `getSerializedAddressParameters` for the bitcoin family introduced by the recent support for BCH, this is also addressed in this PR.