### PR TITLE
Update dependent apps if updating an app

### DIFF
--- a/src/apps/__snapshots__/logic.test.js.snap
+++ b/src/apps/__snapshots__/logic.test.js.snap
@@ -222,6 +222,36 @@ Object {
 }
 `;
 
+exports[`Scenario: install an outdated app with dependents 1`] = `
+Object {
+  "apps": Array [
+    Object {
+      "blocks": 10,
+      "bytes": 40960,
+      "currencyId": "bitcoin",
+      "name": "Bitcoin",
+    },
+    Object {
+      "blocks": 1,
+      "bytes": 4096,
+      "currencyId": "dogecoin",
+      "name": "Dogecoin",
+    },
+  ],
+  "appsSpaceBlocks": 60,
+  "appsSpaceBytes": 245760,
+  "freeSpaceBlocks": 49,
+  "freeSpaceBytes": 200704,
+  "osBlocks": 20,
+  "osBytes": 81920,
+  "shouldWarnMemory": false,
+  "totalAppsBlocks": 11,
+  "totalAppsBytes": 45056,
+  "totalBlocks": 80,
+  "totalBytes": 327680,
+}
+`;
+
 exports[`Scenario: install and uninstall an app 1`] = `
 Object {
   "apps": Array [

--- a/src/apps/logic.js
+++ b/src/apps/logic.js
@@ -296,11 +296,21 @@ export const reducer = (state: State, action: Action): State => {
       } else {
         // if app is already installed but outdated, we'll need to update related deps
         if ((existing && !existing.updated) || depsInstalledOutdated.length) {
+          // if app has installed direct dependent apps, we'll need to update them too
+          const directDependents = findDependents(
+            state.appByName,
+            name
+          ).filter((d) => state.installed.some((a) => a.name === d));
           const outdated = state.installed
             .filter(
               (a) =>
                 !a.updated &&
-                [name, ...deps, ...dependentsOfDep].includes(a.name)
+                [
+                  name,
+                  ...deps,
+                  ...directDependents,
+                  ...dependentsOfDep,
+                ].includes(a.name)
             )
             .map((a) => a.name);
           uninstallList = uninstallList.concat(outdated);

--- a/src/apps/logic.test.js
+++ b/src/apps/logic.test.js
@@ -167,6 +167,19 @@ const scenarios = [
   },
 
   {
+    name: "install an outdated app with dependents",
+    apps: "Bitcoin, Dogecoin",
+    installed: "Bitcoin (outdated), Dogecoin (outdated)",
+    actions: [
+      {
+        dispatch: { type: "install", name: "Bitcoin" },
+        expectPlan: "-Dogecoin, -Bitcoin, +Bitcoin, +Dogecoin",
+        expectInstalled: "Bitcoin, Dogecoin",
+      },
+    ],
+  },
+
+  {
     name: "update all will reinstall the outdated",
     apps: "Bitcoin, Litecoin, Ethereum",
     installed: "Bitcoin (outdated), Litecoin (outdated), Ethereum",


### PR DESCRIPTION
There is a bug in the current logic for app installation. When we try to install an already installed application that is outdated and has _dependent_ apps, it will try to uninstall and install the said app without taking care of the dependent apps first. Resulting in two failed actions and no updates.

For example, triggering an `install` of Bitcoin on a device that has Bitcoin(outdated), Dogecoin(outdated) will create the following action plan:` -Bitcoin, +Bitcoin`. Which can't be completed due to the dependent Dogecoin app. With this PR we look for direct dependent installed apps and add them to the logic, changing the action plan to `-Dogecoin, -Bitcoin, +Bitcoin, +Dogecoin`

This was made evident as part of the dependency rework of the `connectApp` action but has been present for a while, we just didn't have any UI that allowed us to fall into it.