### PR TITLE
feat(Polkadot): improve fees cache by using tx bytesize - COIN-1249

### DIFF
--- a/src/families/polkadot/js-estimateMaxSpendable.js
+++ b/src/families/polkadot/js-estimateMaxSpendable.js
@@ -6,7 +6,7 @@ import { getMainAccount } from "../../account";
 
 import type { Transaction } from "./types";
 import { calculateAmount } from "./logic";
-import { getFees } from "./cache";
+import getEstimatedFees from "./js-getFeesForTransaction";
 
 import createTransaction from "./js-createTransaction";
 
@@ -31,7 +31,7 @@ const estimateMaxSpendable = async ({
     useAllAmount: true,
   };
 
-  const fees = await getFees({ a, t });
+  const fees = await getEstimatedFees({ a, t });
 
   return calculateAmount({ a, t: { ...t, fees } });
 };

--- a/src/families/polkadot/js-prepareTransaction.js
+++ b/src/families/polkadot/js-prepareTransaction.js
@@ -2,7 +2,7 @@
 import type { Account } from "../../types";
 import type { Transaction } from "./types";
 
-import { getFees } from "./cache";
+import getEstimatedFees from "./js-getFeesForTransaction";
 
 const sameFees = (a, b) => (!a || !b ? a === b : a.eq(b));
 
@@ -14,7 +14,7 @@ const sameFees = (a, b) => (!a || !b ? a === b : a.eq(b));
 const prepareTransaction = async (a: Account, t: Transaction) => {
   let fees = t.fees;
 
-  fees = await getFees({ a, t });
+  fees = await getEstimatedFees({ a, t });
 
   if (!sameFees(t.fees, fees)) {
     return { ...t, fees };


### PR DESCRIPTION
Fees estimation depends on 2 factors:
* weight: which depends on the method called by the extrinsic
* bytesize (or length): which varies when changing amounts.


Different amounts don't always change bytesize so we can use bytesize instead of exact amount - avoiding many useless calls.

NOTE: This should be heavily tested since any bad implementation can lead to wrong fee estimation, but I have no specific test plan for this.

