### PR TITLE
LL-5160 (Polkadot) Display correct tx type for send max

### DIFF
--- a/src/families/polkadot/deviceTransactionConfig.js
+++ b/src/families/polkadot/deviceTransactionConfig.js
@@ -15,6 +15,7 @@ export type ExtraDeviceTransactionField = {
 };
 
 const getSendFields = ({
+  transaction,
   status: { amount },
 }: {
   transaction: Transaction,
@@ -25,7 +26,10 @@ const getSendFields = ({
   fields.push({
     type: "text",
     label: "Balances",
-    value: "Transfer keep alive",
+    value:
+      transaction && transaction.useAllAmount
+        ? "Transfer"
+        : "Transfer keep alive",
   });
 
   fields.push({


### PR DESCRIPTION
Polkadot has 2 transaction types for a send:
When it's a send max, which empties the account, the transaction type is Transfer
When it's a "regular" send that leaves some DOT in the account, the transaction type is Transfer keep alive.

Following our recent support of the send max, this PR displays the same tx type that is displayed on the Nano at device step.