### PR TITLE
Few updates on countervalues imports & doc

### DIFF
--- a/docs/countervalues.md
+++ b/docs/countervalues.md
@@ -32,14 +32,14 @@ import {
 
 function App() {
   // get these in the client side
-  const account = ...
-  const trackingPairs = ...
+  const accounts = ...
 
   const trackingPairs = useTrackingPairForAccounts(accounts, countervalueCurrency)
+
   return (
     <Countervalues
       userSettings={{
-        autoFillGaps: true,
+        autofillGaps: true,
         trackingPairs
       }}
       // use this prop to restore local countervalues cache

--- a/src/countervalues/logic.js
+++ b/src/countervalues/logic.js
@@ -2,8 +2,7 @@
 
 import { log } from "@ledgerhq/logs";
 import type { Currency, Account } from "../types";
-import { flattenAccounts } from "../account";
-import { getAccountCurrency } from "../account";
+import { flattenAccounts, getAccountCurrency } from "../account/helpers";
 import { promiseAllBatched } from "../promise";
 import type {
   CounterValuesState,

--- a/src/countervalues/react.js
+++ b/src/countervalues/react.js
@@ -28,7 +28,7 @@ import {
   getAccountCurrency,
   flattenAccounts,
   getAccountUnit,
-} from "../account";
+} from "../account/helpers";
 import {
   initialState,
   calculate,

--- a/src/portfolio/index.js
+++ b/src/portfolio/index.js
@@ -21,7 +21,7 @@ import type {
   CryptoCurrency,
 } from "../types";
 import { getOperationAmountNumberWithInternals } from "../operation";
-import { flattenAccounts, getAccountCurrency } from "../account";
+import { flattenAccounts, getAccountCurrency } from "../account/helpers";
 import { getEnv } from "../env";
 import { getPortfolioRangeConfig, getDates } from "./range";
 


### PR DESCRIPTION
main issue I'm facing right now in web-integration is caused by import pulling the whole npm registry, and ending up with incompatible modules e.g:

![1612973243](https://user-images.githubusercontent.com/315259/107542489-868dc000-6bc8-11eb-9357-b75739d84c28.png)

This PR does not bring much change than just importing directly from helper file rather than index file.

+ minor doc adjustment