### PR TITLE
Fixes libcore to really support changing config

### DIFF
--- a/src/libcore/errors.js
+++ b/src/libcore/errors.js
@@ -20,3 +20,7 @@ export function isNonExistingAccountError(error: Error): boolean {
 export function isNonExistingWalletError(error: Error): boolean {
   return error.message.includes("doesn't exist");
 }
+
+export function isAlreadyExistingWalletError(error: Error): boolean {
+  return error.message.includes("already exists");
+}

--- a/src/libcore/getOrCreateWallet.js
+++ b/src/libcore/getOrCreateWallet.js
@@ -7,7 +7,7 @@ import { atomicQueue } from "../promise";
 import type { Core, CoreWallet } from "./types";
 import { findCurrencyExplorer } from "../api/Ledger";
 import { getEnv } from "../env";
-import { isNonExistingWalletError } from "./errors";
+import { isAlreadyExistingWalletError } from "./errors";
 
 type F = ({
   core: Core,
@@ -60,14 +60,7 @@ export const getOrCreateWallet: F = atomicQueue(
       );
     }
 
-    log("libcore", "getOrCreateWallet " + walletName);
     try {
-      // check if wallet exists yet
-      wallet = await poolInstance.getWallet(walletName);
-    } catch (err) {
-      if (!isNonExistingWalletError(err)) {
-        throw err;
-      }
       // create it with the config
       const currencyCore = await poolInstance.getCurrency(currency.id);
       wallet = await poolInstance.createWallet(
@@ -76,12 +69,17 @@ export const getOrCreateWallet: F = atomicQueue(
         config
       );
       return wallet;
+    } catch (err) {
+      if (!isAlreadyExistingWalletError(err)) {
+        throw err;
+      }
+      // actually wallet was existing...
+      // we need to sync the config in case it changed
+      await poolInstance.updateWalletConfig(walletName, config);
     }
 
-    // if it existed, we still need to sync again the config in case it changed
-    await poolInstance.updateWalletConfig(walletName, config);
-    // and we need to get wallet again to have this config taken into account
     wallet = await poolInstance.getWallet(walletName);
+
     return wallet;
   },
   ({ walletName }: { walletName: string }) => walletName


### PR DESCRIPTION
NB: i'm sending this PR for ci testing but it will be included as part of https://github.com/LedgerHQ/ledger-live-common/pull/1053


---

there is a libcore issue that makes this scenario not working:
getWallet --> updateWalletConfig --> getWallet

instead what this is doing is:
try { return createWallet } catch { updateWallet };  return getWallet

Scenario i was using is:

	VERBOSE=1 ledger-live sync --id dash:xpubhere
	EXPERIMENTAL_EXPLORERS=1 ledger-live sync --id dash:xpubhere
	VERBOSE=1 ledger-live sync --id dash:xpubhere

at any point in time it needs to use v2 or v3 but not stay on the first config used. this PR fixes it.