### PR TITLE
Swap - type flow fix

### DIFF
--- a/src/swap/types.js
+++ b/src/swap/types.js
@@ -93,7 +93,7 @@ export type SwapStatus = {
 };
 
 export type GetStatus = (SwapStatusRequest) => Promise<SwapStatus>;
-export type UpdateAccountSwapStatus = (AccountLike) => Promise<AccountLike>;
+export type UpdateAccountSwapStatus = (AccountLike) => Promise<?AccountLike>;
 export type GetMultipleStatus = (SwapStatusRequest[]) => Promise<SwapStatus[]>;
 
 /*


### PR DESCRIPTION
Broke the typeflow making the `UpdateAccountSwapStatus` only _maybe_ return an account like.