### PR TITLE
LL-3647 Allow tx to be replaced on eth on sync

### DIFF
--- a/src/families/ethereum/postSyncPatch.js
+++ b/src/families/ethereum/postSyncPatch.js
@@ -23,7 +23,7 @@ const postSyncPatchGen = <T: AccountLike>(
         // a child pending parent need to disappear if parent eth op disappear
         parentPendingOperation.some((o) => o.hash === op.hash)) &&
       op.transactionSequenceNumber &&
-      op.transactionSequenceNumber >= latestNonce &&
+      op.transactionSequenceNumber > latestNonce &&
       // retain logic
       (shouldRetainPendingOperation(mainAccount, op) ||
         // after retain logic, we need operation to appear


### PR DESCRIPTION
## Summary
Not sure if this introduces another issue, but following the discussion on the Jira ticket associated, if we allow an operation with the same nonce to replace the pending operation, we can override/replace a pending operation and avoid the ghosting effect.

## Example for testing the solution
- Create a tx on eth on LLD with an amount of 0.0001 and with low gas so it takes time to confirm
- Create another one with the same nonce on mew, amount of 0.0002 and higher gas to replace the first one
- Sync on LLD, it should remove the pending tx with the amount 0.0001 with the one with 0.0002

On develop, the behaviour would be that we'd see both, since the pending one has the same nonce as the new one. Sending another tx would then remove the pending one, or clearing cache since they're only local.

## Context
https://ledgerhq.atlassian.net/browse/LL-3647