### PR TITLE
Fixes Ripple to forward error in some cases

### DIFF
--- a/src/families/ripple/bridge/js.js
+++ b/src/families/ripple/bridge/js.js
@@ -54,7 +54,9 @@ import {
 
 // true if the error should be forwarded and is not a "not found" case
 const checkAccountNotFound = (e) => {
-  return !e.data || e.message !== "actNotFound" && e.data.error !== "actNotFound";
+  return (
+    !e.data || (e.message !== "actNotFound" && e.data.error !== "actNotFound")
+  );
 };
 
 const receive = makeAccountBridgeReceive();

--- a/src/families/ripple/bridge/js.js
+++ b/src/families/ripple/bridge/js.js
@@ -53,7 +53,7 @@ import {
 } from "../../../api/Ripple";
 
 const checkAccountNotFound = (e) => {
-  return e.message !== "actNotFound" && e.data.error !== "actNotFound";
+  return e.message !== "actNotFound" && e.data && e.data.error !== "actNotFound";
 };
 
 const receive = makeAccountBridgeReceive();

--- a/src/families/ripple/bridge/js.js
+++ b/src/families/ripple/bridge/js.js
@@ -52,8 +52,9 @@ import {
   getTransactions,
 } from "../../../api/Ripple";
 
+// true if the error should be forwarded and is not a "not found" case
 const checkAccountNotFound = (e) => {
-  return e.message !== "actNotFound" && e.data && e.data.error !== "actNotFound";
+  return !e.data || e.message !== "actNotFound" && e.data.error !== "actNotFound";
 };
 
 const receive = makeAccountBridgeReceive();


### PR DESCRIPTION
crash logs shows that sometimes we had

`undefined is not an object (evaluating 'e.data.error')`