### PR TITLE
Fixes swap to throw all errors

### DIFF
--- a/src/exchange/swap/initSwap.js
+++ b/src/exchange/swap/initSwap.js
@@ -162,8 +162,9 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         );
         if (unsubscribed) return;
 
-        if (errors.recipient || errors.amount) {
-          throw errors.recipient || errors.amount;
+        const errorsKeys = Object.keys(errors);
+        if (errorsKeys.length > 0) {
+          throw errors[errorsKeys[0]]; // throw the first error
         }
 
         // Prepare swap app to receive the tx to forward.


### PR DESCRIPTION
Before: swap was validating transaction and erroring if it's an error on recipient or amount
After: swap is validating **all** transaction cases and not just recipient or amount.

https://ledgerhq.atlassian.net/browse/LL-5092