### PR TITLE
Swap - Fix live qr export for swap history

### DIFF
--- a/src/cross.js
+++ b/src/cross.js
@@ -126,7 +126,29 @@ const asMaybeSwapOperationRaw = (unsafe: mixed): ?SwapOperationRaw => {
   ) {
     return;
   }
+
   const safe = {};
+  if (provider && typeof provider === "string") {
+    safe.provider = provider;
+  }
+  if (swapId && typeof swapId === "string") {
+    safe.swapId = swapId;
+  }
+  if (status && typeof status === "string") {
+    safe.status = status;
+  }
+  if (receiverAccountId && typeof receiverAccountId === "string") {
+    safe.receiverAccountId = receiverAccountId;
+  }
+  if (operationId && typeof operationId === "string") {
+    safe.operationId = operationId;
+  }
+  if (fromAmount && typeof fromAmount === "string") {
+    safe.fromAmount = fromAmount;
+  }
+  if (toAmount && typeof toAmount === "string") {
+    safe.toAmount = toAmount;
+  }
   if (tokenId && typeof tokenId === "string") {
     safe.tokenId = tokenId;
   }


### PR DESCRIPTION
The previous code made no sense, nothing was exported for a swap history other than an empty object (or a tokenId at most) don't know what we were thinking back then.