### PR TITLE
feat(Polkadot): cache sidecar fetchConstants - COIN-1248

### DIFF
--- a/src/families/polkadot/cache.js
+++ b/src/families/polkadot/cache.js
@@ -61,10 +61,7 @@ const hashTransactionParams = (a: Account, t: Transaction) => {
  *
  * @returns {Promise<Object>} txInfo
  */
-export const getTransactionParams: CacheRes<
-  Array<Account>,
-  Object
-> = makeLRUCache(
+export const getTransactionParams: CacheRes<Array<void>, Object> = makeLRUCache(
   async (): Promise<Object> => apiGetTransactionParams(),
   () => "polkadot",
   {


### PR DESCRIPTION
I added a cache to fetchConstants for sidecar api implementation to avoid calling it too many time - it does not change very often(should never change in fact).

Other solution would have been to totally replace the calls by using metadata and extract constants from it, but it would also need caching (that is already done in cache.js file).
Or maybe not calculating the unlockings date, and do this from preloaded data.
Anyway, I found no other solution than to add LRU cache directly in api.js, to avoir circular imports - and make it just simpler.