### PR TITLE
LL-5519 Fix scan account error handling

### DIFF
--- a/src/bridge/jsHelpers.js
+++ b/src/bridge/jsHelpers.js
@@ -280,23 +280,13 @@ export const makeScanAccounts = (
           );
 
           let result = derivationsCache[path];
-          try {
-            if (!result) {
-              result = await getAddress(transport, {
-                currency,
-                path,
-                derivationMode,
-              });
-              derivationsCache[path] = result;
-            }
-          } catch (e) {
-            // feature detect any denying case that could happen
-            if (
-              e instanceof TransportStatusError ||
-              e instanceof UserRefusedAddress
-            ) {
-              log("scanAccounts", "ignore derivationMode=" + derivationMode);
-            }
+          if (!result) {
+            result = await getAddress(transport, {
+              currency,
+              path,
+              derivationMode,
+            });
+            derivationsCache[path] = result;
           }
           if (!result) continue;
 

--- a/src/bridge/jsHelpers.js
+++ b/src/bridge/jsHelpers.js
@@ -3,11 +3,7 @@ import isEqual from "lodash/isEqual";
 import { BigNumber } from "bignumber.js";
 import { Observable, from } from "rxjs";
 import { log } from "@ledgerhq/logs";
-import {
-  TransportStatusError,
-  UserRefusedAddress,
-  WrongDeviceForAccount,
-} from "@ledgerhq/errors";
+import { WrongDeviceForAccount } from "@ledgerhq/errors";
 import {
   getSeedIdentifierDerivation,
   getDerivationModesForCurrency,


### PR DESCRIPTION
The cause of scan account error (we believe) was due to the nesting try statement doesn't delegate errors to top level try statement.
This PR removes the nesting try catch statement all together.

We need to make sure this change doesn't affect any coins we support.

we must also try with older firmware.