### PR TITLE
WIP: automated ledger-live bot coverage for Tezos transaction

### DIFF
--- a/src/families/tezos/specs.js
+++ b/src/families/tezos/specs.js
@@ -1,0 +1,44 @@
+// @flow
+import invariant from "invariant";
+import type { Transaction } from "./types";
+import { getCryptoCurrencyById, parseCurrencyUnit } from "../../currencies";
+import { pickSiblings } from "../../bot/specs";
+import type { AppSpec } from "../../bot/types";
+
+const maxAccount = 8;
+
+const tezos: AppSpec<Transaction> = {
+  name: "Tezos",
+  currency: getCryptoCurrencyById("tezos"),
+  appQuery: {
+    model: "nanoS",
+    appName: "TezosWallet",
+  },
+  transactionCheck: ({ maxSpendable }) => {
+    invariant(
+      maxSpendable.gt(
+        parseCurrencyUnit(getCryptoCurrencyById("tezos").units[0], "0.1")
+      ),
+      "balance is too low"
+    );
+  },
+  mutations: [
+    {
+      name: "move 50%",
+      maxRun: 2,
+      transaction: ({ maxSpendable, account, siblings, bridge }) => {
+        const sibling = pickSiblings(siblings, maxAccount);
+        const recipient = sibling.freshAddress;
+        const amount = maxSpendable.div(2).integerValue();
+        return {
+          transaction: bridge.createTransaction(account),
+          updates: [{ recipient, amount }],
+        };
+      },
+    },
+  ],
+};
+
+export default {
+  tezos,
+};

--- a/src/families/tezos/speculos-deviceActions.js
+++ b/src/families/tezos/speculos-deviceActions.js
@@ -1,0 +1,68 @@
+// @flow
+import type { DeviceAction } from "../../bot/types";
+import type { Transaction } from "./types";
+import { formatCurrencyUnit } from "../../currencies";
+import { deviceActionFlow } from "../../bot/specs";
+
+const acceptTransaction: DeviceAction<Transaction, *> = deviceActionFlow({
+  steps: [
+    {
+      title: "Review",
+      button: "Rr",
+    },
+    {
+      title: "Confirm",
+      button: "Rr",
+      expectedValue: () => {
+        return "Transaction";
+      },
+    },
+    {
+      title: "Amount",
+      button: "Rr",
+      expectedValue: ({ account, transaction }) => {
+        const amount = transaction.amount;
+        return formatCurrencyUnit(account.unit, amount, {
+          disableRounding: true,
+          joinFragmentsSeparator: " ",
+        }).replace(/\s/g, " ");
+      },
+    },
+    {
+      title: "Fee",
+      button: "Rr",
+      expectedValue: ({ account, status }) => {
+        const amount = status.estimatedFees;
+        return formatCurrencyUnit(account.currency.units[0], amount, {
+          disableRounding: true,
+          joinFragmentsSeparator: " ",
+        }).replace(/\s/g, " ");
+      },
+    },
+    {
+      title: "Source",
+      button: "Rr",
+      expectedValue: ({ account }) => account.freshAddress,
+    },
+    {
+      title: "Destination",
+      button: "Rr",
+      expectedValue: ({ transaction }) => transaction.recipient,
+    },
+    {
+      title: "Storage Limit",
+      button: "Rr",
+    },
+    {
+      title: "Reject",
+      button: "Rr",
+      expectedValue: () => "257",
+    },
+    {
+      title: "Accept",
+      button: "LRlr",
+    },
+  ],
+});
+
+export default { acceptTransaction };

--- a/src/generated/specs.js
+++ b/src/generated/specs.js
@@ -6,6 +6,7 @@ import ethereum from "../families/ethereum/specs.js";
 import polkadot from "../families/polkadot/specs.js";
 import ripple from "../families/ripple/specs.js";
 import stellar from "../families/stellar/specs.js";
+import tezos from "../families/tezos/specs.js";
 import tron from "../families/tron/specs.js";
 
 export default {
@@ -16,5 +17,6 @@ export default {
   polkadot,
   ripple,
   stellar,
+  tezos,
   tron,
 };

--- a/src/generated/speculos-deviceActions.js
+++ b/src/generated/speculos-deviceActions.js
@@ -6,6 +6,7 @@ import ethereum from "../families/ethereum/speculos-deviceActions.js";
 import polkadot from "../families/polkadot/speculos-deviceActions.js";
 import ripple from "../families/ripple/speculos-deviceActions.js";
 import stellar from "../families/stellar/speculos-deviceActions.js";
+import tezos from "../families/tezos/speculos-deviceActions.js";
 import tron from "../families/tron/speculos-deviceActions.js";
 
 export default {
@@ -16,5 +17,6 @@ export default {
   polkadot,
   ripple,
   stellar,
+  tezos,
   tron,
 };


### PR DESCRIPTION
Work in progress of [ledger-live bot](https://github.com/LedgerHQ/ledger-live-common/blob/master/docs/bot.md) coverage for Tezos implementation of Ledger Live like we did for many other currencies.
This is done in context of future rework of this implementation to address recent bugs.

As usual and as described in [ledger-live bot](https://github.com/LedgerHQ/ledger-live-common/blob/master/docs/bot.md), this is end to end test, simulating actions on Ledger Live with the same stack, same backends as well as same Hardware Wallet device apps simulated with [speculos](https://github.com/LedgerHQ/speculos).

![Capture d’écran 2021-04-29 à 20 28 18](https://user-images.githubusercontent.com/211411/116600300-7369d100-a929-11eb-967d-11d6bab63ef7.png)

---

TODO:

- [ ] optimistic operation id mismatch
- [ ] test the creation burn cost (problem: it's only once. hard to assess on long term)
- [ ] test the reveal (it means we need to "unreveal" by a send all)
- [ ] test delegate
- [ ] test undelegate (nb: known issue on this today)
- [ ] change delegation
- [ ] KT accounts => are these still possible to create? (as we need to have bot testing in these conditions)
- [ ] send max (many cases based on account state)