### PR TITLE
Fixes LL-3608: introduce legacy_on_native_segwit recovery mode

### DIFF
--- a/src/derivation.js
+++ b/src/derivation.js
@@ -176,6 +176,13 @@ const modes = Object.freeze({
     },
     isInvalid: true,
   },
+  legacy_on_native_segwit: {
+    purpose: 84,
+    libcoreConfig: {
+      KEYCHAIN_ENGINE: "BIP32_P2PKH",
+    },
+    isInvalid: true,
+  },
   segwit_unsplit: {
     isSegwit: true,
     purpose: 49,
@@ -403,6 +410,7 @@ export const getDerivationModesForCurrency = (
   if (currency.supportsSegwit) {
     all.push("segwit_on_legacy");
     all.push("legacy_on_segwit");
+    all.push("legacy_on_native_segwit");
   }
   if (!disableBIP44[currency.id]) {
     all.push("");


### PR DESCRIPTION
How to test this?

- https://ledger-repl.now.sh/ go to Litecoin app on device, use webusb, select getAddress, select Litecoin, use 84'/2'/0'/0/0 derivation, run it. you get an address. that's a legacy address on a native segwit path. it's invalid but we allow a way to recover it.
- send a very small amount to this address. like 0.001 LTC.
- `SCAN_FOR_INVALID_PATHS=1 ledger-live sync` should discover a new account
- `ledger-live sync` should NOT discover a new account
- you can send a transaction from this account to recover the funds