### PR TITLE
Swap - Split the out of range error for rates into two

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -127,8 +127,12 @@ export const SwapNoAvailableProviders = createCustomErrorClass(
   "SwapNoAvailableProviders"
 );
 
-export const SwapExchangeRateOutOfBounds = createCustomErrorClass(
-  "SwapExchangeRateOutOfBounds"
+export const SwapExchangeRateAmountTooLow = createCustomErrorClass(
+  "SwapExchangeRateAmountTooLow"
+);
+
+export const SwapExchangeRateAmountTooHigh = createCustomErrorClass(
+  "SwapExchangeRateAmountTooHigh"
 );
 
 export const SwapUnknownSwapId = createCustomErrorClass("SwapUnknownSwapId");


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/4631227/94920137-f6bb6500-04b5-11eb-9a8b-eb47d8c7d8f0.png)

This would allow us to do what's shown on the screenshot after a bump, so the error message is shorted and we don't have UI issues on the LLM of overflowing messages. Also if the user is out of bounds it's going to be from one of the sides, not going to be too high first and too low after