### PR TITLE
fix(Polkadot): fix election status threshold + add ENV to tweak it - COIN-1376

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -344,6 +344,12 @@ const envDefinitions = {
     parser: intParser,
     desc: "defines the initial default operation length page to use",
   },
+  POLKADOT_ELECTION_STATUS_THRESHOLD: {
+    def: 25,
+    parser: intParser,
+    desc:
+      "in blocks - number of blocks before Polkadot election effectively opens to consider it as open and disable all staking features",
+  },
   SATSTACK: {
     def: false,
     parser: boolParser,

--- a/src/families/polkadot/api/sidecar.js
+++ b/src/families/polkadot/api/sidecar.js
@@ -51,7 +51,8 @@ const getBaseSidecarUrl = (): string => getEnv("API_POLKADOT_SIDECAR");
 const getSidecarUrl = (route): string => `${getBaseSidecarUrl()}${route || ""}`;
 
 const VALIDATOR_COMISSION_RATIO = 1000000000;
-const ELECTION_STATUS_OPTIMISTIC_THRESHOLD = 25; // blocks = 2 minutes 30
+const ELECTION_STATUS_OPTIMISTIC_THRESHOLD =
+  getEnv("POLKADOT_ELECTION_STATUS_THRESHOLD") || 25; // blocks = 2 minutes 30
 
 /**
  * Fetch Balance from the api.
@@ -578,6 +579,7 @@ export const getStakingProgress = async (): Promise<PolkadotStakingProgress> => 
   ]);
 
   const activeEra = Number(progress.activeEra);
+  const currentBlock = Number(progress.at.height);
   const toggleEstimate = Number(progress.electionStatus?.toggleEstimate);
   const electionClosed = !progress.electionStatus?.status?.Open;
 
@@ -587,8 +589,9 @@ export const getStakingProgress = async (): Promise<PolkadotStakingProgress> => 
   const optimisticElectionClosed =
     electionClosed &&
     activeEra &&
+    currentBlock &&
     toggleEstimate &&
-    activeEra >= toggleEstimate - ELECTION_STATUS_OPTIMISTIC_THRESHOLD
+    currentBlock >= toggleEstimate - ELECTION_STATUS_OPTIMISTIC_THRESHOLD
       ? false
       : electionClosed;
 


### PR DESCRIPTION
Election Status is set Open early to prevent user to start staking flows while election is about to start (or has started, but sync did not fetched it soon enough).

This was not working (comparing activeEra instead of currentBlock to the estimatedToggle value of election provided by sidecar) so i fixed it.

Also, i added an POLKADOT_ELECTION_STATUS_THRESHOLD env variable to tweak it (value is a number of blocks).

**_How to find the currently remaining blocks before election is open ?_**

Go to https://polkadot-sidecar.coin.ledger.com/pallets/staking/progress
Calculate `electionStatus.toggleEstimate`- `at.height` (when election is Close)
This is the expected block remaining before election starts
Set the threshold higher and election will be considered Open
Set the threshold a bit less (1 block = 6s) and you should see Ledger Live Desktop popping a banner saying that an election is pending.