### PR TITLE
LL-6084 - Filter ANN by Live versions

### DIFF
--- a/src/__tests__/announcements/filterAnnouncements.js
+++ b/src/__tests__/announcements/filterAnnouncements.js
@@ -576,4 +576,86 @@ describe("filterAnnouncements", () => {
       });
     });
   });
+
+  describe("appVersion filters", () => {
+    beforeAll(() => {
+      timemachine.config({
+        dateString: "February 22, 2021 13:12:59",
+      });
+    });
+
+    afterAll(() => {
+      timemachine.config({
+        dateString: "February 22, 2021 13:12:59",
+      });
+    });
+
+    const context = {
+      language: "en",
+      currencies: ["bitcoin", "cosmos"],
+      getDate: () => new Date(),
+      appVersion: "2.41.2",
+    };
+
+    beforeEach(() => {
+      const appVersionsData = [["<=2.42.0", ">=3"], [], ["=2.41.3"]];
+      const rawAnnouncementsVersioned = rawAnnouncements.map(
+        (announcement, index) => ({
+          ...announcement,
+          appVersions: appVersionsData[index],
+        })
+      );
+
+      announcements = localizeAnnouncements(rawAnnouncementsVersioned, context);
+    });
+
+    describe("with context.appVersion = '2.41.2'", () => {
+      it("should return all matching announcements", () => {
+        const filtered = filterAnnouncements(announcements, context);
+        const expected = [
+          {
+            uuid: "announcement-id-a",
+            level: "info",
+            icon: "warning",
+            content: {
+              title: "Incoming cosmos fork",
+              text:
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc nibh felis, pom id...",
+              link: {
+                href: "https://ledger.com/there-is/an/incoming-cosmos-fork",
+                label: "Click here for more information on upcoming fork",
+              },
+            },
+            contextual: [],
+            published_at: "2019-09-29T00:00:00.000Z",
+            expired_at: "2021-03-06T00:00:00.000Z",
+            utm_campaign: "promo_feb2021",
+            currencies: ["cosmos"],
+            appVersions: ["<=2.42.0", ">=3"],
+          },
+          {
+            uuid: "announcement-id-b",
+            level: "info",
+            icon: "info",
+            content: {
+              title: "Incoming cosmos fork",
+              text:
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc nibh felis, pom id...",
+              link: {
+                href: "https://ledger.com/there-is/an/incoming-cosmos-fork",
+                label: "Click here for more information on upcoming fork",
+              },
+            },
+            contextual: [],
+            languages: ["en"],
+            published_at: "2019-10-31T00:00:00.000Z",
+            expired_at: "2021-04-06T00:00:00.000Z",
+            appVersions: [],
+          },
+        ];
+
+        expect(filtered).toStrictEqual(expected);
+      });
+    });
+  });
 });

--- a/src/__tests__/announcements/filterAnnouncements.js
+++ b/src/__tests__/announcements/filterAnnouncements.js
@@ -5,10 +5,13 @@ import {
   localizeAnnouncements,
 } from "../../notifications/AnnouncementProvider/logic";
 import api from "../test-helpers/announcements";
+import packageJSON from "../../../package.json";
 
 timemachine.config({
   dateString: "February 22, 2021 13:12:59",
 });
+
+jest.mock("../../../package.json");
 
 let rawAnnouncements;
 let announcements;
@@ -651,6 +654,88 @@ describe("filterAnnouncements", () => {
             published_at: "2019-10-31T00:00:00.000Z",
             expired_at: "2021-04-06T00:00:00.000Z",
             appVersions: [],
+          },
+        ];
+
+        expect(filtered).toStrictEqual(expected);
+      });
+    });
+  });
+
+  describe("liveCommonVersions filters", () => {
+    beforeAll(() => {
+      timemachine.config({
+        dateString: "February 22, 2021 13:12:59",
+      });
+      packageJSON.version = "12.41.2";
+    });
+
+    afterAll(() => {
+      timemachine.config({
+        dateString: "February 22, 2021 13:12:59",
+      });
+    });
+
+    const context = {
+      language: "en",
+      currencies: ["bitcoin", "cosmos"],
+      getDate: () => new Date(),
+    };
+
+    beforeEach(() => {
+      const liveCommonVersionsData = [["<=12.42.0", ">=13"], [], ["=12.41.3"]];
+      const rawAnnouncementsVersioned = rawAnnouncements.map(
+        (announcement, index) => ({
+          ...announcement,
+          liveCommonVersions: liveCommonVersionsData[index],
+        })
+      );
+
+      announcements = localizeAnnouncements(rawAnnouncementsVersioned, context);
+    });
+
+    describe("with current live-common version set to '12.41.2'", () => {
+      it("should return all matching announcements", () => {
+        const filtered = filterAnnouncements(announcements, context);
+        const expected = [
+          {
+            uuid: "announcement-id-a",
+            level: "info",
+            icon: "warning",
+            content: {
+              title: "Incoming cosmos fork",
+              text:
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc nibh felis, pom id...",
+              link: {
+                href: "https://ledger.com/there-is/an/incoming-cosmos-fork",
+                label: "Click here for more information on upcoming fork",
+              },
+            },
+            contextual: [],
+            published_at: "2019-09-29T00:00:00.000Z",
+            expired_at: "2021-03-06T00:00:00.000Z",
+            utm_campaign: "promo_feb2021",
+            currencies: ["cosmos"],
+            liveCommonVersions: ["<=12.42.0", ">=13"],
+          },
+          {
+            uuid: "announcement-id-b",
+            level: "info",
+            icon: "info",
+            content: {
+              title: "Incoming cosmos fork",
+              text:
+                "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc nibh felis, pom id...",
+              link: {
+                href: "https://ledger.com/there-is/an/incoming-cosmos-fork",
+                label: "Click here for more information on upcoming fork",
+              },
+            },
+            contextual: [],
+            languages: ["en"],
+            published_at: "2019-10-31T00:00:00.000Z",
+            expired_at: "2021-04-06T00:00:00.000Z",
+            liveCommonVersions: [],
           },
         ];
 

--- a/src/notifications/AnnouncementProvider/logic.js
+++ b/src/notifications/AnnouncementProvider/logic.js
@@ -4,6 +4,7 @@ import type {
   Announcement,
   AnnouncementsUserSettings,
 } from "./types";
+import semver from "semver";
 
 export function localizeAnnouncements(
   rawAnnouncements: RawAnnouncement[],
@@ -37,6 +38,7 @@ export function filterAnnouncements(
     getDate,
     lastSeenDevice,
     platform: contextPlatform,
+    appVersion: contextAppVersion,
   } = context;
 
   const date = getDate();
@@ -49,6 +51,7 @@ export function filterAnnouncements(
       expired_at,
       device,
       platforms,
+      appVersions,
     }) => {
       if (languages && !languages.includes(language)) {
         return false;
@@ -97,6 +100,15 @@ export function filterAnnouncements(
         )
       ) {
         return false;
+      }
+
+      // filter out by app version
+      if (appVersions?.length && contextAppVersion) {
+        const isAppVersionMatch = appVersions.some((version) =>
+          semver.satisfies(contextAppVersion, version)
+        );
+
+        if (isAppVersionMatch === false) return false;
       }
 
       const publishedAt = new Date(published_at);

--- a/src/notifications/AnnouncementProvider/logic.js
+++ b/src/notifications/AnnouncementProvider/logic.js
@@ -5,6 +5,7 @@ import type {
   AnnouncementsUserSettings,
 } from "./types";
 import semver from "semver";
+import { version as LLCommonVersion } from "../../../package.json";
 
 export function localizeAnnouncements(
   rawAnnouncements: RawAnnouncement[],
@@ -52,6 +53,7 @@ export function filterAnnouncements(
       device,
       platforms,
       appVersions,
+      liveCommonVersions,
     }) => {
       if (languages && !languages.includes(language)) {
         return false;
@@ -109,6 +111,15 @@ export function filterAnnouncements(
         );
 
         if (isAppVersionMatch === false) return false;
+      }
+
+      // filter out by ll-comon version
+      if (liveCommonVersions?.length) {
+        const isLLCommonVersionMatch = liveCommonVersions.some((version) =>
+          semver.satisfies(LLCommonVersion, version)
+        );
+
+        if (isLLCommonVersionMatch === false) return false;
       }
 
       const publishedAt = new Date(published_at);

--- a/src/notifications/AnnouncementProvider/types.js
+++ b/src/notifications/AnnouncementProvider/types.js
@@ -29,6 +29,7 @@ type AnnouncementBase = {
   currencies?: string[], // optional per currency account ownership targeting.
   device?: AnnouncementDeviceFilter, // optional firmware targeting
   platforms?: AnnnouncementPlatformsFilter[], // optional platform targeting
+  appVersions?: string[], // optional app version targeting. Accepts any valid semver string.
 };
 
 export type AnnouncementContent = {
@@ -57,6 +58,7 @@ export type AnnouncementsUserSettings = {
   getDate: () => Date,
   lastSeenDevice?: DeviceModelInfo,
   platform?: string,
+  appVersion?: string,
 };
 
 export type AnnouncementsApi = {

--- a/src/notifications/AnnouncementProvider/types.js
+++ b/src/notifications/AnnouncementProvider/types.js
@@ -30,6 +30,7 @@ type AnnouncementBase = {
   device?: AnnouncementDeviceFilter, // optional firmware targeting
   platforms?: AnnnouncementPlatformsFilter[], // optional platform targeting
   appVersions?: string[], // optional app version targeting. Accepts any valid semver string.
+  liveCommonVersions?: string[], // optional live-common version targeting. Accepts any valid semver string.
 };
 
 export type AnnouncementContent = {


### PR DESCRIPTION
## Context (issues, jira)

[LL-6084]

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

Thanks to this pull request we would be able to filter announces to specific LLM/LLD version.
From LLD/LLM side, we'll now pass current app version to AnnouncementProvider context.

Snippets from LLD:

```javascript
const context = {
    ...
    appVersion: __APP_VERSION__,
};
  ```

## Expectations

- [x] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->


[LL-6084]: https://ledgerhq.atlassian.net/browse/LL-6084