### PR TITLE
LL-4834 – GasLessThanEstimate in errors

### DIFF
--- a/src/families/ethereum/bridge/js.js
+++ b/src/families/ethereum/bridge/js.js
@@ -96,7 +96,7 @@ const getTransactionStatus = (a, t) => {
   }
 
   if (t.estimatedGasLimit && gasLimit.lt(t.estimatedGasLimit)) {
-    warnings.gasLimit = new GasLessThanEstimate();
+    errors.gasLimit = new GasLessThanEstimate();
   }
 
   return Promise.resolve(result);

--- a/src/families/ethereum/test-dataset.js
+++ b/src/families/ethereum/test-dataset.js
@@ -110,10 +110,10 @@ const dataset: DatasetTest<Transaction> = {
                 amount: BigNumber("800000000000000"),
                 estimatedFees: BigNumber("2100000"),
                 totalSpent: BigNumber("800000000000000"),
-                errors: {},
-                warnings: {
+                errors: {
                   gasLimit: new GasLessThanEstimate(),
                 },
+                warnings: {},
               },
             },
             {


### PR DESCRIPTION
This will make lowering gas limit under gas estimation no longer a warning **but an actual error** which will blocker user to reach a broadcast error that would likely happen in that case.