### PR TITLE
gasLimit of regular ETH send should not be amplified

### DIFF
--- a/src/__tests__/__snapshots__/all.libcore.js.snap
+++ b/src/__tests__/__snapshots__/all.libcore.js.snap
@@ -26414,7 +26414,7 @@ Array [
     "type": "TokenAccountRaw",
   },
   Object {
-    "balance": "32",
+    "balance": "31",
     "id": "libcore:1:ethereum:xpub6BemYiVNp19a1XgWqLcpWd1pBDZTgzPEcVvhR15cpXPVQjuEnrU7fa3TUatX2NbRWNkqx51jmyukisqGokHq5dyK5uYcbwQBF7nJyAdpYZy:+0xD46bA6D942050d489DBd938a2C909A5d5039A161",
     "operationsCount": 5,
     "parentId": "libcore:1:ethereum:xpub6BemYiVNp19a1XgWqLcpWd1pBDZTgzPEcVvhR15cpXPVQjuEnrU7fa3TUatX2NbRWNkqx51jmyukisqGokHq5dyK5uYcbwQBF7nJyAdpYZy:",
@@ -26714,7 +26714,7 @@ Array [
     "type": "TokenAccountRaw",
   },
   Object {
-    "balance": "39",
+    "balance": "38",
     "id": "libcore:1:ethereum:xpub6BemYiVNp19a56t4FLHBhvys6iThqTAyC44jUX5b8fpPWSjrGaBMVdXo49wVVBVGVcRVPGo1eUUZPMFrKriqtL68pEeGCt37UzYXP4h3WX5:+0xD46bA6D942050d489DBd938a2C909A5d5039A161",
     "operationsCount": 2,
     "parentId": "libcore:1:ethereum:xpub6BemYiVNp19a56t4FLHBhvys6iThqTAyC44jUX5b8fpPWSjrGaBMVdXo49wVVBVGVcRVPGo1eUUZPMFrKriqtL68pEeGCt37UzYXP4h3WX5:",

--- a/src/env.js
+++ b/src/env.js
@@ -133,6 +133,12 @@ const envDefinitions = {
     parser: boolParser,
     desc: "disable a problematic mechanism of our API",
   },
+  ETHEREUM_GAS_LIMIT_AMPLIFIER: {
+    def: 2,
+    parser: floatParser,
+    desc:
+      "Ethereum gasLimit multiplier for contracts to prevent out of gas issue",
+  },
   EXPERIMENTAL_BLE: {
     def: false,
     parser: boolParser,


### PR DESCRIPTION
- for ETH send, the estimated value is 21000, it should remain 21000
- for all other cases, when it's not 21000, we will multiply by 2 to avoid bad cases where the estimation was too optimistic and that would produse out of gas issues.