### PR TITLE
COIN-1440 [Polkadot] Set fees safety buffer to 0.1 DOT

### DIFF
--- a/src/families/polkadot/js-getTransactionStatus.js
+++ b/src/families/polkadot/js-getTransactionStatus.js
@@ -177,10 +177,6 @@ const getTransactionStatus = async (a: Account, t: Transaction) => {
         });
       }
 
-      if (t.useAllAmount) {
-        warnings.amount = new PolkadotAllFundsWarning();
-      }
-
       break;
 
     case "unbond":

--- a/src/families/polkadot/js-getTransactionStatus.js
+++ b/src/families/polkadot/js-getTransactionStatus.js
@@ -31,7 +31,7 @@ import { verifyValidatorAddresses } from "./api";
 import {
   EXISTENTIAL_DEPOSIT,
   MINIMUM_BOND_AMOUNT,
-  WARNING_FEW_DOT_LEFTOVER,
+  FEES_SAFETY_BUFFER,
   isValidAddress,
   isFirstBond,
   isController,
@@ -89,7 +89,7 @@ const getSendTransactionStatus = async (
     !errors.amount &&
     a.polkadotResources?.lockedBalance.gt(0) &&
     (t.useAllAmount ||
-      a.spendableBalance.minus(totalSpent).lt(WARNING_FEW_DOT_LEFTOVER))
+      a.spendableBalance.minus(totalSpent).lt(FEES_SAFETY_BUFFER))
   ) {
     warnings.amount = new PolkadotAllFundsWarning();
   }
@@ -290,9 +290,9 @@ const getTransactionStatus = async (a: Account, t: Transaction) => {
 
   if (
     t.mode === "bond" &&
-    a.spendableBalance.minus(totalSpent).lt(WARNING_FEW_DOT_LEFTOVER)
+    a.spendableBalance.minus(totalSpent).lt(FEES_SAFETY_BUFFER)
   ) {
-    warnings.amount = new PolkadotAllFundsWarning();
+    errors.amount = new NotEnoughBalance();
   }
 
   if (totalSpent.gt(a.spendableBalance)) {

--- a/src/families/polkadot/logic.js
+++ b/src/families/polkadot/logic.js
@@ -12,9 +12,7 @@ export const MAX_UNLOCKINGS = 32;
 export const PRELOAD_MAX_AGE = 60 * 1000;
 export const MAX_AMOUNT_INPUT = 0xffffffffffffffff;
 export const POLKADOT_SS58_PREFIX = 0;
-export const WARNING_FEW_DOT_LEFTOVER = BigNumber(1000000000);
-
-const BOND_MAX_SAFETY_RATIO = 4; // Fees for the current tx + safety buffer for 3 future transactions
+export const FEES_SAFETY_BUFFER = BigNumber(1000000000); // Arbitrary buffer for paying fees of next transactions
 
 /**
  * Returns true if address is valid, false if it's invalid (can't parse or wrong checksum)
@@ -176,16 +174,16 @@ export const getNonce = (a: Account): number => {
 };
 
 /**
- * Calculate max bond which is the actual spendable minus a safety buffer of 3 times the fees,
+ * Calculate max bond which is the actual spendable minus a safety buffer,
  * so the user still has funds to pay the fees for next transactions
  *
  * @param {*} a
  * @param {*} t
  */
 const calculateMaxBond = (a: Account, t: Transaction): BigNumber => {
-  const fees = t.fees;
-  const safetyRatio = BigNumber(BOND_MAX_SAFETY_RATIO);
-  const amount = a.spendableBalance.minus(fees ? fees.times(safetyRatio) : 0);
+  const amount = a.spendableBalance
+    .minus(t.fees || 0)
+    .minus(FEES_SAFETY_BUFFER);
   return amount.lt(0) ? BigNumber(0) : amount;
 };
 

--- a/src/families/polkadot/test-dataset.js
+++ b/src/families/polkadot/test-dataset.js
@@ -253,25 +253,6 @@ const dataset: DatasetTest<Transaction> = {
               },
             },
             {
-              name: "bond extra - success but warn all funds",
-              transaction: fromTransactionRaw({
-                family: "polkadot",
-                recipient: ACCOUNT_SAME_STASHCONTROLLER,
-                amount: "200000000",
-                mode: "bond",
-                era: null,
-                validators: null,
-                fees: null,
-                rewardDestination: null,
-                numSlashingSpans: 0,
-              }),
-              expectedStatus: {
-                errors: {},
-                warnings: { amount: new PolkadotAllFundsWarning() },
-                amount: BigNumber("200000000"),
-              },
-            },
-            {
               name: "bond extra - not enough spendable",
               transaction: fromTransactionRaw({
                 family: "polkadot",


### PR DESCRIPTION
Follow-up of https://github.com/LedgerHQ/ledger-live-common/pull/1108

Context: https://ledgerhq.atlassian.net/browse/COIN-1440 linked to https://ledgerhq.atlassian.net/browse/COIN-1423

Set the safety buffer that we keep for paying fees of next transactions to 0.1 DOT, and use this amount for both `send max` and `bond max`.
- For send with manual amount: the user can go beyond (up to spendable) with a warning
- For bond: the user can't go beyond, not enough balance error.