### PR TITLE
fix(Polkadot): ensure Polkadot prefix is also valid in address - COIN-1379

### DIFF
--- a/src/families/polkadot/logic.js
+++ b/src/families/polkadot/logic.js
@@ -11,16 +11,20 @@ export const MAX_NOMINATIONS = 16;
 export const MAX_UNLOCKINGS = 32;
 export const PRELOAD_MAX_AGE = 60 * 1000;
 export const MAX_AMOUNT_INPUT = 0xffffffffffffffff;
+export const POLKADOT_SS58_PREFIX = 0;
 
 /**
  * Returns true if address is valid, false if it's invalid (can't parse or wrong checksum)
  *
  * @param {*} address
  */
-export const isValidAddress = (address: string): boolean => {
+export const isValidAddress = (
+  address: string,
+  ss58Format = POLKADOT_SS58_PREFIX
+): boolean => {
   if (!address) return false;
   try {
-    decodeAddress(address);
+    decodeAddress(address, false, ss58Format);
     return true;
   } catch (err) {
     return false;


### PR DESCRIPTION
Address validation was only taking SS58 and checksum is valid, but not that the address belongs to Polkadot network.

This could lead to users sending DOTs to the wrong address.

NOTE: the nano app converts the address to a polkadot address corresponding to the same public key. Although, this could lead to misunderstanding to users, since the address displayed on device is different.

This fixes the issue by considering only POlkadot addresses as valid.