### PR TITLE
Remove prepublish hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "flow-typed": "flow-typed install -s",
     "build": "./scripts/build.sh",
     "prepare": "yarn build",
-    "prepublish": "yarn build",
     "watch": "node scripts/buildReactIcons.js && BABEL_ENV=cjs babel -wsd lib src & flow-copy-source -wv src lib",
     "updateAppSupportsQuitApp": "node scripts/updateAppSupportsQuitApp.js",
     "prettier": "prettier --write 'src/**/*.?s' 'cli/src/**/*.?s'",


### PR DESCRIPTION
[Reference](https://docs.npmjs.com/cli/v6/using-npm/scripts#prepare-and-prepublish)

Since npm@4.0.0 introduced prepare hook, the old prepublish hook was deprecated. Currently the both hooks has been used and it causes the build twice on `<npm | yarn | yalc> publish` command.