### PR TITLE
LL-4672 Allow new apps to pass the quitApp support test

### DIFF
--- a/src/appSupportsQuitApp.js
+++ b/src/appSupportsQuitApp.js
@@ -155,5 +155,5 @@ export const minAppVersion = {
 };
 
 export default ({ name, version }: AppAndVersion) =>
-  name in minAppVersion &&
+  !(name in minAppVersion) ||
   semver.gte(semver.coerce(version), minAppVersion[name]);

--- a/src/appSupportsQuitApp.test.js
+++ b/src/appSupportsQuitApp.test.js
@@ -1,22 +1,24 @@
 // @flow
-import network from "./network";
-import { minAppVersion, req } from "./appSupportsQuitApp";
+import appSupportsQuitApp from "./appSupportsQuitApp";
 
-test("appSupportsQuitApp - Check if we have all apps from provider 1 listed", () => {
-  return network(req).then(({ data }) => {
-    // Extract the names and versions from the latest snapshot
-    if (data && "application_versions" in data) {
-      const latestAppsAndVersions = data.application_versions.reduce(
-        (acc, app) => {
-          acc[app.name] = app.version;
-          return acc;
-        },
-        {}
-      );
+test("appSupportsQuitApp - Apps that are listed fail if version is lt", () => {
+  expect(
+    appSupportsQuitApp({ name: "Wanchain", version: "1.0.0", flags: 0 })
+  ).toBeFalsy();
+});
 
-      expect(Object.keys(latestAppsAndVersions).sort()).toMatchObject(
-        Object.keys(minAppVersion)
-      );
-    }
-  });
+test("appSupportsQuitApp - Apps that are listed pass if version is gte", () => {
+  expect(
+    appSupportsQuitApp({ name: "Wanchain", version: "1.4.0", flags: 0 })
+  ).toBeTruthy();
+});
+
+test("appSupportsQuitApp - Apps that are not listed pass the test", () => {
+  expect(
+    appSupportsQuitApp({
+      name: "FakeAppName",
+      version: "1.2.3",
+      flags: 0,
+    })
+  ).toBeTruthy();
 });


### PR DESCRIPTION
To avoid having to manually update all the apps that get released to say they support the `quitApp` command, we will now assume that apps that are not listed as of today will always support this by default. If there's an app that doesn't support it then we can make it opt-in by updating live-common to exclude it 🤔 

Tests have been updated accordingly 