### PR TITLE
LL-6294 Allow connectApp to require latest fw version

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -14,6 +14,10 @@ export const GetAppAndVersionUnsupportedFormat = createCustomErrorClass(
   "GetAppAndVersionUnsupportedFormat"
 );
 
+export const LatestFirmwareVersionRequired = createCustomErrorClass(
+  "LatestFirmwareVersionRequired"
+);
+
 export const FeeEstimationFailed = createCustomErrorClass(
   "FeeEstimationFailed"
 );

--- a/src/hw/actions/app.js
+++ b/src/hw/actions/app.js
@@ -76,6 +76,7 @@ export type AppRequest = {
   account?: ?Account,
   tokenCurrency?: ?TokenCurrency,
   dependencies?: AppRequest[],
+  requireLatestFirmware?: boolean,
 };
 
 export type AppResult = {|
@@ -299,10 +300,9 @@ function inferCommandParams(appRequest: AppRequest) {
   let derivationMode;
   let derivationPath;
 
-  let appName = appRequest.appName;
-  const account = appRequest.account;
-  let currency = appRequest.currency;
-  let dependencies = appRequest.dependencies;
+  const { account } = appRequest;
+  let { appName, currency, dependencies, requireLatestFirmware } = appRequest;
+
   if (!currency && account) {
     currency = account.currency;
   }
@@ -317,7 +317,7 @@ function inferCommandParams(appRequest: AppRequest) {
   }
 
   if (!currency) {
-    return { appName, dependencies };
+    return { appName, dependencies, requireLatestFirmware };
   }
 
   let extra;
@@ -341,6 +341,7 @@ function inferCommandParams(appRequest: AppRequest) {
   return {
     appName,
     dependencies,
+    requireLatestFirmware,
     requiresDerivation: {
       derivationMode,
       path: derivationPath,
@@ -478,6 +479,7 @@ export const createAction = (
 ): AppAction => {
   const useHook = (device: ?Device, appRequest: AppRequest): AppState => {
     const dependenciesResolvedRef = useRef(false);
+    const latestFirmwareResolvedRef = useRef(false);
 
     const connectApp = useCallback(
       (device, params) =>
@@ -490,10 +492,15 @@ export const createAction = (
               dependencies: dependenciesResolvedRef.current
                 ? undefined
                 : params.dependencies,
+              requireLatestFirmware: latestFirmwareResolvedRef.current
+                ? undefined
+                : params.requireLatestFirmware,
             }).pipe(
               tap((e) => {
                 if (e.type === "dependencies-resolved") {
                   dependenciesResolvedRef.current = true;
+                } else if (e.type === "latest-firmware-resolved") {
+                  latestFirmwareResolvedRef.current = true;
                 }
               }),
               catchError((error: Error) => of({ type: "error", error }))

--- a/src/hw/connectApp.js
+++ b/src/hw/connectApp.js
@@ -230,7 +230,11 @@ const cmd = ({
             }
 
             // in order to check the fw version, install deps, we need dashboard
-            if (dependencies?.length || appAndVersion.name !== appName) {
+            if (
+              dependencies?.length ||
+              requireLatestFirmware ||
+              appAndVersion.name !== appName
+            ) {
               return attemptToQuitApp(transport, appAndVersion);
             }
 

--- a/src/hw/connectApp.js
+++ b/src/hw/connectApp.js
@@ -1,7 +1,8 @@
 // @flow
 
+import semver from "semver";
 import { Observable, concat, from, of, throwError, defer } from "rxjs";
-import { concatMap, map, catchError, delay } from "rxjs/operators";
+import { mergeMap, concatMap, map, catchError, delay } from "rxjs/operators";
 import {
   TransportStatusError,
   FirmwareOrAppUpdateRequired,
@@ -14,16 +15,20 @@ import {
 import Transport from "@ledgerhq/hw-transport";
 import type { DeviceModelId } from "@ledgerhq/devices";
 import type { DerivationMode } from "../types";
+import type { DeviceInfo, FirmwareUpdateContext } from "../types/manager";
 import { getCryptoCurrencyById } from "../currencies";
 import appSupportsQuitApp from "../appSupportsQuitApp";
 import { withDevice } from "./deviceAccess";
 import { streamAppInstall } from "../apps/hw";
 import { isDashboardName } from "./isDashboardName";
 import getAppAndVersion from "./getAppAndVersion";
+import getDeviceInfo from "./getDeviceInfo";
 import getAddress from "./getAddress";
 import openApp from "./openApp";
 import quitApp from "./quitApp";
+import { LatestFirmwareVersionRequired } from "../errors";
 import { mustUpgrade } from "../apps";
+import manager from "../manager";
 
 export type RequiresDerivation = {|
   currencyId: string,
@@ -38,6 +43,7 @@ export type Input = {
   appName: string,
   requiresDerivation?: RequiresDerivation,
   dependencies?: string[],
+  requireLatestFirmware?: boolean,
 };
 
 export type AppAndVersion = {
@@ -58,6 +64,7 @@ export type ConnectAppEvent =
   | { type: "stream-install", progress: number }
   | { type: "listing-apps" }
   | { type: "dependencies-resolved" }
+  | { type: "latest-firmware-resolved" }
   | { type: "ask-quit-app" }
   | { type: "ask-open-app", appName: string }
   | { type: "opened", app?: AppAndVersion, derivation?: { address: string } }
@@ -160,6 +167,7 @@ const cmd = ({
   appName,
   requiresDerivation,
   dependencies,
+  requireLatestFirmware,
 }: Input): Observable<ConnectAppEvent> =>
   withDevice(devicePath)((transport) =>
     Observable.create((o) => {
@@ -167,12 +175,45 @@ const cmd = ({
         .pipe(delay(1000))
         .subscribe((e) => o.next(e));
 
-      const innerSub = ({ appName, dependencies }: any) =>
+      const innerSub = ({
+        appName,
+        dependencies,
+        requireLatestFirmware,
+      }: any) =>
         defer(() => from(getAppAndVersion(transport))).pipe(
           concatMap((appAndVersion): Observable<ConnectAppEvent> => {
             timeoutSub.unsubscribe();
 
             if (isDashboardName(appAndVersion.name)) {
+              // check if we meet minimum fw
+              if (requireLatestFirmware) {
+                return from(getDeviceInfo(transport)).pipe(
+                  mergeMap((deviceInfo: DeviceInfo) =>
+                    from(manager.getLatestFirmwareForDevice(deviceInfo)).pipe(
+                      mergeMap((latest: ?FirmwareUpdateContext) => {
+                        if (
+                          !latest || // Fixme is it safe to let it pass here?
+                          semver.eq(deviceInfo.version, latest.final.version)
+                        ) {
+                          o.next({ type: "latest-firmware-resolved" });
+                          return innerSub({ appName }); // NB without the fw version check
+                        } else {
+                          return throwError(
+                            new LatestFirmwareVersionRequired(
+                              "LatestFirmwareVersionRequired",
+                              {
+                                latest: latest.final.version,
+                                current: deviceInfo.version,
+                              }
+                            )
+                          );
+                        }
+                      })
+                    )
+                  )
+                );
+              }
+
               // check if we meet dependencies
               if (dependencies?.length) {
                 return streamAppInstall({
@@ -188,6 +229,7 @@ const cmd = ({
               return openAppFromDashboard(transport, appName);
             }
 
+            // in order to check the fw version, install deps, we need dashboard
             if (dependencies?.length || appAndVersion.name !== appName) {
               return attemptToQuitApp(transport, appAndVersion);
             }
@@ -242,7 +284,11 @@ const cmd = ({
             return throwError(e);
           })
         );
-      const sub = innerSub({ appName, dependencies }).subscribe(o);
+      const sub = innerSub({
+        appName,
+        dependencies,
+        requireLatestFirmware,
+      }).subscribe(o);
 
       return () => {
         timeoutSub.unsubscribe();

--- a/src/hw/connectApp.js
+++ b/src/hw/connectApp.js
@@ -192,7 +192,7 @@ const cmd = ({
                     from(manager.getLatestFirmwareForDevice(deviceInfo)).pipe(
                       mergeMap((latest: ?FirmwareUpdateContext) => {
                         if (
-                          !latest || // Fixme is it safe to let it pass here?
+                          !latest ||
                           semver.eq(deviceInfo.version, latest.final.version)
                         ) {
                           o.next({ type: "latest-firmware-resolved" });


### PR DESCRIPTION
In order to use this, just modify the input of the `connectApp` request to include the flag. For instance:

```
<DeviceAction
  action={action}
  request={{ account: mainAccount, tokenCurrency, requireLatestFirmware: true }}
  onResult={() => transitionTo("receive")}
/>
```
And it will be the first thing it checks when we connect a device, throwing an error if needed, or letting pass if OK.