### PR TITLE
fix(network): handle error response as parsed json

### DIFF
--- a/src/network.js
+++ b/src/network.js
@@ -17,11 +17,18 @@ const makeError = (msg, status, url, method) => {
     : new LedgerAPI5xx(msg, obj);
 };
 
+const getErrorMessage = (data: Object): ?string => {
+  return (
+    data.cause || data.error || data.message || data.error_message || data.msg
+  );
+};
+
 const extractErrorMessage = (raw: string): ?string => {
   try {
     let data = JSON.parse(raw);
     if (data && Array.isArray(data)) data = data[0];
-    let msg = data.error || data.message || data.error_message || data.msg;
+    let msg = getErrorMessage(data);
+
     if (typeof msg === "string") {
       const m = msg.match(/^JsDefined\((.*)\)$/);
       const innerPart = m ? m[1] : msg;
@@ -56,6 +63,8 @@ const userFriendlyError = <A>(p: Promise<A>, meta): Promise<A> =>
       let msg;
       if (data && typeof data === "string") {
         msg = extractErrorMessage(data);
+      } else if (data && typeof data === "object") {
+        msg = getErrorMessage(data);
       }
       if (msg) {
         errorToThrow = makeError(msg, status, url, method);


### PR DESCRIPTION
Currently, `network.js` is used as a generic http client by many coins, with the advantage of handling errors and logging, and casting to error.

But it does it strangely, not taking into account that in most cases, body is already parsed as json.
I added the handling of error responses as Object, and use an helper to get the message.
I wildly added the "cause" property as a possible error message (that is used in polkadot's sidecar), I don't think it's the best idea though.

I really think that generic client should be more generic and provide a clean way to handle error / transform response etc... without forcing to use plain axios, it's a good idea to wrap it with common behaviour.