### PR TITLE
[LL-3809] add tooltip args on device confirmation

### DIFF
--- a/src/families/ethereum/modules/compound.js
+++ b/src/families/ethereum/modules/compound.js
@@ -232,6 +232,7 @@ const compoundWithdraw: ModeModule = {
       tooltipI18nKey: transaction.useAllAmount
         ? "lend.withdraw.steps.confirmation.tooltip.amountWithdrawn"
         : undefined,
+      tooltipI18nArgs: { tokenName: ctoken.units[0].code },
     });
 
     fields.push(contractField(ctoken));

--- a/src/transaction/deviceTransactionConfig.js
+++ b/src/transaction/deviceTransactionConfig.js
@@ -9,11 +9,29 @@ import type {
 } from "../types";
 import { getMainAccount } from "../account";
 
+type tooltipArgs = { [key: string]: string };
+
 export type CommonDeviceTransactionField =
-  | { type: "amount", label: string, tooltipI18nKey?: string }
-  | { type: "address", label: string, address: string, tooltipI18nKey?: string }
-  | { type: "fees", label: string, tooltipI18nKey?: string }
-  | { type: "text", label: string, value: string, tooltipI18nKey?: string };
+  | {
+      type: "amount",
+      label: string,
+    }
+  | {
+      type: "address",
+      label: string,
+      address: string,
+    }
+  | {
+      type: "fees",
+      label: string,
+    }
+  | {
+      type: "text",
+      label: string,
+      value: string,
+      tooltipI18nKey?: string,
+      tooltipI18nArgs?: tooltipArgs,
+    };
 
 export type DeviceTransactionField =
   | CommonDeviceTransactionField


### PR DESCRIPTION
We were missing the unit argument for the translation

https://github.com/LedgerHQ/ledger-live-desktop/pull/3696#pullrequestreview-633290494