### PR TITLE
LL-3397 Prevent fees from being the same

### DIFF
--- a/src/families/bitcoin/libcore-getAccountNetworkInfo.js
+++ b/src/families/bitcoin/libcore-getAccountNetworkInfo.js
@@ -14,6 +14,7 @@ type Input = {
 type Output = Promise<NetworkInfo>;
 
 const speeds = ["high", "standard", "low"];
+const speedStepIfEqual = 1;
 
 async function bitcoin({ coreAccount }: Input): Output {
   const bitcoinLikeAccount = await coreAccount.asBitcoinLikeAccount();
@@ -23,9 +24,15 @@ async function bitcoin({ coreAccount }: Input): Output {
     bigInts,
     libcoreBigIntToBigNumber
   );
-  const normalized = bigNumbers.map((bn) =>
-    bn.div(1000).integerValue(BigNumber.ROUND_CEIL)
-  );
+  const normalized = bigNumbers
+    .map((bn) => bn.div(1000).integerValue(BigNumber.ROUND_CEIL))
+    .reduce(
+      (out, num, i) => [
+        ...out,
+        i > 0 && out[i - 1].gte(num) ? out[i - 1].plus(speedStepIfEqual) : num,
+      ],
+      []
+    );
   const feeItems = {
     items: normalized.map((feePerByte, i) => ({
       key: String(i),


### PR DESCRIPTION
This code will prevent us from offering feePerByte values that are the same but have misleadingly different labels.
It will work as follows, given we don't set a different value for `speedStepIfEqual`. 

```[0,1,2] => [0,1,2]
[0,0,1] => [0,1,2]
[0,0,3] => [0,1,3]
[1,1,1] => [1,2,3]
```