### PR TITLE
Override recipient for estimateMaxSpendable calculation when it's empty

### DIFF
--- a/src/families/algorand/bridge/libcore.js
+++ b/src/families/algorand/bridge/libcore.js
@@ -304,8 +304,9 @@ const estimateMaxSpendable = async ({
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(),
     subAccountId: account.type === "Account" ? null : account.id,
-    recipient: getAbandonSeedAddress(mainAccount.currency.id),
     ...transaction,
+    recipient:
+      transaction?.recipient || getAbandonSeedAddress(mainAccount.currency.id),
     useAllAmount: true,
   });
   const s = await getTransactionStatus(mainAccount, t);

--- a/src/families/bitcoin/bridge/libcore.js
+++ b/src/families/bitcoin/bridge/libcore.js
@@ -82,8 +82,9 @@ const estimateMaxSpendable = async ({
     // worse case scenario using a legacy address
     ...createTransaction(),
     ...transaction,
+    recipient:
+      transaction?.recipient || getAbandonSeedAddress(mainAccount.currency.id),
     useAllAmount: true,
-    recipient: getAbandonSeedAddress(mainAccount.currency.id),
   });
   const s = await getTransactionStatus(mainAccount, t);
   return s.amount;

--- a/src/families/cosmos/bridge/libcore.js
+++ b/src/families/cosmos/bridge/libcore.js
@@ -408,8 +408,9 @@ const estimateMaxSpendable = async ({
   const mainAccount = getMainAccount(account, parentAccount);
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(),
-    recipient: getAbandonSeedAddress(mainAccount.currency.id),
     ...transaction,
+    recipient:
+      transaction?.recipient || getAbandonSeedAddress(mainAccount.currency.id),
     useAllAmount: true,
   });
   const s = await getTransactionStatus(mainAccount, t);

--- a/src/families/ethereum/bridge/js.js
+++ b/src/families/ethereum/bridge/js.js
@@ -604,8 +604,9 @@ const estimateMaxSpendable = async ({
   const mainAccount = getMainAccount(account, parentAccount);
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(),
-    recipient: "0x0000000000000000000000000000000000000000",
     ...transaction,
+    recipient:
+      transaction?.recipient || "0x0000000000000000000000000000000000000000",
     amount: BigNumber(0),
   });
   const s = await getTransactionStatus(mainAccount, t);

--- a/src/families/ethereum/bridge/libcore.js
+++ b/src/families/ethereum/bridge/libcore.js
@@ -214,8 +214,9 @@ const estimateMaxSpendable = async ({
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(mainAccount),
     subAccountId: account.type === "Account" ? null : account.id,
-    recipient: "0x0000000000000000000000000000000000000000",
     ...transaction,
+    recipient:
+      transaction?.recipient || "0x0000000000000000000000000000000000000000",
     useAllAmount: true,
   });
   const s = await getTransactionStatus(mainAccount, t);

--- a/src/families/ripple/bridge/js.js
+++ b/src/families/ripple/bridge/js.js
@@ -733,8 +733,8 @@ const estimateMaxSpendable = async ({
   const reserveBaseXRP = parseAPIValue(r.validatedLedger.reserveBaseXRP);
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(),
-    recipient: "rHsMGQEkVNJmpGWs8XUBoTBiAAbwxZN5v3", // public testing seed abandonx11,about
     ...transaction,
+    recipient: transaction?.recipient || "rHsMGQEkVNJmpGWs8XUBoTBiAAbwxZN5v3", // public testing seed abandonx11,about
     amount: BigNumber(0),
   });
   const s = await getTransactionStatus(mainAccount, t);

--- a/src/families/stellar/bridge/libcore.js
+++ b/src/families/stellar/bridge/libcore.js
@@ -276,8 +276,8 @@ const estimateMaxSpendable = async ({
   const mainAccount = getMainAccount(account, parentAccount);
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(),
-    recipient: notCreatedStellarMockAddress, // not used address,
     ...transaction,
+    recipient: transaction?.recipient || notCreatedStellarMockAddress, // not used address
     useAllAmount: true,
   });
   const s = await getTransactionStatus(mainAccount, t);

--- a/src/families/tezos/bridge/libcore.js
+++ b/src/families/tezos/bridge/libcore.js
@@ -248,9 +248,9 @@ const estimateMaxSpendable = async ({
   const t = await prepareTransaction(mainAccount, {
     ...createTransaction(),
     subAccountId: account.type === "Account" ? null : account.id,
-    // this seed is empty (worse case scenario is to send to new). addr from: 1. eyebrow 2. odor 3. rice 4. attack 5. loyal 6. tray 7. letter 8. harbor 9. resemble 10. sphere 11. system 12. forward 13. onion 14. buffalo 15. crumble
-    recipient: "tz1VJitLYB31fEC82efFkLRU4AQUH9QgH3q6",
     ...transaction,
+    // this seed is empty (worse case scenario is to send to new). addr from: 1. eyebrow 2. odor 3. rice 4. attack 5. loyal 6. tray 7. letter 8. harbor 9. resemble 10. sphere 11. system 12. forward 13. onion 14. buffalo 15. crumble
+    recipient: transaction?.recipient || "tz1VJitLYB31fEC82efFkLRU4AQUH9QgH3q6",
     useAllAmount: true,
   });
   const s = await getTransactionStatus(mainAccount, t);

--- a/src/families/tron/bridge/js.js
+++ b/src/families/tron/bridge/js.js
@@ -727,8 +727,9 @@ const estimateMaxSpendable = async ({
     {
       ...createTransaction(),
       subAccountId: account.type === "Account" ? null : account.id,
-      recipient: "0x0000000000000000000000000000000000000000",
       ...transaction,
+      recipient:
+        transaction?.recipient || "0x0000000000000000000000000000000000000000",
       amount: BigNumber(0),
     },
     false


### PR DESCRIPTION
Estimate max spendable was broken for ETH because the empty recipient was overriding the one used for the calculation, resulting in an error added to the recipient field which was silenced because it's not a field we have on the swap flow. Reordering the built transaction used to get that transaction status in a way that prioritises the `transaction.recipient` value but defaults to the abandonseed or equivalent recipient makes the estimation work again.