### PR TITLE
[Cosmos] allow unranked validator to be display

### DIFF
--- a/src/families/cosmos/logic.js
+++ b/src/families/cosmos/logic.js
@@ -35,7 +35,7 @@ export function mapDelegations(
     const rank = validators.findIndex(
       (v) => v.validatorAddress === d.validatorAddress
     );
-    const validator = validators[rank];
+    const validator = validators[rank] ?? d;
 
     return {
       ...d,


### PR DESCRIPTION
When a Validator is not in the rank pool of validator it will display an undefined name and address since it doesn't belong to the list anymore