### PR TITLE
Add support for Tezos on exchange from 2.2.13

### DIFF
--- a/src/exchange/index.js
+++ b/src/exchange/index.js
@@ -18,6 +18,7 @@ const exchangeSupportAppVersions = {
   ripple: "2.1.0",
   stellar: "3.3.0",
   stratis: "1.5.0",
+  tezos: "2.2.13",
   zcash: "1.5.0",
   zencash: "1.5.0",
 };

--- a/src/families/tezos/exchange.js
+++ b/src/families/tezos/exchange.js
@@ -1,0 +1,12 @@
+// @flow
+
+import { bip32asBuffer } from "@ledgerhq/hw-app-btc/lib/bip32";
+
+const getSerializedAddressParameters = (
+  path: string
+): { addressParameters: Buffer } => {
+  const addressParameters = bip32asBuffer(path);
+  return { addressParameters };
+};
+
+export default { getSerializedAddressParameters };

--- a/src/generated/exchange.js
+++ b/src/generated/exchange.js
@@ -3,10 +3,12 @@ import bitcoin from "../families/bitcoin/exchange.js";
 import ethereum from "../families/ethereum/exchange.js";
 import ripple from "../families/ripple/exchange.js";
 import stellar from "../families/stellar/exchange.js";
+import tezos from "../families/tezos/exchange.js";
 
 export default {
   bitcoin,
   ethereum,
   ripple,
   stellar,
+  tezos,
 };


### PR DESCRIPTION
After this gets merged any version of LLD/LLM which includes this live-common would be able to perform swaps for Tezos as long as there's a provider offering the operation and as long as it's enabled on our backend. 
No breaking changes to merge this.

When testing, test against swap staging api since it's not in production yet.