### PR TITLE
Allow to disable auto quit app when needed on manager access

### DIFF
--- a/src/hw/connectManager.js
+++ b/src/hw/connectManager.js
@@ -19,6 +19,9 @@ import quitApp from "./quitApp";
 
 export type Input = {
   devicePath: string,
+  managerRequest: ?{
+    autoQuitAppDisabled?: boolean,
+  },
 };
 
 export type ConnectManagerEvent =
@@ -40,7 +43,10 @@ const attemptToQuitApp = (
       )
     : of({ type: "appDetected" });
 
-const cmd = ({ devicePath }: Input): Observable<ConnectManagerEvent> =>
+const cmd = ({
+  devicePath,
+  managerRequest,
+}: Input): Observable<ConnectManagerEvent> =>
   withDevice(devicePath)((transport) =>
     Observable.create((o) => {
       const timeoutSub = of({ type: "unresponsiveDevice" })
@@ -74,7 +80,8 @@ const cmd = ({ devicePath }: Input): Observable<ConnectManagerEvent> =>
             ) {
               return from(getAppAndVersion(transport)).pipe(
                 concatMap((appAndVersion) => {
-                  return !isDashboardName(appAndVersion.name)
+                  return !managerRequest?.autoQuitAppDisabled &&
+                    !isDashboardName(appAndVersion.name)
                     ? attemptToQuitApp(transport, appAndVersion)
                     : of({ type: "appDetected" });
                 })


### PR DESCRIPTION
When a user accesses the manager flow and is already inside an app, the new auto quit app logic will exit the given app (if possible) and continue the flow, listing apps, etc and entering the manager. There is one case where the user might have accessed the app while inside the manager. 

The current logic will exit the manager, quit the app, and access the manager again. This pr provides a way to flag this second entry as to not trigger an automatic exit of the app and merely prompt the user to exit the app to access the manager again.