### PR TITLE
make Live keep asking for data in case of "holes" in it

### DIFF
--- a/src/countervalues/logic.js
+++ b/src/countervalues/logic.js
@@ -382,7 +382,9 @@ function generateCache(
     const now = Date.now();
     const oldestTime = oldestDate.getTime();
     let shiftingValue = map[oldest];
-    fallback = shiftingValue;
+    if (settings.autofillGaps) {
+      fallback = shiftingValue;
+    }
     for (let t = oldestTime; t < now; t += incrementPerGranularity.daily) {
       const d = new Date(t);
       const k = formatCounterValueDay(d);

--- a/src/countervalues/logic.js
+++ b/src/countervalues/logic.js
@@ -13,7 +13,6 @@ import type {
   RateMap,
   RateGranularity,
   PairRateMapCache,
-  RateMapStats,
 } from "./types";
 import {
   pairId,
@@ -112,8 +111,8 @@ export async function loadCountervalues(
     const limit = datapointLimits[granularity];
     settings.trackingPairs.forEach(({ from, to, startDate }) => {
       const key = pairId({ from, to });
-      const value: ?RateMap = data[key];
-      const stats = value && rateMapStats(value);
+      const c: ?PairRateMapCache = cache[key];
+      const stats = c && c.stats;
       const s = status[key];
 
       // when there are too much http failures, slow down the rate to be actually re-fetched
@@ -153,8 +152,12 @@ export async function loadCountervalues(
       }
       if (!needOlderReload) {
         // we do not miss datapoints in the past so we can ask the only remaining part
-        if (stats && stats.earliestDate && stats.earliestDate > start) {
-          start = stats.earliestDate;
+        if (
+          stats &&
+          stats.earliestStableDate &&
+          stats.earliestStableDate > start
+        ) {
+          start = stats.earliestStableDate;
         }
       }
 
@@ -354,7 +357,13 @@ export function calculateMany(
   });
 }
 
-function rateMapStats(map: RateMap): RateMapStats {
+function generateCache(
+  pair: string,
+  rateMap: RateMap,
+  settings: CountervaluesSettings
+): PairRateMapCache {
+  const map = { ...rateMap };
+
   const sorted = Object.keys(map)
     .sort()
     .filter((k) => k !== "latest");
@@ -362,42 +371,51 @@ function rateMapStats(map: RateMap): RateMapStats {
   const earliest = sorted[sorted.length - 1];
   const oldestDate = oldest ? parseFormattedDate(oldest) : null;
   const earliestDate = earliest ? parseFormattedDate(earliest) : null;
-  return { oldest, earliest, oldestDate, earliestDate };
-}
+  let earliestStableDate = earliestDate;
 
-function generateCache(
-  pair: string,
-  rateMap: RateMap,
-  settings: CountervaluesSettings
-): PairRateMapCache {
-  const map = { ...rateMap };
-  const stats = rateMapStats(map);
   let fallback;
+  let hasHole = false;
 
-  const { oldest, oldestDate } = stats;
-  if (settings.autofillGaps) {
-    if (oldestDate && oldest) {
-      // shifting daily gaps (hourly don't need to be shifted as it automatically fallback on a day rate)
-      const now = Date.now();
-      const oldestTime = oldestDate.getTime();
-      let shiftingValue = map[oldest];
-      fallback = shiftingValue;
-      for (let t = oldestTime; t < now; t += incrementPerGranularity.daily) {
-        const k = formatCounterValueDay(new Date(t));
-        if (!(k in map)) {
+  if (oldestDate && oldest) {
+    // we find the most recent stable day and we set it in earliestStableDate
+    // if autofillGaps is on, shifting daily gaps (hourly don't need to be shifted as it automatically fallback on a day rate)
+    const now = Date.now();
+    const oldestTime = oldestDate.getTime();
+    let shiftingValue = map[oldest];
+    fallback = shiftingValue;
+    for (let t = oldestTime; t < now; t += incrementPerGranularity.daily) {
+      const d = new Date(t);
+      const k = formatCounterValueDay(d);
+      if (!(k in map)) {
+        if (!hasHole) {
+          hasHole = true;
+          earliestStableDate = d;
+        }
+        if (settings.autofillGaps) {
           map[k] = shiftingValue;
-        } else {
+        }
+      } else {
+        if (settings.autofillGaps) {
           shiftingValue = map[k];
         }
       }
-      if (!map.latest) {
-        map.latest = shiftingValue;
-      }
-    } else {
+    }
+    if (!map.latest && settings.autofillGaps) {
+      map.latest = shiftingValue;
+    }
+  } else {
+    if (settings.autofillGaps) {
       fallback = map.latest || 0;
     }
   }
 
+  const stats = {
+    oldest,
+    earliest,
+    oldestDate,
+    earliestDate,
+    earliestStableDate,
+  };
   return { map, stats, fallback };
 }
 

--- a/src/countervalues/types.js
+++ b/src/countervalues/types.js
@@ -69,8 +69,12 @@ export type CounterValuesStatus = {
 export type RateMapStats = {
   oldest: ?string,
   earliest: ?string,
+  // oldest datapoint
   oldestDate: ?Date,
+  // most recent datapoint
   earliestDate: ?Date,
+  // most recent datapoint before the first "hole"
+  earliestStableDate: ?Date,
 };
 
 export type PairRateMapCache = {


### PR DESCRIPTION
### Root cause (backend)

Our API sometimes happens to have missing data. like this:

https://countervalues.live.ledger.com/hourly/BTC/EUR

```js
{"2021-01-25T02": 27055.75799909473,
  "2021-01-25T04": 27667.026575169515,
  "2021-01-28T03": 25755.58755949997 }
```

which also happens on /daily.

### Before behavior (frontend)

when Ledger Live was loading that, it made our previous logic considering `2021-01-28T03` as the "latest date" we can continue forward from. It was making Ledger Live never retrying to pull the data before, even with holes in it, until user Clear Cache. We basically assumed that if API managed to get 2021-01-28T03, it should have managed to have all the previous datapoint before it (and if it won't, we assumed it was a permanently NA case)

so Ledger Live was only polling https://countervalues.live.ledger.com/hourly/BTC/EUR?start=2021-01-28T03

visually, it makes Ledger Live show graph as completely flat, with some spikes here and here (on each data point that we managed to partially get).

![téléchargement](https://user-images.githubusercontent.com/211411/106454999-e0391080-648b-11eb-9222-18268d4e499f.jpeg)

### After behavior (frontend)


With this PR logic, we no longer will assume `2021-01-28T03` is the data to start recovering from, we will take the last date before the first hole happens. we call it "last stable date".

Tradeoff: we consider the "last stable date" **only for daily endpoint** so we would pull from 2021-01-25 in daily and 2021-01-25T00 in hourly. That means we assume that, when there is a hole situation, that it happens both on daily and hourly. It's an acceptable approach from Live perspective because hourly is only esthetic with a fallback on daily when not available. Doing it on hourly would be not a so good idea because it's also pretty common to have holes in hourly and we don't want to pull things too much.

NB for future: note that we don't "clean up" our previous cache for hourly: we load 1 past week of data, but we never clean up when that range is "past".