### PR TITLE
fix(Algorand specs): move ~50% test case: take rewards into account

### DIFF
--- a/src/families/algorand/specs.js
+++ b/src/families/algorand/specs.js
@@ -110,7 +110,10 @@ const algorand: AppSpec<Transaction> = {
         };
       },
       test: ({ account, accountBeforeTransaction, operation }) => {
-        expect(account.balance.toString()).toBe(
+        const rewards =
+          accountBeforeTransaction.algorandResources?.rewards || 0;
+
+        expect(account.balance.plus(rewards).toString()).toBe(
           accountBeforeTransaction.balance.minus(operation.value).toString()
         );
       },


### PR DESCRIPTION
An Algorand account having a balance >= 1 ALGO generates rewards. Those rewards are added to the balance when a transaction is performed.

When the bot runs the `move ~50%` test case using a sender account with at least 1 ALGO (and, therefore, generating rewards), the test fails as the rewards are currently not taken into account when comparing the expected balance with the actual one.

For instance:

```
→ FROM Algorand 1: 1.2095 ALGO . . .
★ using mutation 'move ~50%'
→ TO Algorand 3: 1.2 ALGO (77ops) . . .
✔️ transaction 
    SEND 0.003717 ALGO
    TO BFTNQRVUQMPBU7ID323SJ2SO63G6PLMZVHPWQBXHBHX25C636Y6UZCGUAI
    with fees=0.001 ALGO
STATUS (2496ms)
  amount: 0.003717 ALGO
  estimated fees: 0.001 ALGO
  total spent: 0.004717 ALGO
  warnings: feeTooHigh: FeeTooHigh
✔️ has been signed! (11s) 
✔️ broadcasted! (732ms) optimistic operation: 
  -0.004717 ALGO     OUT        PPUANJOPVWAJHM2T6ZP5YULW6X5B25PWGMQ5Z4PGRPPR36TQLRFA 2020-09-07T16:11
(final state reached in 30.5s)
⚠️ Error: expect(received).toBe(expected) // Object.is equality
Expected: "1204841"
Received: "1204830"
. . .
```
The suggested fix re-introduces the rewards at the assertion level. 