### PR TITLE
COIN-1372 Bump Polkadot app minimum version to v6.28.0

### DIFF
--- a/src/apps/support.js
+++ b/src/apps/support.js
@@ -27,7 +27,7 @@ export function shouldUpgrade(
 const appVersionsRequired = {
   Cosmos: ">= 2.14",
   Algorand: ">= 1.2.9",
-  Polkadot: ">= 5.26.1",
+  Polkadot: ">= 6.28.0",
 };
 
 export function mustUpgrade(


### PR DESCRIPTION
**HOLD** until Polkadot app v6.28.0 is released on provider 1