### PR TITLE
LL-5118 Deduct payout fees from swap operation history

### DIFF
--- a/src/exchange/swap/addToSwapHistory.js
+++ b/src/exchange/swap/addToSwapHistory.js
@@ -35,6 +35,11 @@ export default ({
       ? operation.subOperations[0].id
       : operation.id;
 
+  // Nb deduct the payoutnetworkfees if they are present
+  const toAmount = transaction.amount
+    .times(exchangeRate.magnitudeAwareRate)
+    .minus(exchangeRate.payoutNetworkFees || 0);
+
   const swapOperation: SwapOperation = {
     status: "pending",
     provider: exchangeRate.provider,
@@ -44,7 +49,7 @@ export default ({
     receiverAccountId: mainToAccount.id,
     tokenId,
     fromAmount: transaction.amount,
-    toAmount: exchangeRate.toAmount,
+    toAmount,
   };
 
   return isFromToken && subAccounts


### PR DESCRIPTION
### Description

We are currently storing the total amount (displayed on the device) instead of the total amount minus payout fees for the swap history entries. This can cause users to believe the should've received more and contact support. We should change LLC to deduct the payout fees if present for the floating rate trading method.

### Context
https://ledgerhq.atlassian.net/browse/LL-5118 