### PR TITLE
Fix flow loop on connect app when dependencies are present

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "19.9.0-beta.0",
+  "version": "19.9.0-beta.1",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "19.9.0-beta.1",
+  "version": "19.9.0-beta.2",
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {

--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -89,7 +89,7 @@ export const streamAppInstall = ({
             return of({
               type: "app-not-installed",
               appNames: missingAppNames,
-              appName: missingAppNames[0], // TODO remove when LLD/LLM integrate appNames
+              appName: missingAppNames[0] || appNames[0], // TODO remove when LLD/LLM integrate appNames
             });
           }
 

--- a/src/hw/actions/app.js
+++ b/src/hw/actions/app.js
@@ -547,7 +547,7 @@ export const createAction = (
       return () => {
         sub.unsubscribe();
       };
-    }, [params, deviceSubject, state.opened, resetIndex]);
+    }, [params, deviceSubject, state.opened, resetIndex, connectApp]);
 
     const onRetry = useCallback(() => {
       setResetIndex((i) => i + 1);

--- a/src/hw/actions/app.js
+++ b/src/hw/actions/app.js
@@ -21,7 +21,7 @@ import {
   takeWhile,
 } from "rxjs/operators";
 import isEqual from "lodash/isEqual";
-import { useEffect, useCallback, useState, useMemo } from "react";
+import { useEffect, useCallback, useState, useMemo, useRef } from "react";
 import { log } from "@ledgerhq/logs";
 import { getDeviceModel } from "@ledgerhq/devices";
 import {
@@ -476,16 +476,31 @@ export function setDeviceMode(mode: $Keys<typeof implementations>) {
 export const createAction = (
   connectAppExec: (ConnectAppInput) => Observable<ConnectAppEvent>
 ): AppAction => {
-  const connectApp = (device, params) =>
-    !device
-      ? empty()
-      : connectAppExec({
-          modelId: device.modelId,
-          devicePath: device.deviceId,
-          ...params,
-        }).pipe(catchError((error: Error) => of({ type: "error", error })));
-
   const useHook = (device: ?Device, appRequest: AppRequest): AppState => {
+    const dependenciesResolvedRef = useRef(false);
+
+    const connectApp = useCallback(
+      (device, params) =>
+        !device
+          ? empty()
+          : connectAppExec({
+              modelId: device.modelId,
+              devicePath: device.deviceId,
+              ...params,
+              dependencies: dependenciesResolvedRef.current
+                ? undefined
+                : params.dependencies,
+            }).pipe(
+              tap((e) => {
+                if (e.type === "dependencies-resolved") {
+                  dependenciesResolvedRef.current = true;
+                }
+              }),
+              catchError((error: Error) => of({ type: "error", error }))
+            ),
+      []
+    );
+
     // repair modal will interrupt everything and be rendered instead of the background content
     const [state, setState] = useState(() => getInitialState(device));
     const [resetIndex, setResetIndex] = useState(0);

--- a/src/hw/connectApp.js
+++ b/src/hw/connectApp.js
@@ -57,6 +57,7 @@ export type ConnectAppEvent =
   | { type: "app-not-installed", appNames: string[], appName: string }
   | { type: "stream-install", progress: number }
   | { type: "listing-apps" }
+  | { type: "dependencies-resolved" }
   | { type: "ask-quit-app" }
   | { type: "ask-open-app", appName: string }
   | { type: "opened", app?: AppAndVersion, derivation?: { address: string } }
@@ -183,7 +184,10 @@ const cmd = ({
                 return streamAppInstall({
                   transport,
                   appNames: [appName, ...dependencies],
-                  onSuccessObs: () => innerSub({ appName }), // NB without deps
+                  onSuccessObs: () => {
+                    o.next({ type: "dependencies-resolved" });
+                    return innerSub({ appName }); // NB without deps
+                  },
                 });
               }
               // we're in dashboard


### PR DESCRIPTION
During the integration of the `connectApp` evolution on LLD/LLM I noticed we were falling in a flow loop where, although the dependencies were actually sorted correctly when possible (inline install) the flow was unable to be completed due to the action running again. This was caused by the fact that exiting and entering an application is considered a device switch and we had to introduce a flag that removes the dependency array if we already fulfilled it. Big shoutout to @gre for helping me on this one.