### PR TITLE
Swap - update accounts only with swap history changes

### DIFF
--- a/src/swap/updateAccountSwapStatus.js
+++ b/src/swap/updateAccountSwapStatus.js
@@ -50,8 +50,6 @@ const updateAccountSwapStatus: UpdateAccountSwapStatus = async (
       };
     }
   }
-
-  return account;
 };
 
 export default updateAccountSwapStatus;


### PR DESCRIPTION
Since I was returning the account regardless, I was unable to filter by state on the LLD side which meant it dispatched an update for all accounts and in turn slowed the access to the history tab.