### PR TITLE
LL-4886 fix(network): throw InvalidServerResponse when JSON parse fails

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -1,6 +1,12 @@
 // @flow
 import { createCustomErrorClass } from "@ledgerhq/errors";
 
+// API errors
+
+export const InvalidServerResponse = createCustomErrorClass(
+  "InvalidServerResponse"
+);
+
 // TODO we need to migrate in all errors that are in @ledgerhq/errors
 // but only make sense to live-common to not pollute ledgerjs
 


### PR DESCRIPTION
Fixes https://ledgerhq.atlassian.net/browse/LL-4886

Error: InvalidServerResponse

This error could be used for more usecase, but the one here is only about JSON parse.
`network.js` should really be cleaned up since there are many mixed logics for handling error.