### PR TITLE
Update minimum Algorand app version

### DIFF
--- a/src/apps/support.js
+++ b/src/apps/support.js
@@ -26,7 +26,7 @@ export function shouldUpgrade(
 
 const appVersionsRequired = {
   Cosmos: ">= 2.14",
-  Algorand: ">= 1.2.6",
+  Algorand: ">= 1.2.9",
 };
 
 export function mustUpgrade(


### PR DESCRIPTION
Algorand app 1.2.9 needed (updated list of ASA)