### PR TITLE
Remove the amount update from Cosmos rewards spec

### DIFF
--- a/src/families/cosmos/specs.js
+++ b/src/families/cosmos/specs.js
@@ -3,6 +3,7 @@ import expect from "expect";
 import sample from "lodash/sample";
 import sampleSize from "lodash/sampleSize";
 import invariant from "invariant";
+import { BigNumber } from "bignumber.js";
 import type { Transaction } from "../../families/cosmos/types";
 import { getCurrentCosmosPreloadData } from "../../families/cosmos/preloadedData";
 import { getCryptoCurrencyById } from "../../currencies";
@@ -313,7 +314,12 @@ const cosmos: AppSpec<Transaction> = {
               validators: [
                 {
                   address: delegation.validatorAddress,
-                  amount: delegation.pendingRewards,
+                  // TODO: the test should be
+                  // amount: delegation.pendingRewards,
+                  // but it won't work until COIN-665 is fixed until then,
+                  // amount is set to 0 in
+                  // src/families/cosmos/libcore-buildOperation in the REWARD case
+                  amount: BigNumber(0),
                 },
               ],
             },


### PR DESCRIPTION
The operation can't be expected to match until COIN-665 is fixed