### PR TITLE
Swap - Bug fixes

### DIFF
--- a/src/exchange/swap/getExchangeRates.js
+++ b/src/exchange/swap/getExchangeRates.js
@@ -56,7 +56,7 @@ const getExchangeRates: GetExchangeRates = async (
       let magnitudeAwareRate;
 
       if (!amountFrom) {
-        const isTooSmall = BigNumber(apiAmount).lt(minAmountFrom);
+        const isTooSmall = BigNumber(apiAmount).lte(minAmountFrom);
 
         error = isTooSmall
           ? new SwapExchangeRateAmountTooLow(null, {

--- a/src/exchange/swap/initSwap.js
+++ b/src/exchange/swap/initSwap.js
@@ -251,7 +251,11 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
             .toString();
         }
 
-        o.next({ type: "init-swap-requested", amountExpectedTo });
+        o.next({
+          type: "init-swap-requested",
+          amountExpectedTo,
+          estimatedFees,
+        });
 
         try {
           await swap.checkRefundAddress(

--- a/src/exchange/swap/types.js
+++ b/src/exchange/swap/types.js
@@ -90,7 +90,11 @@ export type UpdateAccountSwapStatus = (Account) => Promise<?Account>;
 export type GetMultipleStatus = (SwapStatusRequest[]) => Promise<SwapStatus[]>;
 
 export type SwapRequestEvent =
-  | { type: "init-swap-requested", amountExpectedTo?: string }
+  | {
+      type: "init-swap-requested",
+      amountExpectedTo?: string,
+      estimatedFees: BigNumber,
+    }
   | { type: "init-swap-error", error: Error }
   | { type: "init-swap-result", initSwapResult: InitSwapResult };
 

--- a/src/hw/actions/initSwap.js
+++ b/src/hw/actions/initSwap.js
@@ -78,6 +78,7 @@ const reducer = (state: any, e: SwapRequestEvent | { type: "init-swap" }) => {
         initSwapRequested: true,
         isLoading: false,
         amountExpectedTo: e.amountExpectedTo,
+        estimatedFees: e.estimatedFees,
       };
     case "init-swap-result":
       return {


### PR DESCRIPTION
#### https://github.com/LedgerHQ/ledger-live-common/pull/1117/commits/ff1039e4044fa2f5e2fd4042a6544b66989f7d7d Lower bound of the provider rates not included
Using the exact amount set as a lower bound ( minimum) for the rates from swap providers resulted in the incorrect trigger of the `AmountTooHigh` error due to us checking `lt` and not `lte`. This caused the form to show the error using the max amount message instead of the minimum, which was confusing.

#### https://github.com/LedgerHQ/ledger-live-common/pull/1117/commits/05a834b00284b4b1b3fa285d0ad8fb1c187939e7 Expose estimated fees from inside initSwap to match device data
Fees for erc20 tokens seem to not match the estimated ones in the summary, so this exposes the fees estimated from inside the `initSwap` logic so that the device validation step should the same amount as the app.