### PR TITLE
Consider dependencies as not met if error

### DIFF
--- a/src/hw/actions/app.js
+++ b/src/hw/actions/app.js
@@ -550,6 +550,8 @@ export const createAction = (
     }, [params, deviceSubject, state.opened, resetIndex, connectApp]);
 
     const onRetry = useCallback(() => {
+      // After an error we can't guarantee dependencies are resolved
+      dependenciesResolvedRef.current = false;
       setResetIndex((i) => i + 1);
       setState(getInitialState(device));
     }, [device]);


### PR DESCRIPTION
When an error occurs in the middle of installing multiple applications inline, we are still calling the `onSuccess` event, with this, the `onRetry` action would consider the dependencies as no longer met and allow a full listApps and dependency check when running the action.