### PR TITLE
LL-4555 - Modification for wallet connect

### DIFF
--- a/src/families/ethereum/modules/send.js
+++ b/src/families/ethereum/modules/send.js
@@ -10,6 +10,7 @@ import {
   NotEnoughBalance,
   FeeTooHigh,
   NotEnoughBalanceInParentAccount,
+  AmountRequired,
 } from "@ledgerhq/errors";
 import {
   inferTokenAccount,
@@ -59,6 +60,12 @@ const send: ModeModule = {
 
       if (!t.data) {
         if (
+          !t.allowZeroAmount &&
+          !result.errors.amount &&
+          result.amount.eq(0)
+        ) {
+          result.errors.amount = new AmountRequired();
+        } else if (
           !result.totalSpent.gt(0) ||
           result.totalSpent.gt(account.spendableBalance)
         ) {

--- a/src/families/ethereum/modules/send.js
+++ b/src/families/ethereum/modules/send.js
@@ -59,9 +59,7 @@ const send: ModeModule = {
       }
 
       if (!t.data) {
-        if (!result.errors.amount && result.amount.eq(0)) {
-          result.errors.amount = new AmountRequired();
-        } else if (
+        if (
           !result.totalSpent.gt(0) ||
           result.totalSpent.gt(account.spendableBalance)
         ) {

--- a/src/families/ethereum/modules/send.js
+++ b/src/families/ethereum/modules/send.js
@@ -10,7 +10,6 @@ import {
   NotEnoughBalance,
   FeeTooHigh,
   NotEnoughBalanceInParentAccount,
-  AmountRequired,
 } from "@ledgerhq/errors";
 import {
   inferTokenAccount,

--- a/src/families/ethereum/types.js
+++ b/src/families/ethereum/types.js
@@ -56,6 +56,7 @@ export type Transaction = {|
   estimatedGasLimit: ?BigNumber,
   feeCustomUnit: ?Unit,
   networkInfo: ?NetworkInfo,
+  allowZeroAmount: ?Boolean,
 |};
 
 export type TransactionRaw = {|

--- a/src/families/ethereum/types.js
+++ b/src/families/ethereum/types.js
@@ -56,7 +56,7 @@ export type Transaction = {|
   estimatedGasLimit: ?BigNumber,
   feeCustomUnit: ?Unit,
   networkInfo: ?NetworkInfo,
-  allowZeroAmount: ?Boolean,
+  allowZeroAmount?: Boolean,
 |};
 
 export type TransactionRaw = {|

--- a/src/families/ethereum/types.js
+++ b/src/families/ethereum/types.js
@@ -56,7 +56,7 @@ export type Transaction = {|
   estimatedGasLimit: ?BigNumber,
   feeCustomUnit: ?Unit,
   networkInfo: ?NetworkInfo,
-  allowZeroAmount?: Boolean,
+  allowZeroAmount?: boolean,
 |};
 
 export type TransactionRaw = {|

--- a/src/hw/signMessage/index.js
+++ b/src/hw/signMessage/index.js
@@ -65,9 +65,13 @@ export type Request = {
   message: MessageData,
 };
 
+export type SignMessageResult = {
+  result: string,
+};
+
 export const createAction = (
   connectAppExec: (ConnectAppInput) => Observable<ConnectAppEvent>,
-  signMessage: (ConnectAppInput) => Observable<T>
+  signMessage: (request: Request) => Observable<SignMessageResult>
 ) => {
   const useHook = (reduxDevice: ?Device, request: Request): State => {
     const appState: AppState = createAppAction(connectAppExec).useHook(
@@ -92,7 +96,7 @@ export const createAction = (
       }
       try {
         result = await (
-          signMessage ||
+          signMessage(request) ||
           withDevice(device.deviceId)((t) => from(dispatch(t, request.message)))
         ).toPromise();
       } catch (e) {
@@ -109,7 +113,7 @@ export const createAction = (
         ...initialState,
         signMessageResult: result?.signature,
       });
-    }, [request.message, device]);
+    }, [device, request]);
 
     useEffect(() => {
       if (!device || !opened || inWrongDeviceForAccount || error) {

--- a/src/hw/signMessage/index.js
+++ b/src/hw/signMessage/index.js
@@ -66,7 +66,8 @@ export type Request = {
 };
 
 export const createAction = (
-  connectAppExec: (ConnectAppInput) => Observable<ConnectAppEvent>
+  connectAppExec: (ConnectAppInput) => Observable<ConnectAppEvent>,
+  signMessage: (ConnectAppInput) => Observable<T>
 ) => {
   const useHook = (reduxDevice: ?Device, request: Request): State => {
     const appState: AppState = createAppAction(connectAppExec).useHook(
@@ -90,8 +91,9 @@ export const createAction = (
         return;
       }
       try {
-        result = await withDevice(device.deviceId)((t) =>
-          from(dispatch(t, request.message))
+        result = await (
+          signMessage ||
+          withDevice(device.deviceId)((t) => from(dispatch(t, request.message)))
         ).toPromise();
       } catch (e) {
         if (e.name === "UserRefusedAddress") {

--- a/src/walletconnect/Provider.js
+++ b/src/walletconnect/Provider.js
@@ -171,6 +171,10 @@ const ProviderCommon = ({
 
     if (state.status !== STATUS.DISCONNECTED) {
       dispatch({
+        currentCallRequestId: null,
+      });
+
+      dispatch({
         session: null,
         dappInfo: null,
         error: null,

--- a/src/walletconnect/Provider.js
+++ b/src/walletconnect/Provider.js
@@ -171,14 +171,11 @@ const ProviderCommon = ({
 
     if (state.status !== STATUS.DISCONNECTED) {
       dispatch({
-        currentCallRequestId: null,
-      });
-
-      dispatch({
         session: null,
         dappInfo: null,
         error: null,
         connector: null,
+        currentCallRequestId: null,
         status: STATUS.DISCONNECTED,
       });
 


### PR DESCRIPTION
transaction with 0 amount:
- Needed for wallet connect since the example dapp use transaction with amount = 0.
- also would be needed to cancel a previous transaction

sign message action
- allow to pass a command on desktop while remaining compatible as is with current funciton signature used by mobile

wallet connect provider
- clean current request id when disconnected