### PR TITLE
Swap `refunded` state to be KO instead of OK

### DIFF
--- a/src/exchange/swap/index.js
+++ b/src/exchange/swap/index.js
@@ -9,8 +9,8 @@ import initSwap from "./initSwap";
 import { getEnv } from "../../env";
 
 export const operationStatusList = {
-  finishedOK: ["finished", "refunded"],
-  finishedKO: ["expired", "failed"],
+  finishedOK: ["finished"],
+  finishedKO: ["expired", "failed", "refunded"],
   pending: [
     "confirming",
     "exchanging",


### PR DESCRIPTION
Due to the recently introduced stylings for swap status, I noticed the refunded status would show as green and it conveys to the user the operation ended successfully while it's not the case. This changes that. First version of  LLD and LLM including this change will automatically use the right color.