### PR TITLE
COIN-1423 [Polkadot] Keep a safety buffer of (3 * fees) for bond max

### DIFF
--- a/src/families/polkadot/logic.js
+++ b/src/families/polkadot/logic.js
@@ -183,9 +183,9 @@ export const getNonce = (a: Account): number => {
  * @param {*} t
  */
 const calculateMaxBond = (a: Account, t: Transaction): BigNumber => {
-  const amount = a.spendableBalance.minus(
-    t.fees ? BigNumber(BOND_MAX_SAFETY_RATIO).times(t.fees) : 0
-  );
+  const fees = t.fees;
+  const safetyRatio = BigNumber(BOND_MAX_SAFETY_RATIO);
+  const amount = a.spendableBalance.minus(fees ? fees.times(safetyRatio) : 0);
   return amount.lt(0) ? BigNumber(0) : amount;
 };
 

--- a/src/families/polkadot/logic.js
+++ b/src/families/polkadot/logic.js
@@ -14,6 +14,8 @@ export const MAX_AMOUNT_INPUT = 0xffffffffffffffff;
 export const POLKADOT_SS58_PREFIX = 0;
 export const WARNING_FEW_DOT_LEFTOVER = BigNumber(1000000000);
 
+const BOND_MAX_SAFETY_RATIO = 4; // Fees for the current tx + safety buffer for 3 future transactions
+
 /**
  * Returns true if address is valid, false if it's invalid (can't parse or wrong checksum)
  *
@@ -181,7 +183,9 @@ export const getNonce = (a: Account): number => {
  * @param {*} t
  */
 const calculateMaxBond = (a: Account, t: Transaction): BigNumber => {
-  const amount = a.spendableBalance.minus(4 * t.fees || 0); // 4 = fees for this tx + safety buffer for 3 future transactions
+  const amount = a.spendableBalance.minus(t.fees
+    ? BigNumber(BOND_MAX_SAFETY_RATIO).times(t.fees)
+    : 0);
   return amount.lt(0) ? BigNumber(0) : amount;
 };
 

--- a/src/families/polkadot/logic.js
+++ b/src/families/polkadot/logic.js
@@ -183,9 +183,9 @@ export const getNonce = (a: Account): number => {
  * @param {*} t
  */
 const calculateMaxBond = (a: Account, t: Transaction): BigNumber => {
-  const amount = a.spendableBalance.minus(t.fees
-    ? BigNumber(BOND_MAX_SAFETY_RATIO).times(t.fees)
-    : 0);
+  const amount = a.spendableBalance.minus(
+    t.fees ? BigNumber(BOND_MAX_SAFETY_RATIO).times(t.fees) : 0
+  );
   return amount.lt(0) ? BigNumber(0) : amount;
 };
 

--- a/src/families/polkadot/logic.js
+++ b/src/families/polkadot/logic.js
@@ -174,6 +174,18 @@ export const getNonce = (a: Account): number => {
 };
 
 /**
+ * Calculate max bond which is the actual spendable minus a safety buffer of 3 times the fees,
+ * so the user still has funds to pay the fees for next transactions
+ *
+ * @param {*} a
+ * @param {*} t
+ */
+const calculateMaxBond = (a: Account, t: Transaction): BigNumber => {
+  const amount = a.spendableBalance.minus(4 * t.fees || 0); // 4 = fees for this tx + safety buffer for 3 future transactions
+  return amount.lt(0) ? BigNumber(0) : amount;
+};
+
+/**
  * Calculates max unbond amount which is the remaining active locked balance (not unlocking)
  *
  * @param {*} account
@@ -199,6 +211,7 @@ const calculateMaxRebond = (a: Account): BigNumber => {
  * Calculate the real spendable
  *
  * @param {*} a
+ * @param {*} t
  */
 const calculateMaxSend = (a: Account, t: Transaction): BigNumber => {
   const amount = a.spendableBalance.minus(t.fees || 0);
@@ -222,6 +235,10 @@ export const calculateAmount = ({
     switch (t.mode) {
       case "send":
         amount = calculateMaxSend(a, t);
+        break;
+
+      case "bond":
+        amount = calculateMaxBond(a, t);
         break;
 
       case "unbond":

--- a/src/families/polkadot/test-dataset.js
+++ b/src/families/polkadot/test-dataset.js
@@ -311,19 +311,6 @@ const dataset: DatasetTest<Transaction> = {
               },
             },
             {
-              name: "[bond] use all amount should warn",
-              transaction: (t) => ({
-                ...t,
-                useAllAmount: true,
-                mode: "bond",
-              }),
-              expectedStatus: (account) => ({
-                errors: {},
-                warnings: { amount: new PolkadotAllFundsWarning() },
-                totalSpent: account.spendableBalance,
-              }),
-            },
-            {
               name: "[unbond] no amount",
               transaction: fromTransactionRaw({
                 family: "polkadot",


### PR DESCRIPTION
  Customer Support reports that a lot of users do a "bond max" and are immediately locked, with not enough funds to pay the fees for any other transactions.

This quick fix reduces the amount when doing a bond max, by keeping an additional buffer of 3 times the fees.

More context in the issue: https://ledgerhq.atlassian.net/browse/COIN-1423