### PR TITLE
SOCKS proxy support

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "semver": "^7.3.4",
     "sha.js": "^2.4.11",
     "stellar-sdk": "^7.0.0",
+    "socks-proxy-agent": "^5.0.0",
     "triple-beam": "^1.3.0",
     "winston": "^3.3.3",
     "xstate": "^4.16.2"

--- a/src/api/socket.js
+++ b/src/api/socket.js
@@ -16,6 +16,14 @@ import { cancelDeviceAction } from "../hw/deviceAccess";
 import { getEnv } from "../env";
 import type { SocketEvent } from "../types/manager";
 
+let proxyAgent;
+
+const socksProxy = process.env.SOCKS_PROXY;
+if (socksProxy) {
+  const SocksProxyAgent = require("socks-proxy-agent");
+  proxyAgent = new SocksProxyAgent(socksProxy);
+}
+
 const warningsSubject = new Subject();
 export const warnings: Observable<string> = warningsSubject.asObservable();
 
@@ -42,7 +50,7 @@ export const createDeviceSocket = (
     let inBulk = false; // bulk is a mode where we have many apdu to run on device and no longer need the connection
     let timeoutForAllowManager = null; // track if there is an ongoing allow manager step
 
-    const ws = new WS(url);
+    const ws = new WS(url, { agent: proxyAgent });
 
     ws.onopen = () => {
       log("socket-opened", url);

--- a/src/network.js
+++ b/src/network.js
@@ -6,6 +6,14 @@ import { NetworkDown, LedgerAPI5xx, LedgerAPI4xx } from "@ledgerhq/errors";
 import { retry } from "./promise";
 import { getEnv } from "./env";
 
+let proxyAgent;
+
+const socksProxy = process.env.SOCKS_PROXY;
+if (socksProxy) {
+  const SocksProxyAgent = require("socks-proxy-agent");
+  proxyAgent = new SocksProxyAgent(socksProxy);
+}
+
 const makeError = (msg, status, url, method) => {
   const obj = {
     status,
@@ -92,6 +100,8 @@ const userFriendlyError = <A>(p: Promise<A>, meta): Promise<A> =>
 const implementation = (arg: Object): Promise<*> => {
   invariant(typeof arg === "object", "network takes an object as parameter");
   let promise;
+  arg.httpsAgent = proxyAgent;
+  arg.proxy = false;
   if (arg.method === "GET") {
     if (!("timeout" in arg)) {
       arg.timeout = getEnv("GET_CALLS_TIMEOUT");

--- a/yarn.lock
+++ b/yarn.lock
@@ -4574,6 +4574,11 @@ ip-regex@^4.3.0:
   resolved "https://registry.yarnpkg.com/ip-regex/-/ip-regex-4.3.0.tgz#687275ab0f57fa76978ff8f4dddc8a23d5990db5"
   integrity sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==
 
+ip@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/ip/-/ip-1.1.5.tgz#bdded70114290828c0a039e72ef25f5aaec4354a"
+  integrity sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -7298,6 +7303,11 @@ slice-ansi@^4.0.0:
     astral-regex "^2.0.0"
     is-fullwidth-code-point "^3.0.0"
 
+smart-buffer@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.1.0.tgz#91605c25d91652f4661ea69ccf45f1b331ca21ba"
+  integrity sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
+
 snapdragon-node@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/snapdragon-node/-/snapdragon-node-2.1.1.tgz#6c175f86ff14bdb0724563e8f3c1b021a286853b"
@@ -7327,6 +7337,23 @@ snapdragon@^0.8.1:
     source-map "^0.5.6"
     source-map-resolve "^0.5.0"
     use "^3.1.0"
+
+socks-proxy-agent@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-5.0.0.tgz#7c0f364e7b1cf4a7a437e71253bed72e9004be60"
+  integrity sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==
+  dependencies:
+    agent-base "6"
+    debug "4"
+    socks "^2.3.3"
+
+socks@^2.3.3:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/socks/-/socks-2.5.1.tgz#7720640b6b5ec9a07d556419203baa3f0596df5f"
+  integrity sha512-oZCsJJxapULAYJaEYBSzMcz8m3jqgGrHaGhkmU/o/PQfFWYWxkAaA0UMGImb6s6tEXfKi959X6VJjMMQ3P6TTQ==
+  dependencies:
+    ip "^1.1.5"
+    smart-buffer "^4.1.0"
 
 sodium-native@^2.3.0:
   version "2.4.9"


### PR DESCRIPTION
With the contribution from @G-Ray the apps seems to work with a valid provided SOCKS proxy. I've only tested it with the one launched when running the Tor Browser, it does not (as expected) work with proxies on other protocols but it would be nice to explore that since the original issue was users behind corporate http proxies if I recall correctly.

We need to test this further because there were some 422 errors when fetching the countervalue endpoints but I couldn't see any broken behaviour in the app, which is better than not working at all. We could probably do some error handling too when we detect an invalid SOCKS proxy value instead of crashing. 