### PR TITLE
Add min version for stellar app

### DIFF
--- a/src/exchange/index.js
+++ b/src/exchange/index.js
@@ -16,6 +16,7 @@ const exchangeSupportAppVersions = {
   litecoin: "1.5.0",
   qtum: "1.5.0",
   ripple: "2.1.0",
+  stellar: "3.3.0",
   stratis: "1.5.0",
   zcash: "1.5.0",
   zencash: "1.5.0",


### PR DESCRIPTION
Although the cli support for stellar was introduced in a previous pr, I forgot to add the entry to the min version check that governs access to the feature on LLD and LLM, making it impossible for QA to test. This fixes that.