### PR TITLE
LL-4428 Fix ghost pending tx when dropped

### DIFF
--- a/src/families/ethereum/postSyncPatch.js
+++ b/src/families/ethereum/postSyncPatch.js
@@ -33,11 +33,10 @@ const postSyncPatchGen = <T: AccountLike>(
 };
 
 const postSyncPatch = (initial: Account, synced: Account): Account => {
-  const sendingOps = (synced.operations || []).filter(
-    (op) => op.type === "OUT"
+  const last = synced.operations.find((op) =>
+    ["OUT", "FEES"].includes(op.type)
   );
-  const latestNonce =
-    (sendingOps.length > 0 && sendingOps[0].transactionSequenceNumber) || 0;
+  const latestNonce = last?.transactionSequenceNumber || 0;
   const acc = postSyncPatchGen(initial, synced, latestNonce, synced);
   const { subAccounts, pendingOperations } = acc;
   const initialSubAccounts = initial.subAccounts;


### PR DESCRIPTION
We were only clearing the pending operations when an `OUT` operation was added with a nonce higher or equal to the pending one, this resulted in the edge case where we could replace a tx with another one sending to a different account but it would remain there for a self tx. The reason is this self transaction is currently marked as an `IN` not a `SELF` or similar (could be an improvement cc product according to @gre).

