### PR TITLE
remove env EXPERIMENTAL_INLINE_INSTALL to enable for all

### DIFF
--- a/src/apps/hw.js
+++ b/src/apps/hw.js
@@ -84,10 +84,7 @@ export const streamAppInstall = ({
             return defer(onSuccessObs || empty);
           }
 
-          if (
-            isOutOfMemoryState(predictOptimisticState(state)) ||
-            !getEnv("EXPERIMENTAL_INLINE_INSTALL")
-          ) {
+          if (isOutOfMemoryState(predictOptimisticState(state))) {
             // In this case we can't install either by lack of storage, or permissions,
             // we fallback to the error case listing the missing apps.
             const missingAppNames: string[] = state.installQueue;

--- a/src/env.js
+++ b/src/env.js
@@ -229,11 +229,6 @@ const envDefinitions = {
     desc:
       "enable an experimental version of the portfolio percentage calculation",
   },
-  EXPERIMENTAL_INLINE_INSTALL: {
-    def: false,
-    parser: boolParser,
-    desc: "enable an experimental inline app installation flow",
-  },
   EXPERIMENTAL_SEND_MAX: {
     def: false,
     parser: boolParser,

--- a/src/hw/connectApp.js
+++ b/src/hw/connectApp.js
@@ -24,7 +24,7 @@ import getAddress from "./getAddress";
 import openApp from "./openApp";
 import quitApp from "./quitApp";
 import { mustUpgrade } from "../apps";
-import { getEnv } from "../env";
+
 export type RequiresDerivation = {|
   currencyId: string,
   path: string,

--- a/src/hw/connectApp.js
+++ b/src/hw/connectApp.js
@@ -76,18 +76,12 @@ export const openAppFromDashboard = (
           switch (e.statusCode) {
             case 0x6984:
             case 0x6807:
-              return getEnv("EXPERIMENTAL_INLINE_INSTALL")
-                ? streamAppInstall({
-                    transport,
-                    appNames: [appName],
-                    onSuccessObs: () =>
-                      from(openAppFromDashboard(transport, appName)),
-                  })
-                : of({
-                    type: "app-not-installed",
-                    appName,
-                    appNames: [appName],
-                  });
+              return streamAppInstall({
+                transport,
+                appNames: [appName],
+                onSuccessObs: () =>
+                  from(openAppFromDashboard(transport, appName)),
+              });
             case 0x6985:
             case 0x5501:
               return throwError(new UserRefusedOnDevice());


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LL-5462 Activate in-app device flow as non-experimental

dev impact: will be part of next live-common release and will need also to be removed from the experimental on LLD/LLM.
qa impact: app will be like if you had the experimental before but the experimental will just disappear as it will be for all users now.