### PR TITLE
Error handling + action fix

### DIFF
--- a/src/errors.js
+++ b/src/errors.js
@@ -193,6 +193,36 @@ export const SwapGenericAPIError = createCustomErrorClass(
   "SwapGenericAPIError"
 );
 
+export const JSONRPCResponseError = createCustomErrorClass(
+  "JSONRPCResponseError"
+);
+export const JSONDecodeError = createCustomErrorClass("JSONDecodeError");
+export const NoIPHeaderError = createCustomErrorClass("NoIPHeaderError");
+export const CurrencyNotSupportedError = createCustomErrorClass(
+  "CurrencyNotSupportedError"
+);
+export const CurrencyDisabledError = createCustomErrorClass(
+  "CurrencyDisabledError"
+);
+export const CurrencyDisabledAsInputError = createCustomErrorClass(
+  "CurrencyDisabledAsInputError"
+);
+export const CurrencyDisabledAsOutputError = createCustomErrorClass(
+  "CurrencyDisabledAsOutputError"
+);
+export const CurrencyNotSupportedByProviderError = createCustomErrorClass(
+  "CurrencyNotSupportedByProviderError"
+);
+export const TradeMethodNotSupportedError = createCustomErrorClass(
+  "TradeMethodNotSupportedError"
+);
+export const UnexpectedError = createCustomErrorClass("UnexpectedError");
+export const NotImplementedError = createCustomErrorClass(
+  "NotImplementedError"
+);
+export const ValidationError = createCustomErrorClass("ValidationError");
+export const AccessDeniedError = createCustomErrorClass("AccessDeniedError");
+
 export const AlgorandASANotOptInInRecipient = createCustomErrorClass(
   "AlgorandASANotOptInInRecipient"
 );

--- a/src/exchange/swap/getExchangeRates.js
+++ b/src/exchange/swap/getExchangeRates.js
@@ -7,7 +7,7 @@ import type { Unit } from "../../types";
 import { formatCurrencyUnit } from "../../currencies";
 import { mockGetExchangeRates } from "./mock";
 import network from "../../network";
-import { getSwapAPIBaseURL } from "./";
+import { getSwapAPIError, getSwapAPIBaseURL } from "./";
 import { getEnv } from "../../env";
 import { BigNumber } from "bignumber.js";
 import {
@@ -109,17 +109,24 @@ const inferError = (
     minAmountFrom: string,
     maxAmountFrom: string,
     errorCode?: number,
+    errorMessage?: string,
   }
 ): ?Error => {
   const tenPowMagnitude = BigNumber(10).pow(unitFrom.magnitude);
-  const { amountTo, minAmountFrom, maxAmountFrom, errorCode } = responseData;
+  const {
+    amountTo,
+    minAmountFrom,
+    maxAmountFrom,
+    errorCode,
+    errorMessage,
+  } = responseData;
 
   if (!amountTo) {
     // We are in an error case regardless of api version.
     if (errorCode) {
-      // TODO Do we have consistent errorCodes for providers?
-      return new Error(`Generic Swap API error with code [${errorCode}]`);
+      return getSwapAPIError(errorCode, errorMessage);
     }
+
     // For out of range errors we will have a min/max pairing
     if (minAmountFrom) {
       const isTooSmall = BigNumber(apiAmount).lte(minAmountFrom);

--- a/src/exchange/swap/index.js
+++ b/src/exchange/swap/index.js
@@ -9,6 +9,21 @@ import getKYCStatus from "./getKYCStatus";
 import submitKYC from "./submitKYC";
 import initSwap from "./initSwap";
 import { getEnv } from "../../env";
+import {
+  JSONRPCResponseError,
+  JSONDecodeError,
+  NoIPHeaderError,
+  CurrencyNotSupportedError,
+  CurrencyDisabledError,
+  CurrencyDisabledAsInputError,
+  CurrencyDisabledAsOutputError,
+  CurrencyNotSupportedByProviderError,
+  TradeMethodNotSupportedError,
+  UnexpectedError,
+  NotImplementedError,
+  ValidationError,
+  AccessDeniedError,
+} from "../../errors";
 
 export const operationStatusList = {
   finishedOK: ["finished"],
@@ -117,7 +132,28 @@ const USStates = {
 
 const countries = {
   US: "United States",
-  ES: "Spain", // FIXME remove before merging
+};
+
+const swapBackendErrorCodes = {
+  "100": JSONRPCResponseError,
+  "101": JSONDecodeError,
+  "200": NoIPHeaderError,
+  "300": CurrencyNotSupportedError,
+  "301": CurrencyDisabledError,
+  "302": CurrencyDisabledAsInputError,
+  "303": CurrencyDisabledAsOutputError,
+  "304": CurrencyNotSupportedByProviderError,
+  "400": TradeMethodNotSupportedError,
+  "500": UnexpectedError,
+  "600": NotImplementedError,
+  "700": ValidationError,
+  "701": AccessDeniedError,
+};
+
+export const getSwapAPIError = (errorCode: number, errorMessage?: string) => {
+  if (errorCode in swapBackendErrorCodes)
+    return new swapBackendErrorCodes[errorCode](errorMessage);
+  return new Error(errorMessage);
 };
 
 export {

--- a/src/exchange/swap/types.js
+++ b/src/exchange/swap/types.js
@@ -16,7 +16,10 @@ import type {
 export type ValidKYCStatus = "open" | "pending" | "approved" | "closed";
 export type KYCStatus = { id: string, status: ValidKYCStatus };
 export type GetKYCStatus = (string, string) => Promise<KYCStatus>;
-export type SubmitKYC = (string, KYCData) => Promise<KYCStatus>;
+export type SubmitKYC = (
+  string,
+  KYCData
+) => Promise<KYCStatus | { error: Error }>;
 
 export type KYCData = {
   firstName: string,

--- a/src/hw/actions/initSwap.js
+++ b/src/hw/actions/initSwap.js
@@ -37,6 +37,7 @@ type InitSwapRequest = {
   exchangeRate: ExchangeRate,
   transaction: Transaction,
   userId?: string,
+  requireLatestFirmware?: boolean,
 };
 
 type Result =
@@ -117,7 +118,14 @@ export const createAction = (
       state.freezeReduxDevice
     );
 
-    const { exchange, exchangeRate, transaction, userId } = initSwapRequest;
+    const {
+      exchange,
+      exchangeRate,
+      transaction,
+      userId,
+      requireLatestFirmware,
+    } = initSwapRequest;
+
     const {
       fromAccount,
       fromParentAccount,
@@ -134,6 +142,7 @@ export const createAction = (
           { account: mainFromAccount },
           { account: maintoAccount },
         ],
+        requireLatestFirmware,
       }
     );
 


### PR DESCRIPTION
> **WARNING**: ~This is marked as a draft because we are pending the backend's deployment of the latest version which will handle these new errors. For now, it's coded blindly relying on the specs~.

This pr prepares to handle the error cases that might arise when interacting with the swap feature with the new provider. Due to the limitations, we have in the KYC form, the error handling is at a generic level and not per field. It also includes a reset mechanism (and disabling of the form) based on a specific error for unauthorized rates for the specified user.

This needs to be tested once all the pieces are in place.

It also includes a fix for the `requireLatestFirmware` mod we introduced, ironically I only made it work for all flows _except_ swap. Thanks @LFBarreto for helping find this bug, I was not passing the flag to the nested `connectApp` inside `initSwap`.


### Update
Tested against the latest deployed staging, the error handling is as good as we can make it currently. If you are adventurous and want to try it before it gets merged, yalc this version on LLD, and replace your valid ID for wyre in the app.json file with something invalid, for instance, turn your "US_123456" into "_US_123456" and refresh the app. It should let you reach the form but throw the unauthorized error later.