### PR TITLE
Add missing `hold` op status

### DIFF
--- a/src/exchange/swap/index.js
+++ b/src/exchange/swap/index.js
@@ -11,7 +11,15 @@ import { getEnv } from "../../env";
 export const operationStatusList = {
   finishedOK: ["finished", "refunded"],
   finishedKO: ["expired", "failed"],
-  pending: ["confirming", "exchanging", "sending", "waiting", "new", "hold", "overdue"],
+  pending: [
+    "confirming",
+    "exchanging",
+    "sending",
+    "waiting",
+    "new",
+    "hold",
+    "overdue",
+  ],
 };
 
 const getSwapAPIBaseURL: () => string = () => getEnv("SWAP_API_BASE");

--- a/src/exchange/swap/index.js
+++ b/src/exchange/swap/index.js
@@ -11,7 +11,7 @@ import { getEnv } from "../../env";
 export const operationStatusList = {
   finishedOK: ["finished", "refunded"],
   finishedKO: ["expired", "failed"],
-  pending: ["confirming", "exchanging", "sending", "waiting", "new"],
+  pending: ["confirming", "exchanging", "sending", "waiting", "new", "hold", "overdue"],
 };
 
 const getSwapAPIBaseURL: () => string = () => getEnv("SWAP_API_BASE");


### PR DESCRIPTION
This status (and `overdue` although it doesn't seem to be a real status) as defined in the api definition https://github.com/LedgerHQ/swap/blob/master/doc/openapi-swap.yaml#L179-L189 was missing and would make users facing AML/KYC procedures not have an icon on their swap history/details which adds insult to injury. It's a fairly rare operation status to fall into but that doesn't justify ignoring it.