### PR TITLE
[LL-2985] remove mandatory param freshaddressindex

### DIFF
--- a/src/types/bridge.js
+++ b/src/types/bridge.js
@@ -83,7 +83,7 @@ export interface AccountBridge<T: Transaction> {
       verify?: boolean,
       deviceId: string,
       subAccountId?: string,
-      freshAddressIndex: ?number,
+      freshAddressIndex?: ?number,
     }
   ): Observable<{
     address: string,


### PR DESCRIPTION
all the .receive from accountBridge warn that freshAddressIndex was missing, this should fix this