### PR TITLE
Update repo url in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Common ground for the Ledger Live apps",
   "repository": {
     "type": "git",
-    "url": "git://github.com/LedgerHQ/ledger-live-common"
+    "url": "https://github.com/LedgerHQ/ledger-live-common"
   },
   "version": "17.3.0",
   "main": "lib/index.js",


### PR DESCRIPTION
this at least breaks rendering in `yarn upgrade-interactive`, how dare!

![1606826759](https://user-images.githubusercontent.com/315259/100742802-a8eeaa80-33db-11eb-95f7-ebdd275b0e32.png)
