### PR TITLE
Fix broken logic for pending accounts

### DIFF
--- a/src/account/pending.js
+++ b/src/account/pending.js
@@ -13,7 +13,7 @@ export function shouldRetainPendingOperation(
     last &&
     last.transactionSequenceNumber &&
     op.transactionSequenceNumber &&
-    op.transactionSequenceNumber >= last.transactionSequenceNumber
+    op.transactionSequenceNumber <= last.transactionSequenceNumber
   ) {
     return false;
   }
@@ -23,7 +23,7 @@ export function shouldRetainPendingOperation(
 
 const appendPendingOp = (ops: Operation[], op: Operation) => {
   const filtered: Operation[] = ops.filter(
-    (o) => o.transactionSequenceNumber === op.transactionSequenceNumber
+    (o) => o.transactionSequenceNumber !== op.transactionSequenceNumber
   );
   filtered.unshift(op);
   return filtered;

--- a/src/appSupportsQuitApp.js
+++ b/src/appSupportsQuitApp.js
@@ -94,6 +94,7 @@ export const minAppVersion = {
   NIX: "1.5.0",
   NOS: "1.2.2",
   Nano: "1.2.2",
+  Nervos: "0.5.0",
   Nimiq: "1.4.4",
   ONT: "1.2.2",
   Oasis: "1.8.1",


### PR DESCRIPTION
During the development of polkadot's integration @rjarasson-ledger identified that part of the pending operations logic from live-common is currently broken. I've taken his notes, done some local testing to confirm that this is in fact the case and I hereby provide the fix for both accounts.

### What is broken
Here we are basically removing all other pending operations from the account, so a second operation will replace any other pending operation. This can be tested by quickly sending two transactions and as soon as the second one is broadcasted, the first pending one will disappear. The filter function will keep all elements that _pass_ the test, it filters-in not filter-out, so we'd only keep a pending operation with the same `transactionSequenceNumber` as the one we are adding, which will never be the case.

https://github.com/LedgerHQ/ledger-live-common/blob/220978ee61fe6c8720b41f87bcc4232561215e6f/src/account/pending.js#L24-L30

On the second snippet, the fact that we are comparing the `transactionSequenceNumber` of op vs last by checking if that number on our pending operation is larger than or equal to the last non-pending operation. This means that whenever there's a patching sync (one that changes the status of the account) we will essentially empty the pending operation list. This can also be tested by two sends, by the time we get a response from our explorers saying the first operation is there, the second one, which locally is pending, will disappear.

https://github.com/LedgerHQ/ledger-live-common/blob/220978ee61fe6c8720b41f87bcc4232561215e6f/src/account/pending.js#L5-L22

### Side effects of this bug
I want to believe that this can be the cause of multiple bugs that were then not reproducible by the dev team, throughout the development of the swap feature, in several occasions I had missing op details for pending operations after a swap, we've seen this _bug_ come and go in multiple sprints and we dismissed it when we couldn't reproduce it. Furthermore, this has been like this since the beginning of time.

This was not easy to find because on 99% of the time we will have only one pending operation, and the next patching sync for that account would be the one that includes that operation, which had the side effect of removing the pending operation too.

### TLDR
Pending operations were being wiped both when adding a new pending operation to that account, and when updating an account with a postSync patch by incorrect comparison of the transactionSequenceNumber in one case, and by a flipped filter in the other case.


### Test plan 1
- On a clean LLD (maybe this affects LLM 🤔) add two existing accounts from a crypto (say ETH)
- Send a low amount from account 1 to account 2
- Verify the pending operation is shown
- Quickly repeat sending a low amount from account 1 to account 2
- Notice that the first pending operation disappears (you shall not see two pending operations from the same account)
- On a build including this fix, you should be able to see both pending operations.


Kudos to @rjarasson-ledger for finding those 🎊 