### PR TITLE
Fix countervalue available flag for asset distribution

### DIFF
--- a/src/portfolio/v2/index.js
+++ b/src/portfolio/v2/index.js
@@ -257,7 +257,13 @@ export function getCurrencyPortfolio(
   const portfolios = accounts.map((a) =>
     getBalanceHistoryWithCountervalue(a, range, count, cvState, cvCurrency)
   );
-  const histories = portfolios.map((p) => p.history);
+  let countervalueAvailable = false;
+  const histories = portfolios.map((p) => {
+    if (p.countervalueAvailable) {
+      countervalueAvailable = true;
+    }
+    return p.history;
+  });
   const history = getDates(range, count).map((date, i) => ({
     date,
     value: histories.reduce((sum, h) => sum + h[i]?.value, 0),
@@ -283,8 +289,7 @@ export function getCurrencyPortfolio(
 
   return {
     history,
-    countervalueAvailable:
-      portfolios[portfolios.length - 1].countervalueAvailable,
+    countervalueAvailable,
     accounts,
     range,
     histories,


### PR DESCRIPTION
I fix the logic for calculating countervalueAvailable flag so that the cv and current price shows up above the chart.

![Screen Shot 2021-04-30 at 17 11 04](https://user-images.githubusercontent.com/8398372/116715681-378d4500-a9d7-11eb-830e-ad82343e541d.png)
