### PR TITLE
LL-5413 Allow 6811 status code as missing deps for install

### DIFF
--- a/src/hw/installApp.js
+++ b/src/hw/installApp.js
@@ -26,7 +26,7 @@ export default function installApp(
     catchError((e: Error) => {
       if (!e || !e.message) return throwError(e);
       const status = e.message.slice(e.message.length - 4);
-      if (status === "6a83") {
+      if (status === "6a83" || status === "6811") {
         const dependencies = getDependencies(app.name);
         return throwError(
           new ManagerAppDepInstallRequired("", {


### PR DESCRIPTION
Following the discussion on https://ledgerhq.atlassian.net/browse/LL-5413 and the changes introduced by the latest version, allow the `6811` status to also represent the missing dependencies error instead of falling back to the generic `UNKNOWN_ERROR` from @LedgerHQ/errors. I don't see _how_ this is possible in the context of installing apps after a fw update though.