### PR TITLE
LL-5794 -Manager - "Apps installed" tab: Apps order should be corresponding to the install queue

### DIFF
--- a/src/apps/react.js
+++ b/src/apps/react.js
@@ -110,19 +110,15 @@ export function useAppsSections(
     { type: "default", order: "asc" }
   );
 
-  const device = installedAppList
-    .sort(({ name: _name }, { name }) =>
-      installed.indexOf(_name) > installed.indexOf(name) ? -1 : 0
-    )
-    .sort(({ name: _name }, { name }) => {
-      // place install queue on top of list
-      // with the app being installed at the top
-      let pos1 = installQueue.indexOf(_name);
-      let pos2 = installQueue.indexOf(name);
-      pos1 = pos1 < 0 ? Number.MAX_VALUE : pos1;
-      pos2 = pos2 < 0 ? Number.MAX_VALUE : pos2;
-      return pos1 - pos2;
-    });
+  const device = installedAppList.sort(({ name: _name }, { name }) => {
+    // place install queue on top of list
+    // with the app being installed at the top
+    let pos1 = installQueue.indexOf(_name);
+    let pos2 = installQueue.indexOf(name);
+    pos1 = pos1 < 0 ? Number.MAX_VALUE : pos1;
+    pos2 = pos2 < 0 ? Number.MAX_VALUE : pos2;
+    return pos1 - pos2;
+  });
 
   return { update, catalog, device };
 }

--- a/src/apps/react.js
+++ b/src/apps/react.js
@@ -114,10 +114,15 @@ export function useAppsSections(
     .sort(({ name: _name }, { name }) =>
       installed.indexOf(_name) > installed.indexOf(name) ? -1 : 0
     )
-    .sort(
-      ({ name: _name }, { name }) =>
-        installQueue.indexOf(_name) > installQueue.indexOf(name) ? -1 : 0 // place install queue on top of list
-    );
+    .sort(({ name: _name }, { name }) => {
+      // place install queue on top of list
+      // with the app being installed at the top
+      let pos1 = installQueue.indexOf(_name);
+      let pos2 = installQueue.indexOf(name);
+      pos1 = pos1 < 0 ? Number.MAX_VALUE : pos1;
+      pos2 = pos2 < 0 ? Number.MAX_VALUE : pos2;
+      return pos1 - pos2;
+    });
 
   return { update, catalog, device };
 }

--- a/src/apps/react.test.js
+++ b/src/apps/react.test.js
@@ -162,3 +162,53 @@ test("Apps hooks - useAppsSections - Correct number of installed apps with query
   );
   expect(result.current.device.length).toBe(1);
 });
+
+const mockedStateWithInstallQueue = {
+  ...initState(
+    mockListAppsResult(
+      "Bitcoin, Ethereum, Litecoin, Dogecoin, Ethereum Classic, XRP, Bitcoin Cash",
+      "Litecoin (outdated), Ethereum, Ethereum Classic",
+      deviceInfo155
+    )
+  ),
+  installQueue: ["Bitcoin", "Dogecoin"],
+};
+
+test('Apps hooks - useAppsSections - Sort "device" category apps with installing apps first', () => {
+  const options = {
+    query: "",
+    appFilter: "all",
+    sort: { type: "name", order: "desc" },
+  };
+  const { result: vanillaResult } = renderHook(() =>
+    useAppsSections(mockedState, options)
+  );
+  const { result: installQueueResult } = renderHook(() =>
+    useAppsSections(mockedStateWithInstallQueue, options)
+  );
+  // "catalog" and "update" categories should be similar with/without install queue
+  expect(vanillaResult.current.catalog).toMatchObject(
+    installQueueResult.current.catalog
+  );
+  expect(vanillaResult.current.update).toMatchObject(
+    installQueueResult.current.update
+  );
+  // "device" category should be sorted differently
+  expect(vanillaResult.current.device.map((elt) => elt.name)).toMatchObject([
+    // Installed apps
+    "Ethereum",
+    "Litecoin",
+    "Ethereum Classic",
+  ]);
+  expect(
+    installQueueResult.current.device.map((elt) => elt.name)
+  ).toMatchObject([
+    // Apps being installed
+    "Bitcoin",
+    "Dogecoin",
+    // Installed apps
+    "Ethereum",
+    "Litecoin",
+    "Ethereum Classic",
+  ]);
+});


### PR DESCRIPTION
## Context (issues, jira)

[LL-5794]

## Description / Usage

In the LLD/LLM `Manager` / `Installed Apps` tab, apps with status installing will now be listed by installation order with the next installation target at the top.

<details>
  <summary>Screens 📸 </summary>

<img height="800" alt="Simulator Screen Shot - iPhone 11 - 2021-07-16 at 14 05 08" src="https://user-images.githubusercontent.com/86958797/125945850-e5b68e69-bcec-415f-a81e-7cf1dc258b66.png"  />
<br/><hr />
<img width="800" alt="Capture d’écran 2021-07-16 à 11 32 47" src="https://user-images.githubusercontent.com/86958797/125945844-94ae0fcd-114a-4b80-ab82-e37b1b7a67eb.png">

</details>

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

[LL-5794]: https://ledgerhq.atlassian.net/browse/LL-5794