### PR TITLE
LL-3916 allow bridge to be able to define preload() refresh time

### DIFF
--- a/docs/gist-tx.md
+++ b/docs/gist-tx.md
@@ -75,7 +75,10 @@ async function main() {
   const currencyBridge = getCurrencyBridge(currency);
 
   // some currency requires some data to be loaded (today it's not highly used but will be more and more)
-  await currencyBridge.preload(currency);
+  const data = await currencyBridge.preload(currency);
+  if (data) {
+    currencyBridge.hydrate(currency, data);
+  }
 
   // in our case, we don't need to paginate
   const syncConfig = { paginationConfig: {} };

--- a/src/__tests__/test-helpers/bridge.js
+++ b/src/__tests__/test-helpers/bridge.js
@@ -148,6 +148,32 @@ export function testBridge<T>(family: string, data: DatasetTest<T>) {
         FIXME_ignoreAccountFields,
         FIXME_ignoreOperationFields,
       } = currencyData;
+
+      test("functions are defined", () => {
+        expect(typeof bridge.scanAccounts).toBe("function");
+        expect(typeof bridge.preload).toBe("function");
+        expect(typeof bridge.hydrate).toBe("function");
+      });
+
+      test("preload and rehydrate", async () => {
+        const data1 = await bridge.preload(currency);
+        bridge.hydrate(data1, currency);
+        if (data1) {
+          const serialized1 = JSON.parse(JSON.stringify(data1));
+          bridge.hydrate(serialized1, currency);
+          expect(serialized1).toBeDefined();
+
+          const data2 = await bridge.preload(currency);
+          if (data2) {
+            bridge.hydrate(data2, currency);
+            expect(data1).toMatchObject(data2);
+            const serialized2 = JSON.parse(JSON.stringify(data2));
+            expect(serialized1).toMatchObject(serialized2);
+            bridge.hydrate(serialized2, currency);
+          }
+        }
+      });
+
       if (scanAccounts) {
         if (FIXME_ignoreOperationFields) {
           console.warn(
@@ -282,27 +308,6 @@ export function testBridge<T>(family: string, data: DatasetTest<T>) {
           });
         });
       }
-
-      test("functions are defined", () => {
-        expect(typeof bridge.scanAccounts).toBe("function");
-        expect(typeof bridge.preload).toBe("function");
-        expect(typeof bridge.hydrate).toBe("function");
-      });
-
-      test("preload and rehydrate", async () => {
-        const data1 = await bridge.preload(currency);
-        if (data1) {
-          const serialized1 = JSON.parse(JSON.stringify(data1));
-          bridge.hydrate(serialized1, currency);
-          expect(serialized1).toBeDefined();
-
-          const data2 = await bridge.preload(currency);
-          expect(data1).toMatchObject(data2);
-          const serialized2 = JSON.parse(JSON.stringify(data2));
-          expect(serialized1).toMatchObject(serialized2);
-          bridge.hydrate(serialized2, currency);
-        }
-      });
 
       const currencyDataTest = currencyData.test;
       if (currencyDataTest) {

--- a/src/bridge/cache.js
+++ b/src/bridge/cache.js
@@ -1,0 +1,60 @@
+// @flow
+import type { CryptoCurrency } from "../types";
+import { makeLRUCache } from "../cache";
+import { getCurrencyBridge } from "./";
+
+export type BridgeCacheSystem = {
+  hydrateCurrency: (currency: CryptoCurrency) => Promise<?mixed>,
+  prepareCurrency: (currency: CryptoCurrency) => Promise<?mixed>,
+};
+
+const defaultCacheStrategy = {
+  localCacheMaxAge: 5 * 60 * 1000,
+};
+
+export function makeBridgeCacheSystem({
+  saveData,
+  getData,
+}: {
+  saveData: (currency: CryptoCurrency, data: mixed) => Promise<void>,
+  getData: (currency: CryptoCurrency) => Promise<?mixed>,
+}): BridgeCacheSystem {
+  const hydrateCurrency = async (currency: CryptoCurrency) => {
+    const value = await getData(currency);
+    const bridge = getCurrencyBridge(currency);
+    bridge.hydrate(value, currency);
+    return value;
+  };
+
+  const lruCaches = {};
+
+  const prepareCurrency = async (currency: CryptoCurrency) => {
+    const bridge = getCurrencyBridge(currency);
+    const { localCacheMaxAge } = {
+      ...defaultCacheStrategy,
+      ...(bridge.getPreloadStrategy && bridge.getPreloadStrategy(currency)),
+    };
+    let cache = lruCaches[currency.id];
+    if (!cache) {
+      cache = makeLRUCache(
+        async () => {
+          const preloaded = await bridge.preload(currency);
+          if (preloaded) {
+            bridge.hydrate(preloaded, currency);
+            await saveData(currency, preloaded);
+          }
+          return preloaded;
+        },
+        () => "",
+        { maxAge: localCacheMaxAge }
+      );
+      lruCaches[currency.id] = cache;
+    }
+    return cache();
+  };
+
+  return {
+    hydrateCurrency,
+    prepareCurrency,
+  };
+}

--- a/src/bridge/cache.js
+++ b/src/bridge/cache.js
@@ -9,7 +9,7 @@ export type BridgeCacheSystem = {
 };
 
 const defaultCacheStrategy = {
-  localCacheMaxAge: 5 * 60 * 1000,
+  preloadMaxAge: 5 * 60 * 1000,
 };
 
 export function makeBridgeCacheSystem({
@@ -30,7 +30,7 @@ export function makeBridgeCacheSystem({
 
   const prepareCurrency = async (currency: CryptoCurrency) => {
     const bridge = getCurrencyBridge(currency);
-    const { localCacheMaxAge } = {
+    const { preloadMaxAge } = {
       ...defaultCacheStrategy,
       ...(bridge.getPreloadStrategy && bridge.getPreloadStrategy(currency)),
     };
@@ -46,7 +46,7 @@ export function makeBridgeCacheSystem({
           return preloaded;
         },
         () => "",
-        { maxAge: localCacheMaxAge }
+        { maxAge: preloadMaxAge }
       );
       lruCaches[currency.id] = cache;
     }

--- a/src/families/ethereum/bridge/js.js
+++ b/src/families/ethereum/bridge/js.js
@@ -171,7 +171,12 @@ const estimateMaxSpendable = async ({
   return s.amount;
 };
 
+const getPreloadStrategy = (_currency) => ({
+  preloadMaxAge: 30 * 1000,
+});
+
 const currencyBridge: CurrencyBridge = {
+  getPreloadStrategy,
   preload,
   hydrate,
   scanAccounts,

--- a/src/types/bridge.js
+++ b/src/types/bridge.js
@@ -37,6 +37,10 @@ export type ScanAccountEventRaw = {
 // unique identifier of a device. it will depends on the underlying implementation.
 export type DeviceId = string;
 
+export type PreloadStrategy = $Shape<{
+  preloadMaxAge: number,
+}>;
+
 // Abstraction related to a currency
 export interface CurrencyBridge {
   // Preload data required for the bridges to work. (e.g. tokens, delegators,...)
@@ -56,6 +60,8 @@ export interface CurrencyBridge {
     scheme?: ?DerivationMode,
     syncConfig: SyncConfig,
   }): Observable<ScanAccountEvent>;
+
+  getPreloadStrategy?: (currency: CryptoCurrency) => PreloadStrategy;
 }
 
 // Abstraction related to an account


### PR DESCRIPTION
- allow bridge to be able to define `getPreloadConfig`
- define an helper `makeBridgeCacheSystem` that we can reuse on LLD/LLM to generate prepareCurrency and hydrateCurrency concepts