### PR TITLE
scanAccounts to not fail on older device versions

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -10,6 +10,10 @@ export const ConnectManagerTimeout = createCustomErrorClass(
   "ConnectManagerTimeout"
 );
 
+export const GetAppAndVersionUnsupportedFormat = createCustomErrorClass(
+  "GetAppAndVersionUnsupportedFormat"
+);
+
 export const FeeEstimationFailed = createCustomErrorClass(
   "FeeEstimationFailed"
 );

--- a/src/hw/getAppAndVersion.js
+++ b/src/hw/getAppAndVersion.js
@@ -1,5 +1,5 @@
 // @flow
-import invariant from "invariant";
+import { GetAppAndVersionUnsupportedFormat } from "../errors";
 import Transport from "@ledgerhq/hw-transport";
 
 export default async (
@@ -8,7 +8,11 @@ export default async (
   const r = await transport.send(0xb0, 0x01, 0x00, 0x00);
   let i = 0;
   const format = r[i++];
-  invariant(format === 1, "getAppAndVersion: format not supported");
+  if (format !== 1) {
+    throw new GetAppAndVersionUnsupportedFormat(
+      "getAppAndVersion: format not supported"
+    );
+  }
   const nameLength = r[i++];
   const name = r.slice(i, (i += nameLength)).toString("ascii");
   const versionLength = r[i++];

--- a/src/libcore/scanAccounts.js
+++ b/src/libcore/scanAccounts.js
@@ -36,6 +36,7 @@ import {
   createAccountFromDevice,
 } from "./createAccountFromDevice";
 import { remapLibcoreErrors, isNonExistingAccountError } from "./errors";
+import { GetAppAndVersionUnsupportedFormat } from "../errors";
 import nativeSegwitAppsVersionsMap from "./nativeSegwitAppsVersionsMap";
 import type { Core, CoreWallet } from "./types";
 
@@ -182,14 +183,27 @@ export const scanAccounts = ({
 
             if (derivationMode === "native_segwit") {
               if (nativeSegwitAppsVersionsMap[currency.managerAppName]) {
-                const { version } = await getAppAndVersion(transport);
-                if (
-                  !semver.gte(
-                    version,
-                    nativeSegwitAppsVersionsMap[currency.managerAppName]
-                  )
-                ) {
-                  continue;
+                try {
+                  const { version } = await getAppAndVersion(transport);
+                  if (
+                    !semver.gte(
+                      version,
+                      nativeSegwitAppsVersionsMap[currency.managerAppName]
+                    )
+                  ) {
+                    continue;
+                  }
+                } catch (e) {
+                  // in case the apdu is not even supported, we assume to not do native_segwit
+
+                  if (
+                    (e instanceof TransportStatusError &&
+                      e.statusCode === 0x6d00) ||
+                    e instanceof GetAppAndVersionUnsupportedFormat
+                  ) {
+                    continue;
+                  }
+                  throw e;
                 }
               }
             }


### PR DESCRIPTION
- we had a mecanism in place to feature detect "native segwit" feature which didn't work in past version of Bitcoin apps.
- that mecanism is based on "get app" apdu, which unfortunately do'nt even work in even older nano s
- the solution is to consider a fail of get app is a "not supported" case too