### PR TITLE
LL-3885 Integrate quitApp into manager device action

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -195,11 +195,6 @@ const envDefinitions = {
     parser: boolParser,
     desc: "enable an experimental implementation of USB support",
   },
-  EXPERIMENTAL_QUIT_APP: {
-    def: false,
-    parser: boolParser,
-    desc: "enable attempting to quit the device app if needed via apdu",
-  },
   EXPLORER: {
     def: "https://explorers.api.live.ledger.com",
     parser: stringParser,


### PR DESCRIPTION
Introduce support (when applicable) for the quitApp command that will automatically exit the current app if it's not the one expected in the current flow. This was already in use in the `connectApp` device action, this pr introduces it to flows that use the `connectManager` device action, in particular it affects direct manager access, swap feature and sell feature/