### PR TITLE
Update XRPL endpoint to alternative

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -70,7 +70,7 @@ const envDefinitions = {
   },
   API_RIPPLE_WS: {
     parser: stringParser,
-    def: "wss://xrpl.ws",
+    def: "wss://node.xrpledger.foundation",
     desc: "XRP Ledger full history open WebSocket endpoint",
   },
   API_POLKADOT_INDEXER: {

--- a/src/env.js
+++ b/src/env.js
@@ -70,7 +70,7 @@ const envDefinitions = {
   },
   API_RIPPLE_WS: {
     parser: stringParser,
-    def: "wss://node.xrpledger.foundation",
+    def: "wss://xrplcluster.com",
     desc: "XRP Ledger full history open WebSocket endpoint",
   },
   API_POLKADOT_INDEXER: {


### PR DESCRIPTION
the .WS domain TLD has trouble and we're (XRP Ledger Foundation) are not comfortable using .ws in the future as our primary endpoint. We launched an alternative endpoint on a more reliable TLD:
wss://node.xrpledger.foundation

More info:
https://twitter.com/XRPLF/status/1367433363657809924
https://twitter.com/WietseWind/status/1367431235686006785