### PR TITLE
Swap - Add hardcoded min version of currency apps to support exchange

### DIFF
--- a/src/swap/index.js
+++ b/src/swap/index.js
@@ -12,6 +12,7 @@ import getProviders from "./getProviders";
 import getCompleteSwapHistory from "./getCompleteSwapHistory";
 import initSwap from "./initSwap";
 import { getEnv } from "../env";
+import gte from "semver/functions/gte";
 
 const getSwapAPIBaseURL: () => string = () => getEnv("SWAP_API_BASE");
 const swapProviders: {
@@ -27,6 +28,31 @@ const swapProviders: {
       "hex"
     ),
   },
+};
+
+// Minimum version of a currency app which has exchange capabilities, meaning it can be used
+// for sell/swap, and do silent signing.
+const exchangeSupportAppVersions = {
+  bitcoin_cash: "1.5.7",
+  bitcoin_gold: "1.5.7",
+  bitcoin: "1.5.7",
+  dash: "1.5.7",
+  digibyte: "1.5.7",
+  dogecoin: "1.5.7",
+  ethereum: "1.4.6",
+  litecoin: "1.5.7",
+  qtum: "1.5.7",
+  stratis: "1.5.7",
+  zcash: "1.5.7",
+  zencash: "1.5.7",
+};
+
+export const isExchangeSupportedByApp = (
+  appName: string,
+  appVersion: string
+): boolean => {
+  const minVersion = exchangeSupportAppVersions[appName];
+  return minVersion && gte(appVersion, minVersion);
 };
 
 const getCurrencySwapConfig = (

--- a/src/swap/logic.js
+++ b/src/swap/logic.js
@@ -3,6 +3,7 @@
 import { NotEnoughBalance } from "@ledgerhq/errors";
 import { BigNumber } from "bignumber.js";
 import type { SwapState } from "./types";
+import { isExchangeSupportedByApp } from "./index";
 import type {
   Account,
   AccountLike,
@@ -11,8 +12,8 @@ import type {
 } from "../types";
 import type { InstalledItem } from "../apps";
 import { flattenAccounts, getAccountCurrency } from "../account";
-
-const validCurrencyStatus = { ok: 1, noApps: 1, noAccounts: 1 };
+// NB Why flow?
+const validCurrencyStatus = { ok: 1, noApps: 1, noAccounts: 1, outdatedApp: 1 };
 export type CurrencyStatus = $Keys<typeof validCurrencyStatus>;
 export type CurrenciesStatus = { [string]: CurrencyStatus };
 
@@ -67,13 +68,13 @@ export const getCurrenciesWithStatus = ({
   installedApps: InstalledItem[],
 }): CurrenciesStatus => {
   const statuses = {};
-  const installedAppsStatus = {};
+  const installedAppMap = {};
   const notEmptyCurrencies = flattenAccounts(accounts).map(
     (a) => getAccountCurrency(a).id
   );
 
-  for (const { name, updated } of installedApps)
-    installedAppsStatus[name] = updated;
+  for (const data of installedApps) installedAppMap[data.name] = data;
+
   for (const c of selectableCurrencies) {
     if (c.type !== "CryptoCurrency" && c.type !== "TokenCurrency") continue;
     const mainCurrency =
@@ -85,9 +86,14 @@ export const getCurrenciesWithStatus = ({
 
     if (!mainCurrency) continue;
     statuses[c.id] =
-      mainCurrency.managerAppName in installedAppsStatus
+      mainCurrency.managerAppName in installedAppMap
         ? notEmptyCurrencies.includes(mainCurrency.id)
-          ? "ok"
+          ? isExchangeSupportedByApp(
+              mainCurrency.id,
+              installedAppMap[mainCurrency.managerAppName].version
+            )
+            ? "ok"
+            : "outdatedApp"
           : "noAccounts"
         : "noApp";
   }


### PR DESCRIPTION
Allows us to identify after running the `listApps` from the swap form whether an app needs to be updated or not. This means we now have 4 states for any currency on swap. 
- OK.
- Needs update.
- No app installed.
- No accounts added.