### PR TITLE
Stop scanning for bch_on_bitcoin_segwit paths

### DIFF
--- a/src/derivation.js
+++ b/src/derivation.js
@@ -73,6 +73,7 @@ const modes = Object.freeze({
     skipFirst: true, // already included in the normal bip44,
     tag: "metamask",
   },
+  // Deprecated and should no longer be used.
   bch_on_bitcoin_segwit: {
     overridesCoinType: 0,
     isInvalid: true,
@@ -199,7 +200,7 @@ const modes = Object.freeze({
 
 const legacyDerivations: $Shape<CryptoCurrencyConfig<DerivationMode[]>> = {
   aeternity: ["aeternity"],
-  bitcoin_cash: ["bch_on_bitcoin_segwit"],
+  bitcoin_cash: [],
   bitcoin: ["legacy_on_bch"],
   vertcoin: ["vertcoin_128", "vertcoin_128_segwit"],
   ethereum: ["ethM", "ethMM"],


### PR DESCRIPTION
decision was made to drop the support of scanning for BCH accounts that were wrongly derivating using bitcoin segwit path and format because it's impossible to express a transaction that would recover from such funds.

LL-2949