### PR TITLE
LL-3406 Export the hideEmptyTokenAccounts setting

### DIFF
--- a/src/cross.js
+++ b/src/cross.js
@@ -37,6 +37,7 @@ export type Settings = {
   },
   developerModeEnabled?: boolean,
   blacklistedTokenIds?: string[],
+  hideEmptyTokenAccounts?: boolean,
 };
 
 export type DataIn = {
@@ -176,6 +177,7 @@ const asResultSettings = (unsafe: mixed): Settings => {
     pairExchanges,
     developerModeEnabled,
     blacklistedTokenIds,
+    hideEmptyTokenAccounts,
   } = unsafe;
 
   const currenciesSettingsSafe: {
@@ -207,6 +209,9 @@ const asResultSettings = (unsafe: mixed): Settings => {
   }
   if (developerModeEnabled && typeof developerModeEnabled === "boolean") {
     res.developerModeEnabled = developerModeEnabled;
+  }
+  if (hideEmptyTokenAccounts && typeof hideEmptyTokenAccounts === "boolean") {
+    res.hideEmptyTokenAccounts = hideEmptyTokenAccounts;
   }
   const blacklistedTokenIdsSafe: string[] = [];
   if (blacklistedTokenIds && Array.isArray(blacklistedTokenIds)) {


### PR DESCRIPTION
This is needed to decode the exposed setting from LLD/LLM, we need to change the selector there too after a release of live-common. Leaving a note on the jira task for when this makes it into a release.

https://ledgerhq.atlassian.net/browse/LL-3406