### PR TITLE
Use correct unit for swap rate errors

### DIFF
--- a/cli/src/live-common-setup-base.js
+++ b/cli/src/live-common-setup-base.js
@@ -37,7 +37,7 @@ setSupportedCurrencies([
   "stellar",
   "cosmos",
   "algorand",
-  "polkadot"
+  "polkadot",
 ]);
 
 for (const k in process.env) setEnvUnsafe(k, process.env[k]);

--- a/cli/src/scan.js
+++ b/cli/src/scan.js
@@ -376,7 +376,7 @@ export function scan(arg: ScanCommonOpts): Observable<Account> {
               operationsCount: 0,
               operations: [],
               pendingOperations: [],
-              swapHistory: []
+              swapHistory: [],
             };
             return account;
           })

--- a/src/exchange/swap/getExchangeRates.js
+++ b/src/exchange/swap/getExchangeRates.js
@@ -25,9 +25,8 @@ const getExchangeRates: GetExchangeRates = async (
   const unitTo = getAccountUnit(exchange.toAccount);
   const to = getAccountCurrency(exchange.toAccount).id;
   const amountFrom = transaction.amount;
-  const apiAmount = BigNumber(amountFrom).div(
-    BigNumber(10).pow(unitFrom.magnitude)
-  );
+  const tenPowMagnitude = BigNumber(10).pow(unitFrom.magnitude);
+  const apiAmount = BigNumber(amountFrom).div(tenPowMagnitude);
 
   const res = await network({
     method: "POST",
@@ -50,7 +49,7 @@ const getExchangeRates: GetExchangeRates = async (
           ? new SwapExchangeRateAmountTooLow(null, {
               minAmountFromFormatted: formatCurrencyUnit(
                 unitFrom,
-                BigNumber(minAmountFrom),
+                BigNumber(minAmountFrom).times(tenPowMagnitude),
                 {
                   alwaysShowSign: false,
                   disableRounding: true,
@@ -61,7 +60,7 @@ const getExchangeRates: GetExchangeRates = async (
           : new SwapExchangeRateAmountTooHigh(null, {
               maxAmountFromFormatted: formatCurrencyUnit(
                 unitFrom,
-                BigNumber(maxAmountFrom),
+                BigNumber(maxAmountFrom).times(tenPowMagnitude),
                 {
                   alwaysShowSign: false,
                   disableRounding: true,

--- a/src/exchange/swap/mock.js
+++ b/src/exchange/swap/mock.js
@@ -25,7 +25,8 @@ export const mockGetExchangeRates = async (
   const amount = transaction.amount;
   const unitFrom = getAccountUnit(fromAccount);
   const unitTo = getAccountUnit(toAccount);
-  const amountFrom = amount.div(BigNumber(10).pow(unitFrom.magnitude));
+  const tenPowMagnitude = BigNumber(10).pow(unitFrom.magnitude);
+  const amountFrom = amount.div(tenPowMagnitude);
   const minAmountFrom = BigNumber(0.0001);
   const maxAmountFrom = BigNumber(1000);
 
@@ -33,7 +34,7 @@ export const mockGetExchangeRates = async (
     throw new SwapExchangeRateAmountTooLow(null, {
       minAmountFromFormatted: formatCurrencyUnit(
         unitFrom,
-        BigNumber(minAmountFrom),
+        BigNumber(minAmountFrom).times(tenPowMagnitude),
         {
           alwaysShowSign: false,
           disableRounding: true,
@@ -47,7 +48,7 @@ export const mockGetExchangeRates = async (
     throw new SwapExchangeRateAmountTooHigh(null, {
       maxAmountFromFormatted: formatCurrencyUnit(
         unitFrom,
-        BigNumber(maxAmountFrom),
+        BigNumber(maxAmountFrom).times(tenPowMagnitude),
         {
           alwaysShowSign: false,
           disableRounding: true,

--- a/src/families/ethereum/types.js
+++ b/src/families/ethereum/types.js
@@ -82,7 +82,7 @@ export type TypedMessage = {
   hashes: {
     domainHash: string,
     messageHash: string,
-  }
+  },
 };
 
 export type TypedMessageData = {
@@ -93,7 +93,7 @@ export type TypedMessageData = {
   message: TypedMessage,
   hashes: {
     stringHash: string,
-  }
+  },
 };
 
 //

--- a/src/families/polkadot/types.js
+++ b/src/families/polkadot/types.js
@@ -5,7 +5,11 @@ import type {
   TransactionCommonRaw,
 } from "../../types/transaction";
 
-export type RewardDestinationType = "Staked" | "Stash" | "Account" | "Controller"
+export type RewardDestinationType =
+  | "Staked"
+  | "Stash"
+  | "Account"
+  | "Controller";
 
 export type CoreStatics = {};
 
@@ -15,7 +19,7 @@ export type CoreOperationSpecifics = {};
 
 export type CoreCurrencySpecifics = {};
 
-export type PolkadotNominationStatus = "active" | "inactive" | "waiting" | null;
+export type PolkadotNominationStatus = "active" | "inactive" | "waiting" | null;
 
 export type PolkadotNomination = {|
   address: string,
@@ -46,8 +50,8 @@ export type PolkadotResources = {|
   lockedBalance: BigNumber,
   unlockedBalance: BigNumber,
   unlockingBalance: BigNumber,
-  unlockings: ?PolkadotUnlocking[],
-  nominations: ?PolkadotNomination[],
+  unlockings: ?(PolkadotUnlocking[]),
+  nominations: ?(PolkadotNomination[]),
   numSlashingSpans: number,
 |};
 
@@ -58,8 +62,8 @@ export type PolkadotResourcesRaw = {|
   lockedBalance: string,
   unlockedBalance: string,
   unlockingBalance: string,
-  unlockings: ?PolkadotUnlockingRaw[],
-  nominations: ?PolkadotNominationRaw[],
+  unlockings: ?(PolkadotUnlockingRaw[]),
+  nominations: ?(PolkadotNominationRaw[]),
   numSlashingSpans: number,
 |};
 
@@ -68,7 +72,7 @@ export type Transaction = {|
   mode: string,
   family: "polkadot",
   fees: ?BigNumber,
-  validators: ?string[],
+  validators: ?(string[]),
   era: ?string,
   rewardDestination: ?string,
   numSlashingSpans: ?number,
@@ -79,7 +83,7 @@ export type TransactionRaw = {|
   family: "polkadot",
   mode: string,
   fees: ?string,
-  validators: ?string[],
+  validators: ?(string[]),
   era: ?string,
   rewardDestination: ?string,
   numSlashingSpans: ?number,


### PR DESCRIPTION
Fixes a regression in the error handling of swap exchange rate bounds where we would treat 1BTC (or base unit for chose currency) as 1 satoshi of the same currency, resulting in error that displayed the wrong amount. 
![image](https://user-images.githubusercontent.com/4631227/106302420-412cd280-6259-11eb-8642-ceb178a77ef4.png)


>_Prettier brought some unrelated styling changes here, perhaps we need to fix that on master first_