### PR TITLE
LL-5866 Remove payoutNetworkFees from toAmount value to match binaryPayload data

### DIFF
--- a/src/exchange/swap/addToSwapHistory.js
+++ b/src/exchange/swap/addToSwapHistory.js
@@ -35,10 +35,7 @@ export default ({
       ? operation.subOperations[0].id
       : operation.id;
 
-  // Nb deduct the payoutnetworkfees if they are present
-  const toAmount = transaction.amount
-    .times(exchangeRate.magnitudeAwareRate)
-    .minus(exchangeRate.payoutNetworkFees || 0);
+  const toAmount = transaction.amount.times(exchangeRate.magnitudeAwareRate);
 
   const swapOperation: SwapOperation = {
     status: "pending",

--- a/src/exchange/swap/initSwap.js
+++ b/src/exchange/swap/initSwap.js
@@ -57,7 +57,7 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         const deviceTransactionId = await swap.startNewTransaction();
         if (unsubscribed) return;
 
-        const { provider, rateId } = exchangeRate;
+        const { provider, rateId, payoutNetworkFees } = exchangeRate;
         const {
           fromParentAccount,
           fromAccount,
@@ -244,11 +244,14 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         if (unsubscribed) return;
 
         // NB Floating rates may change the original amountTo so we can pass an override
-        // to properly render the amount on the device confirmation steps.
+        // to properly render the amount on the device confirmation steps. Although changelly
+        // made the calculation inside the binary payload, we still have to deal with it here
+        // to not break their other clients.
         let amountExpectedTo;
         if (swapResult?.amountExpectedTo) {
           amountExpectedTo = BigNumber(swapResult.amountExpectedTo)
             .times(BigNumber(10).pow(unitTo.magnitude))
+            .minus(BigNumber(payoutNetworkFees || 0))
             .toString();
         }
 


### PR DESCRIPTION
The estimated amount to receive contained inside the binary payload no longer includes the `payoutNetworkFees` so we don't have to break down the amount on the confirmation/summary screens anymore. 

This is only available currently on the staging swap API but will be rolled to production.
If there's a gap of time where this code is in prod but the backend is not aligned, the users will see a different amount between the device and the summary (device being higher because it includes the fees) don't know how to proceed in merging this + the LLD/LLM prs + putting it all in prod. Needs to be planned properly.