### PR TITLE
Add support for floating rates on Swap.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "18.8.2-swap-api-v2.4",
+  "version": "18.8.2-swap-api-v2.5",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "18.8.2-swap-api-v2.1",
+  "version": "18.8.2-swap-api-v2.4",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "18.8.2",
+  "version": "18.8.2-swap-api-v2.1",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/src/env.js
+++ b/src/env.js
@@ -376,7 +376,7 @@ const envDefinitions = {
     desc: "dev flag to skip onboarding flow",
   },
   SWAP_API_BASE: {
-    def: "https://swap.ledger.com",
+    def: "https://swap.ledger.com/v2",
     parser: stringParser,
     desc: "Swap API base",
   },

--- a/src/exchange/hw-app-exchange/Exchange.js
+++ b/src/exchange/hw-app-exchange/Exchange.js
@@ -4,10 +4,15 @@ import { BigNumber } from "bignumber.js";
 import { TransportStatusError } from "@ledgerhq/errors";
 import invariant from "invariant";
 
-const TRANSACTION_TYPES = {
+export const TRANSACTION_RATES = {
+  FIXED: 0x00,
+  FLOATING: 0x01,
+};
+export const TRANSACTION_TYPES = {
   SWAP: 0x00,
   SELL: 0x01,
 };
+type TransactionRate = $Values<typeof TRANSACTION_RATES>;
 type TransactionType = $Values<typeof TRANSACTION_TYPES>;
 
 const START_NEW_TRANSACTION_COMMAND: number = 0x03;
@@ -31,6 +36,7 @@ const maybeThrowProtocolError = (result: Buffer): void => {
 export default class Exchange {
   transport: Transport<*>;
   transactionType: TransactionType;
+  transactionRate: TransactionRate;
   allowedStatuses: Array<number> = [
     0x9000,
     0x6a80,
@@ -44,8 +50,13 @@ export default class Exchange {
     0x9d1a,
   ];
 
-  constructor(transport: Transport<*>, transactionType: TransactionType) {
+  constructor(
+    transport: Transport<*>,
+    transactionType: TransactionType,
+    transactionRate?: TransactionRate
+  ) {
     this.transactionType = transactionType;
+    this.transactionRate = transactionRate || TRANSACTION_RATES.FIXED;
     this.transport = transport;
   }
 
@@ -53,7 +64,7 @@ export default class Exchange {
     let result: Buffer = await this.transport.send(
       0xe0,
       START_NEW_TRANSACTION_COMMAND,
-      0x00,
+      this.transactionRate,
       this.transactionType,
       Buffer.alloc(0),
       this.allowedStatuses
@@ -71,7 +82,7 @@ export default class Exchange {
     let result: Buffer = await this.transport.send(
       0xe0,
       SET_PARTNER_KEY_COMMAND,
-      0x00,
+      this.transactionRate,
       this.transactionType,
       partnerNameAndPublicKey,
       this.allowedStatuses
@@ -84,7 +95,7 @@ export default class Exchange {
     let result: Buffer = await this.transport.send(
       0xe0,
       CHECK_PARTNER_COMMAND,
-      0x00,
+      this.transactionRate,
       this.transactionType,
       signatureOfPartnerData,
       this.allowedStatuses
@@ -108,7 +119,7 @@ export default class Exchange {
     let result: Buffer = await this.transport.send(
       0xe0,
       PROCESS_TRANSACTION_RESPONSE,
-      0x00,
+      this.transactionRate,
       this.transactionType,
       bufferToSend,
       this.allowedStatuses
@@ -121,7 +132,7 @@ export default class Exchange {
     let result: Buffer = await this.transport.send(
       0xe0,
       CHECK_TRANSACTION_SIGNATURE,
-      0x00,
+      this.transactionRate,
       this.transactionType,
       transactionSignature,
       this.allowedStatuses
@@ -155,7 +166,7 @@ export default class Exchange {
       this.transactionType === TRANSACTION_TYPES.SWAP
         ? CHECK_PAYOUT_ADDRESS
         : CHECK_ASSET_IN,
-      0x00,
+      this.transactionRate,
       this.transactionType,
       bufferToSend,
       this.allowedStatuses
@@ -187,8 +198,8 @@ export default class Exchange {
     let result: Buffer = await this.transport.send(
       0xe0,
       CHECK_REFUND_ADDRESS,
-      0x00,
-      0x00,
+      this.transactionRate,
+      this.transactionType,
       bufferToSend,
       this.allowedStatuses
     );
@@ -199,7 +210,7 @@ export default class Exchange {
     let result: Buffer = await this.transport.send(
       0xe0,
       SIGN_COIN_TRANSACTION,
-      0x00,
+      this.transactionRate,
       this.transactionType,
       Buffer.alloc(0),
       this.allowedStatuses

--- a/src/exchange/sell/checkSignatureAndPrepare.js
+++ b/src/exchange/sell/checkSignatureAndPrepare.js
@@ -8,7 +8,7 @@ import { getAccountCurrency, getMainAccount } from "../../account";
 import { getCurrencyExchangeConfig } from "../";
 import perFamily from "../../generated/exchange";
 import type { SellRequestEvent } from "./types";
-
+import { TRANSACTION_TYPES } from "../hw-app-exchange/Exchange";
 import type {
   Account,
   AccountLike,
@@ -40,7 +40,7 @@ export default async (
     transaction,
   } = input;
 
-  const exchange = new Exchange(transport, 0x01);
+  const exchange = new Exchange(transport, TRANSACTION_TYPES.SELL);
   const mainAccount = getMainAccount(account, parentAccount);
   const { estimatedFees } = status;
   const provider = getProvider("coinify"); // FIXME Don't forget to switch to prod

--- a/src/exchange/sell/getTransactionId.js
+++ b/src/exchange/sell/getTransactionId.js
@@ -2,13 +2,14 @@
 import type Transport from "@ledgerhq/hw-transport";
 import Exchange from "../hw-app-exchange/Exchange";
 import type { SellRequestEvent } from "./types";
+import { TRANSACTION_TYPES } from "../hw-app-exchange/Exchange";
 
 function base64EncodeUrl(str) {
   return str.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
 
 export default async (transport: Transport<*>): Promise<SellRequestEvent> => {
-  const sell = new Exchange(transport, 0x01);
+  const sell = new Exchange(transport, TRANSACTION_TYPES.SELL);
   const txId = await sell.startNewTransaction();
   return {
     type: "init-sell-get-transaction-id",

--- a/src/exchange/swap/addToSwapHistory.js
+++ b/src/exchange/swap/addToSwapHistory.js
@@ -44,7 +44,7 @@ export default ({
     receiverAccountId: mainToAccount.id,
     tokenId,
     fromAmount: transaction.amount,
-    toAmount: transaction.amount.times(exchangeRate.magnitudeAwareRate),
+    toAmount: exchangeRate.toAmount,
   };
 
   return isFromToken && subAccounts

--- a/src/exchange/swap/addToSwapHistory.js
+++ b/src/exchange/swap/addToSwapHistory.js
@@ -36,7 +36,7 @@ export default ({
       : operation.id;
 
   const swapOperation: SwapOperation = {
-    status: "new",
+    status: "pending",
     provider: exchangeRate.provider,
     operationId,
     swapId,

--- a/src/exchange/swap/getExchangeRates.js
+++ b/src/exchange/swap/getExchangeRates.js
@@ -97,7 +97,9 @@ const getExchangeRates: GetExchangeRates = async (
           ? { rate, rateId }
           : {
               rate: BigNumber(amountTo).div(amountFrom),
-              payoutNetworkFees: BigNumber(payoutNetworkFees),
+              payoutNetworkFees: BigNumber(payoutNetworkFees).times(
+                BigNumber(10).pow(unitTo.magnitude)
+              ),
             }),
         error,
       };

--- a/src/exchange/swap/getExchangeRates.js
+++ b/src/exchange/swap/getExchangeRates.js
@@ -30,7 +30,7 @@ const getExchangeRates: GetExchangeRates = async (
 
   const res = await network({
     method: "POST",
-    url: `${getSwapAPIBaseURL()}/rate/fixed`,
+    url: `${getSwapAPIBaseURL()}/rate`,
     data: [
       {
         from,
@@ -41,11 +41,23 @@ const getExchangeRates: GetExchangeRates = async (
   });
 
   return res.data.map(
-    ({ rate, rateId, provider, minAmountFrom, maxAmountFrom }) => {
-      if (!rate || !rateId) {
+    ({
+      rate,
+      rateId,
+      provider,
+      amountFrom,
+      amountTo,
+      minAmountFrom,
+      maxAmountFrom,
+      tradeMethod,
+    }) => {
+      let error;
+      let magnitudeAwareRate;
+
+      if (!amountFrom) {
         const isTooSmall = BigNumber(apiAmount).lt(minAmountFrom);
 
-        throw isTooSmall
+        error = isTooSmall
           ? new SwapExchangeRateAmountTooLow(null, {
               minAmountFromFormatted: formatCurrencyUnit(
                 unitFrom,
@@ -68,19 +80,22 @@ const getExchangeRates: GetExchangeRates = async (
                 }
               ),
             });
+      } else {
+        // NB Allows us to simply multiply satoshi values from/to
+        magnitudeAwareRate = (tradeMethod === "fixed"
+          ? BigNumber(rate)
+          : BigNumber(amountTo).div(amountFrom)
+        ).div(BigNumber(10).pow(unitFrom.magnitude - unitTo.magnitude));
       }
-
-      // NB Allows us to simply multiply satoshi values from/to
-      const magnitudeAwareRate = BigNumber(rate).div(
-        BigNumber(10).pow(unitFrom.magnitude - unitTo.magnitude)
-      );
 
       return {
         magnitudeAwareRate,
-        rate,
-        rateId,
         provider,
-        expirationDate: new Date(),
+        tradeMethod,
+        ...(tradeMethod === "fixed"
+          ? { rate, rateId }
+          : { rate: BigNumber(amountTo).div(amountFrom) }),
+        error,
       };
     }
   );

--- a/src/exchange/swap/getExchangeRates.js
+++ b/src/exchange/swap/getExchangeRates.js
@@ -50,6 +50,7 @@ const getExchangeRates: GetExchangeRates = async (
       minAmountFrom,
       maxAmountFrom,
       tradeMethod,
+      payoutNetworkFees,
     }) => {
       let error;
       let magnitudeAwareRate;
@@ -94,7 +95,10 @@ const getExchangeRates: GetExchangeRates = async (
         tradeMethod,
         ...(tradeMethod === "fixed"
           ? { rate, rateId }
-          : { rate: BigNumber(amountTo).div(amountFrom) }),
+          : {
+              rate: BigNumber(amountTo).div(amountFrom),
+              payoutNetworkFees: BigNumber(payoutNetworkFees),
+            }),
         error,
       };
     }

--- a/src/exchange/swap/getExchangeRates.js
+++ b/src/exchange/swap/getExchangeRates.js
@@ -93,6 +93,9 @@ const getExchangeRates: GetExchangeRates = async (
         magnitudeAwareRate,
         provider,
         tradeMethod,
+        toAmount: BigNumber(amountTo).times(
+          BigNumber(10).pow(unitTo.magnitude)
+        ),
         ...(tradeMethod === "fixed"
           ? { rate, rateId }
           : {

--- a/src/exchange/swap/index.js
+++ b/src/exchange/swap/index.js
@@ -10,16 +10,8 @@ import { getEnv } from "../../env";
 
 export const operationStatusList = {
   finishedOK: ["finished"],
-  finishedKO: ["expired", "failed", "refunded"],
-  pending: [
-    "confirming",
-    "exchanging",
-    "sending",
-    "waiting",
-    "new",
-    "hold",
-    "overdue",
-  ],
+  finishedKO: ["expired", "refunded"],
+  pending: ["pending", "onhold"],
 };
 
 const getSwapAPIBaseURL: () => string = () => getEnv("SWAP_API_BASE");

--- a/src/exchange/swap/initSwap.js
+++ b/src/exchange/swap/initSwap.js
@@ -75,14 +75,16 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
           BigNumber(10).pow(unitFrom.magnitude)
         );
 
-        // Request a lock on the specified rate for 20 minutes,
-        // user is expected to send funds after this.
+        // Request a swap, this locks the rates for fixed trade method only.
         // NB Added the try/catch because of the API stability issues.
         let res;
         try {
           res = await network({
             method: "POST",
             url: `${getSwapAPIBaseURL()}/swap`,
+            headers: {
+              EquipmentId: getEnv("USER_ID"),
+            },
             data: {
               provider,
               amountFrom: apiAmount,

--- a/src/exchange/swap/logic.js
+++ b/src/exchange/swap/logic.js
@@ -130,7 +130,6 @@ export const reducer = (
       return {
         ...state,
         toCurrency: payload.toCurrency,
-        useAllAmount: false,
         toAccount: undefined,
         toParentAccount: undefined,
         ...reset,
@@ -143,6 +142,7 @@ export const reducer = (
     case "onSetExchangeRate":
       return {
         ...state,
+        error: undefined,
         exchangeRate: payload.exchangeRate,
         ratesExpiration: payload.withExpiration
           ? new Date(new Date().getTime() + ratesExpirationThreshold)

--- a/src/exchange/swap/logic.js
+++ b/src/exchange/swap/logic.js
@@ -1,61 +1,15 @@
 // @flow
 
-import { BigNumber } from "bignumber.js";
-import type { SwapState } from "./types";
+import type { SwapState, TradeMethod } from "./types";
 import { isExchangeSupportedByApp } from "../";
-import type {
-  Account,
-  AccountLike,
-  TokenCurrency,
-  CryptoCurrency,
-} from "../../types";
+import type { AccountLike, TokenCurrency, CryptoCurrency } from "../../types";
 import type { InstalledItem } from "../../apps";
 import { flattenAccounts, getAccountCurrency } from "../../account";
-const validCurrencyStatus = { ok: 1, noApp: 1, noAccounts: 1, outdatedApp: 1 };
 export type CurrencyStatus = $Keys<typeof validCurrencyStatus>;
 export type CurrenciesStatus = { [string]: CurrencyStatus };
+import uniq from "lodash/uniq";
 
-export const initState: ({
-  okCurrencies: (TokenCurrency | CryptoCurrency)[],
-  defaultCurrency?: TokenCurrency | CryptoCurrency,
-  defaultAccount?: AccountLike,
-  defaultParentAccount?: Account,
-}) => SwapState = ({
-  okCurrencies,
-  defaultCurrency,
-  defaultAccount,
-  defaultParentAccount,
-}) => ({
-  swap: {
-    exchange: {
-      fromAccount: defaultAccount,
-      fromParentAccount: defaultParentAccount,
-    },
-    exchangeRate: undefined,
-  },
-  error: null,
-  isLoading: false,
-  useAllAmount: false,
-  okCurrencies,
-  fromCurrency: defaultCurrency,
-  toCurrency: null,
-  fromAmount: BigNumber(0),
-});
-
-export const canRequestRates = (state: SwapState) => {
-  const { swap, error, fromAmount } = state;
-  const { exchange, exchangeRate } = swap;
-  const { fromAccount, toAccount } = exchange;
-  return !!(
-    fromAccount &&
-    toAccount &&
-    fromAmount &&
-    !exchangeRate &&
-    !error &&
-    fromAmount.gt(0)
-  );
-};
-
+const validCurrencyStatus = { ok: 1, noApp: 1, noAccounts: 1, outdatedApp: 1 };
 export const getCurrenciesWithStatus = ({
   accounts,
   selectableCurrencies,
@@ -98,142 +52,126 @@ export const getCurrenciesWithStatus = ({
   return statuses;
 };
 
+const reset = {
+  isTimerVisible: true,
+  ratesExpiration: undefined,
+  error: undefined,
+  exchangeRate: undefined,
+};
+
+const ratesExpirationThreshold = 60000;
+
+export const getValidToCurrencies = ({
+  selectableCurrencies,
+  fromCurrency,
+}: {
+  selectableCurrencies: { [TradeMethod]: (TokenCurrency | CryptoCurrency)[] },
+  fromCurrency: ?(TokenCurrency | CryptoCurrency),
+}): (TokenCurrency | CryptoCurrency)[] => {
+  const out = [];
+  const tradeMethods = Object.keys(selectableCurrencies);
+  for (const tradeMethod of tradeMethods) {
+    const currenciesForTradeMethod = selectableCurrencies[tradeMethod];
+    if (currenciesForTradeMethod.includes(fromCurrency)) {
+      out.push(
+        ...selectableCurrencies[tradeMethod].filter((c) => c !== fromCurrency)
+      );
+    }
+  }
+  return uniq(out);
+};
+
+const allTradeMethods: TradeMethod[] = ["fixed", "float"]; // Flow i give up
+
+export const getEnabledTradeMethods = ({
+  selectableCurrencies,
+  fromCurrency,
+  toCurrency,
+}: {
+  selectableCurrencies: { [TradeMethod]: (TokenCurrency | CryptoCurrency)[] },
+  toCurrency: ?(TokenCurrency | CryptoCurrency),
+  fromCurrency: ?(TokenCurrency | CryptoCurrency),
+}): TradeMethod[] => {
+  const tradeMethods = Object.keys(selectableCurrencies).filter((m) =>
+    allTradeMethods.includes(m)
+  );
+  return fromCurrency && toCurrency
+    ? tradeMethods.filter(
+        (method) =>
+          allTradeMethods.includes(method) &&
+          selectableCurrencies[method].includes(fromCurrency) &&
+          selectableCurrencies[method].includes(toCurrency)
+      )
+    : tradeMethods;
+};
+
 export const reducer = (
   state: SwapState,
-  { type, payload }: { type: string, payload: any }
+  { type, payload }: { type: string, payload: $Shape<SwapState> }
 ) => {
-  let newState;
-
   switch (type) {
-    case "patchExchange":
-      newState = {
-        ...state,
-        swap: {
-          ...state.swap,
-          exchangeRate: null,
-          exchange: { ...state.swap.exchange, ...payload },
-        },
-        error: null,
-      };
-      break;
-    case "fetchRates":
-      newState = { ...state, isLoading: true, error: null };
-      break;
-    case "setRate": {
-      newState = {
-        ...state,
-        swap: { ...state.swap, exchangeRate: payload.rate },
-        ratesTimestamp: new Date(),
-        error: null,
-      };
-      break;
-    }
-    case "setFromCurrency": {
-      let toCurrency = state.toCurrency;
-      if (state.toCurrency?.id === payload.fromCurrency?.id) {
-        toCurrency = null;
-      }
-      newState = {
-        ...state,
-        useAllAmount: false,
-        swap: {
-          ...state.swap,
-          exchangeRate: null,
-          exchange: {
-            ...state.swap.exchange,
-            fromAccount: undefined,
-            fromParentAccount: undefined,
-            toAccount: undefined,
-            toParentAccount: undefined,
-          },
-        },
-        fromAmount: BigNumber(0),
-        fromCurrency: payload.fromCurrency,
-        toCurrency,
-        error: null,
-      };
-      break;
-    }
-    case "setToCurrency": {
-      newState = {
-        ...state,
-        swap: {
-          ...state.swap,
-          exchangeRate: null,
-          exchange: {
-            ...state.swap.exchange,
-            toAccount: undefined,
-            toParentAccount: undefined,
-          },
-        },
-        toCurrency: payload.toCurrency,
-        error: null,
-      };
-      break;
-    }
-    case "setFromAccount": {
-      newState = {
-        ...state,
-        useAllAmount: false,
-        swap: {
-          ...state.swap,
-          exchangeRate: null,
-          exchange: {
-            ...state.swap.exchange,
-            ...payload,
-          },
-        },
-        fromAmount: BigNumber(0),
-        error: null,
-      };
-      break;
-    }
-    case "setToAccount": {
-      newState = {
-        ...state,
-        swap: {
-          ...state.swap,
-          exchangeRate: null,
-          exchange: {
-            ...state.swap.exchange,
-            ...payload,
-          },
-        },
-        error: null,
-      };
-      break;
-    }
-    case "setFromAmount": {
-      let error;
-      const { fromAmount, useAllAmount = false } = payload;
-
-      newState = {
-        ...state,
-        useAllAmount,
-        swap: {
-          ...state.swap,
-          exchangeRate: null,
-        },
-        fromAmount: fromAmount,
-        ratesTimestamp: undefined,
-        error,
-      };
-      break;
-    }
-    case "setError":
-      return { ...state, error: payload.error };
-    case "expireRates":
+    case "onResetRate":
       return {
         ...state,
-        ratesTimestamp: undefined,
-
-        swap: {
-          ...state.swap,
-          exchangeRate: null,
-        },
+        ...reset,
       };
-    default:
-      return state;
+    case "onSetFromCurrency":
+      return {
+        ...state,
+        fromCurrency: payload.fromCurrency,
+        useAllAmount: false,
+        toCurrency:
+          state.toCurrency === payload.fromCurrency
+            ? undefined
+            : state.toCurrency,
+        exchangeRate: undefined,
+      };
+    case "onSetToCurrency":
+      return {
+        ...state,
+        toCurrency: payload.toCurrency,
+        useAllAmount: false,
+        toAccount: undefined,
+        toParentAccount: undefined,
+        ...reset,
+      };
+    case "onSetError":
+      return {
+        ...state,
+        error: payload.error,
+      };
+    case "onSetExchangeRate":
+      return {
+        ...state,
+        exchangeRate: payload.exchangeRate,
+        ratesExpiration: payload.withExpiration
+          ? new Date(new Date().getTime() + ratesExpirationThreshold)
+          : undefined,
+      };
+    case "onSetUseAllAmount":
+      return {
+        ...state,
+        useAllAmount: payload.useAllAmount,
+      };
+    case "onSetToAccount":
+      return {
+        ...state,
+        toAccount: payload.toAccount,
+        toParentAccount: payload.toParentAccount,
+      };
+    case "onSetLoadingRates":
+      return {
+        ...state,
+        loadingRates: payload.loadingRates,
+      };
+    case "onFlip":
+      return {
+        ...state,
+        fromCurrency: state.toCurrency,
+        toCurrency: state.fromCurrency,
+        toAccount: payload.toAccount,
+        toParentAccount: payload.toParentAccount,
+      };
   }
-  return newState;
+  return state || {};
 };

--- a/src/exchange/swap/mock.js
+++ b/src/exchange/swap/mock.js
@@ -71,6 +71,7 @@ export const mockGetExchangeRates = async (
       rateId: "mockedRateId",
       provider: "changelly",
       expirationDate: new Date(),
+      tradeMethod: "fixed", // TODO add float mocks when we have a UI
     },
   ];
 };

--- a/src/exchange/swap/mock.js
+++ b/src/exchange/swap/mock.js
@@ -60,14 +60,16 @@ export const mockGetExchangeRates = async (
 
   //Fake delay to show loading UI
   await new Promise((r) => setTimeout(r, 800));
+  const magnitudeAwareRate = BigNumber(1)
+    .div(BigNumber(10).pow(unitFrom.magnitude))
+    .times(BigNumber(10).pow(unitTo.magnitude));
 
   //Mock OK, not really magnitude aware
   return [
     {
       rate: BigNumber("1"),
-      magnitudeAwareRate: BigNumber(1)
-        .div(BigNumber(10).pow(unitFrom.magnitude))
-        .times(BigNumber(10).pow(unitTo.magnitude)),
+      toAmount: amountFrom.times(magnitudeAwareRate),
+      magnitudeAwareRate,
       rateId: "mockedRateId",
       provider: "changelly",
       expirationDate: new Date(),

--- a/src/exchange/swap/serialization.js
+++ b/src/exchange/swap/serialization.js
@@ -13,6 +13,7 @@ import {
   toAccountLikeRaw,
   toAccountRaw,
 } from "../../account";
+import { deserializeError, serializeError } from "@ledgerhq/errors";
 
 export const fromExchangeRaw = (exchangeRaw: ExchangeRaw): Exchange => {
   const fromAccount = fromAccountLikeRaw(exchangeRaw.fromAccount);
@@ -59,6 +60,8 @@ export const toExchangeRateRaw = (
     rateId,
     provider,
     providerURL,
+    tradeMethod,
+    error,
   } = exchangeRate;
 
   return {
@@ -67,6 +70,8 @@ export const toExchangeRateRaw = (
     rateId,
     provider,
     providerURL,
+    tradeMethod,
+    error: JSON.stringify(serializeError(error)) || "{}",
   };
 };
 
@@ -79,6 +84,8 @@ export const fromExchangeRateRaw = (
     rateId,
     provider,
     providerURL,
+    tradeMethod,
+    error,
   } = exchangeRateRaw;
 
   return {
@@ -87,5 +94,7 @@ export const fromExchangeRateRaw = (
     rateId,
     provider,
     providerURL,
+    tradeMethod,
+    error: error ? deserializeError(JSON.parse(error)) : undefined,
   };
 };

--- a/src/exchange/swap/serialization.js
+++ b/src/exchange/swap/serialization.js
@@ -57,6 +57,8 @@ export const toExchangeRateRaw = (
   const {
     rate,
     magnitudeAwareRate,
+    payoutNetworkFees,
+    toAmount,
     rateId,
     provider,
     providerURL,
@@ -67,6 +69,8 @@ export const toExchangeRateRaw = (
   return {
     rate: rate.toString(),
     magnitudeAwareRate: magnitudeAwareRate.toString(),
+    payoutNetworkFees: payoutNetworkFees ? payoutNetworkFees.toString() : "",
+    toAmount: toAmount.toString(),
     rateId,
     provider,
     providerURL,
@@ -81,6 +85,8 @@ export const fromExchangeRateRaw = (
   const {
     rate,
     magnitudeAwareRate,
+    payoutNetworkFees,
+    toAmount,
     rateId,
     provider,
     providerURL,
@@ -91,6 +97,10 @@ export const fromExchangeRateRaw = (
   return {
     rate: new BigNumber(rate),
     magnitudeAwareRate: new BigNumber(magnitudeAwareRate),
+    payoutNetworkFees: payoutNetworkFees
+      ? new BigNumber(payoutNetworkFees)
+      : undefined,
+    toAmount: new BigNumber(toAmount),
     rateId,
     provider,
     providerURL,

--- a/src/exchange/swap/types.js
+++ b/src/exchange/swap/types.js
@@ -30,6 +30,7 @@ export type ExchangeRate = {
   rate: BigNumber, // NB Raw rate, for display
   magnitudeAwareRate: BigNumber, // NB rate between satoshi units
   payoutNetworkFees?: BigNumber, // Only for float
+  toAmount: BigNumber, // There's a delta somewhere between from times rate and the api.
   rateId?: string,
   provider: string,
   tradeMethod: "fixed" | "float",
@@ -41,6 +42,8 @@ export type TradeMethod = "fixed" | "float";
 export type ExchangeRateRaw = {
   rate: string,
   magnitudeAwareRate: string,
+  payoutNetworkFees?: string,
+  toAmount: string,
   rateId?: string,
   provider: string,
   tradeMethod: TradeMethod,

--- a/src/exchange/swap/types.js
+++ b/src/exchange/swap/types.js
@@ -29,16 +29,21 @@ export type ExchangeRaw = {
 export type ExchangeRate = {
   rate: BigNumber, // NB Raw rate, for display
   magnitudeAwareRate: BigNumber, // NB rate between satoshi units
-  rateId: string,
+  rateId?: string,
   provider: string,
+  tradeMethod: "fixed" | "float",
+  error?: Error,
   providerURL?: ?string,
 };
 
+export type TradeMethod = "fixed" | "float";
 export type ExchangeRateRaw = {
   rate: string,
   magnitudeAwareRate: string,
-  rateId: string,
+  rateId?: string,
   provider: string,
+  tradeMethod: TradeMethod,
+  error?: string,
   providerURL?: ?string,
 };
 
@@ -138,17 +143,19 @@ export type SwapOperationRaw = {
 };
 
 export type SwapState = {
-  swap: {
-    exchange: $Shape<Exchange>,
-    exchangeRate?: ?ExchangeRate,
-  },
+  // NB fromAccount and fromParentAccount and amount come from `useBridgeTransaction`
+  useAllAmount?: boolean,
+  loadingRates?: boolean,
+  isTimerVisible?: boolean,
   error?: ?Error,
-  ratesTimestamp?: Date,
-  okCurrencies: (CryptoCurrency | TokenCurrency)[],
-  fromCurrency: ?(CryptoCurrency | TokenCurrency),
-  toCurrency: ?(CryptoCurrency | TokenCurrency),
-  useAllAmount: boolean,
-  fromAmount: BigNumber,
+
+  fromCurrency?: ?(CryptoCurrency | TokenCurrency),
+  toCurrency?: ?(CryptoCurrency | TokenCurrency),
+  toAccount?: ?AccountLike,
+  toParentAccount?: ?Account,
+  ratesExpiration?: ?Date,
+  exchangeRate?: ?ExchangeRate,
+  withExpiration?: boolean,
 };
 
 export type InitSwapInput = {

--- a/src/exchange/swap/types.js
+++ b/src/exchange/swap/types.js
@@ -96,7 +96,7 @@ export type UpdateAccountSwapStatus = (Account) => Promise<?Account>;
 export type GetMultipleStatus = (SwapStatusRequest[]) => Promise<SwapStatus[]>;
 
 export type SwapRequestEvent =
-  | { type: "init-swap-requested" }
+  | { type: "init-swap-requested", amountExpectedTo?: string }
   | { type: "init-swap-error", error: Error }
   | { type: "init-swap-result", initSwapResult: InitSwapResult };
 

--- a/src/exchange/swap/types.js
+++ b/src/exchange/swap/types.js
@@ -29,6 +29,7 @@ export type ExchangeRaw = {
 export type ExchangeRate = {
   rate: BigNumber, // NB Raw rate, for display
   magnitudeAwareRate: BigNumber, // NB rate between satoshi units
+  payoutNetworkFees?: BigNumber, // Only for float
   rateId?: string,
   provider: string,
   tradeMethod: "fixed" | "float",

--- a/src/exchange/swap/types.js
+++ b/src/exchange/swap/types.js
@@ -68,17 +68,11 @@ export type InitSwapResult = {
 };
 
 type ValidSwapStatus =
-  | "confirming"
-  | "finished"
-  | "exchanging"
-  | "hold"
-  | "sending"
-  | "waiting"
-  | "overdue"
-  | "refunded"
-  | "new"
+  | "pending"
+  | "onhold"
   | "expired"
-  | "failed";
+  | "finished"
+  | "refunded";
 
 export type SwapStatusRequest = {
   provider: string,

--- a/src/hw/actions/initSwap.js
+++ b/src/hw/actions/initSwap.js
@@ -21,6 +21,7 @@ type State = {|
   initSwapResult: ?InitSwapResult,
   initSwapRequested: boolean,
   initSwapError: ?Error,
+  error?: Error,
   isLoading: boolean,
   freezeReduxDevice: boolean,
 |};
@@ -120,12 +121,13 @@ export const createAction = (
       }
     );
 
-    const { device, opened } = appState;
+    const { device, opened, error } = appState;
     const { exchange, exchangeRate, transaction } = initSwapRequest;
+    const hasError = error || state.error;
 
     useEffect(() => {
       if (!opened || !device) {
-        setState(initialState);
+        setState({ ...initialState, isLoading: !hasError });
         return;
       }
 
@@ -155,7 +157,7 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [exchange, exchangeRate, transaction, device, opened]);
+    }, [exchange, exchangeRate, transaction, device, opened, hasError]);
 
     return {
       ...appState,

--- a/src/hw/actions/initSwap.js
+++ b/src/hw/actions/initSwap.js
@@ -72,7 +72,12 @@ const reducer = (state: any, e: SwapRequestEvent | { type: "init-swap" }) => {
         isLoading: false,
       };
     case "init-swap-requested":
-      return { ...state, initSwapRequested: true, isLoading: false };
+      return {
+        ...state,
+        initSwapRequested: true,
+        isLoading: false,
+        amountExpectedTo: e.amountExpectedTo,
+      };
     case "init-swap-result":
       return {
         ...state,


### PR DESCRIPTION
This is a breaking change that should **not be merged** until the current v2 version of the swap backend is in production.
Backend will maintain a legacy version for users running live-common prior to this commit, and a v2 which will start from here on. The changes include dropping unneeded wrapping arrays for some endpoints and more importantly the support for floating rates from our providers.

The CLI command has also been updated accordingly to allow testing the feature.