### PR TITLE
fix(Algorand specs): claim rewards test case: check spendable balance

### DIFF
--- a/src/families/algorand/specs.js
+++ b/src/families/algorand/specs.js
@@ -23,7 +23,7 @@ const minBalanceNewAccount = parseCurrencyUnit(currency.units[0], "0.1");
 // Spendable balance for a non-ASA account
 const getSpendableBalance = (maxSpendable) => {
   maxSpendable = maxSpendable.minus(minFees);
-  invariant(maxSpendable.gt(minFees), "Spendable balance is too low");
+  invariant(maxSpendable.gt(0), "Spendable balance is too low");
   return maxSpendable;
 };
 

--- a/src/families/algorand/specs.js
+++ b/src/families/algorand/specs.js
@@ -23,7 +23,7 @@ const minBalanceNewAccount = parseCurrencyUnit(currency.units[0], "0.1");
 // Spendable balance for a non-ASA account
 const getSpendableBalance = (maxSpendable) => {
   maxSpendable = maxSpendable.minus(minFees);
-  invariant(maxSpendable.gt(minFees), "spendable balance is too low");
+  invariant(maxSpendable.gt(minFees), "Spendable balance is too low");
   return maxSpendable;
 };
 
@@ -151,7 +151,7 @@ const algorand: AppSpec<Transaction> = {
       name: "send ASA ~50%",
       maxRun: 2,
       transaction: ({ account, siblings, bridge, maxSpendable }) => {
-        invariant(maxSpendable.gt(minFees), "not enough balance");
+        invariant(maxSpendable.gt(minFees), "Spendable balance is too low");
         const subAccount = sample(getAssetsWithBalance(account));
 
         invariant(
@@ -234,9 +234,14 @@ const algorand: AppSpec<Transaction> = {
     {
       name: "claim rewards",
       maxRun: 1,
-      transaction: ({ account, bridge }) => {
+      transaction: ({ account, bridge, maxSpendable }) => {
         const rewards = account.algorandResources?.rewards;
+
         invariant(rewards && rewards.gt(0), "No pending rewards");
+
+        // Ensure that the rewards can effectively be claimed
+        // (fees have to be paid in order to claim the rewards)
+        invariant(maxSpendable.gt(minFees), "Spendable balance is too low");
 
         let transaction = bridge.createTransaction(account);
 


### PR DESCRIPTION
In the context of Algorand, the claim rewards operation requires fees to be paid.

Currently, the `claim rewards` test case does not check whether the spendable balance allows to pay the fees or not. Consequently, the test unduly fails when the fees cannot be paid.

[For instance](https://github.com/LedgerHQ/ledger-live-common/commit/f1573a4434644385801328b9caaa5f8ec599a5ee#commitcomment-42237036):

```
▬ Algorand 1.2.8 on nanoS 1.6.1
→ FROM Algorand 1: 1.2 ALGO . . .
max spendable ~0
★ using mutation 'claim rewards'
→ TO Algorand 1: 1.2 ALGO . . .
✔️ transaction 
    CLAIM REWARD 0 ALGO
    TO QTXTCZ22YEF5BLDPA5EUOIH5PQZZWIQDDVAVMPEFKZIMEAFTNJJ5RLURKQ
    with fees=0.001 ALGO
STATUS (1575ms)
  amount: 0 ALGO
  estimated fees: 0.001 ALGO
  total spent: 0.001 ALGO
  errors: amount: NotEnoughBalance
  warnings: claimReward: ClaimRewardsFeesWarning
⚠️ NotEnoughBalance: NotEnoughBalance
```

The suggested fix adds an invariant (similar to the ones already implemented for the other test cases) to ensure that fees can be paid when claiming a reward before performing the test. Incidentally, the corresponding invariants' messages are being normalised.