### PR TITLE
LL-2940 Made new device flow not experimental

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -149,12 +149,6 @@ const envDefinitions = {
     parser: stringParser,
     desc: "enable experimental support of currencies (comma separated)",
   },
-  EXPERIMENTAL_DEVICE_FLOW: {
-    def: false,
-    parser: boolParser,
-    desc:
-      "enable a new flow implementation (at the moment we're having early support of 'openApp')",
-  },
   EXPERIMENTAL_EXPLORERS: {
     def: false,
     parser: boolParser,


### PR DESCRIPTION
This will remove the experimental setting from LLD and make all users go through the Open App flow when possible. 
There's a known bug on LLD that will make the Add Account (and potentially any other flow involving this) stay in an empty state between the moment the user accepts to open the application, and the moment the application is actually reporting its version and name.

For LLD it's a matter of adding a conditional in the device action rendering in case `allowOpeningGranted && !appAndVersion` to render the loading view meanwhile.