### PR TITLE
Improved model detection for proxy transport

### DIFF
--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -1,6 +1,7 @@
 // @flow
 
 import Transport from "@ledgerhq/hw-transport";
+// $FlowExpectedError Caused by TS migration, flow def support stopped at v5.
 import { getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { concat, of, empty, from, Observable, throwError, defer } from "rxjs";

--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -118,7 +118,8 @@ export const listApps = (
 
   const deviceModelId =
     // $FlowFixMe
-    (transport.deviceModel && transport.deviceModel.id) || "nanoS";
+    (transport.deviceModel && transport.deviceModel.id) ||
+    getEnv("DEVICE_PROXY_MODEL");
 
   return Observable.create((o) => {
     let sub;

--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -1,7 +1,7 @@
 // @flow
 
 import Transport from "@ledgerhq/hw-transport";
-import { getDeviceModel } from "@ledgerhq/devices";
+import { getDeviceModel, identifyTargetId } from "@ledgerhq/devices";
 import { UnexpectedBootloader } from "@ledgerhq/errors";
 import { concat, of, empty, from, Observable, throwError, defer } from "rxjs";
 import { mergeMap, map } from "rxjs/operators";
@@ -119,6 +119,7 @@ export const listApps = (
   const deviceModelId =
     // $FlowFixMe
     (transport.deviceModel && transport.deviceModel.id) ||
+    (deviceInfo && identifyTargetId(deviceInfo.targetId))?.id ||
     getEnv("DEVICE_PROXY_MODEL");
 
   return Observable.create((o) => {

--- a/src/env.js
+++ b/src/env.js
@@ -166,6 +166,11 @@ const envDefinitions = {
     parser: stringParser,
     desc: "enable a proxy to use instead of a physical device",
   },
+  DEVICE_PROXY_MODEL: {
+    def: "nanoS",
+    parser: stringParser,
+    desc: "allow to override the default model of a proxied device",
+  },
   DISABLE_TRANSACTION_BROADCAST: {
     def: false,
     parser: boolParser,


### PR DESCRIPTION
With this new logic, we are both able to automatically detect the device model based on the target id and override that detection with a new env in case we want to test specific models on the manager via the env `DEVICE_PROXY_MODEL` this means that when using a proxy connection on LLM we will be able to see the correct information on the manager allowing us to install applications and see the remaining storage on the device instead of falling back to a nano s with 0 storage.

### Before this PR / After this PR (added lines for emphasis)
This is using the exact same device, with the same installed applications.
![image](https://user-images.githubusercontent.com/4631227/124154676-00e6b000-da96-11eb-8294-df440c048010.png)

### How to test
- Yalc this or on a LLM setup
- Connect a nano s via proxy
- Launch LLM and choose that device while accessing the manager
- Ensure the data and storage is correct
- Repeat with a nano X.