### PR TITLE
Fixes dep bug when inline install not enabled

### DIFF
--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -79,6 +79,11 @@ export const streamAppInstall = ({
             initState(e.result)
           );
 
+          if (!state.installQueue.length) {
+            // NB nothing to do
+            return defer(onSuccessObs || empty);
+          }
+
           if (
             isOutOfMemoryState(predictOptimisticState(state)) ||
             !getEnv("EXPERIMENTAL_INLINE_INSTALL")


### PR DESCRIPTION
Without this, if the user doesn't have inline install experimental enabled and meets all the requirements, it will still throw an error saying it needs the exchange app, because we didn't check if any action would be performed. I should've caught this sooner.