### PR TITLE
added logic so announcement refresh themselves on parameter change

### DIFF
--- a/src/notifications/AnnouncementProvider/index.js
+++ b/src/notifications/AnnouncementProvider/index.js
@@ -1,6 +1,6 @@
 // @flow
 
-import React, { createContext, useMemo, useCallback, useContext } from "react";
+import React, { createContext, useMemo, useCallback, useContext, useEffect } from "react";
 import differenceBy from "lodash/differenceBy";
 import { useMachine } from "@xstate/react";
 import type { Announcement, AnnouncementsUserSettings, State } from "./types";
@@ -123,6 +123,10 @@ export const AnnouncementProvider = ({
     },
   });
 
+  useEffect(() => {
+    send({ type: "UPDATE_DATA" });
+  }, [context]);
+
   const api = useMemo(
     () => ({
       updateCache: async () => {
@@ -132,7 +136,7 @@ export const AnnouncementProvider = ({
         send({ type: "SET_AS_SEEN", seenId });
       },
     }),
-    [send]
+    [send],
   );
 
   const value = {

--- a/src/notifications/AnnouncementProvider/index.js
+++ b/src/notifications/AnnouncementProvider/index.js
@@ -1,6 +1,12 @@
 // @flow
 
-import React, { createContext, useMemo, useCallback, useContext, useEffect } from "react";
+import React, {
+  createContext,
+  useMemo,
+  useCallback,
+  useContext,
+  useEffect,
+} from "react";
 import differenceBy from "lodash/differenceBy";
 import { useMachine } from "@xstate/react";
 import type { Announcement, AnnouncementsUserSettings, State } from "./types";
@@ -136,7 +142,7 @@ export const AnnouncementProvider = ({
         send({ type: "SET_AS_SEEN", seenId });
       },
     }),
-    [send],
+    [send]
   );
 
   const value = {

--- a/src/notifications/AnnouncementProvider/machine.js
+++ b/src/notifications/AnnouncementProvider/machine.js
@@ -53,11 +53,11 @@ export const announcementMachine = Machine(
         on: {
           UPDATE_DATA: {
             target: "updating",
-            actions: assign({ isLoading: true, error: null }),
           },
         },
       },
       updating: {
+        entry: assign({ isLoading: true, error: null }),
         invoke: {
           src: "fetchData",
           onDone: {


### PR DESCRIPTION
This PR should ensure that announcement are correctly refreshed whenever parameters change. Please be careful that client implementation don't change the context object on every render, but rather when a param changed.