### PR TITLE
LL-6521  - Swap providers fetching

### DIFF
--- a/src/__tests__/exchange/swap/hooks.test.js
+++ b/src/__tests__/exchange/swap/hooks.test.js
@@ -1,0 +1,114 @@
+// @flow
+import { renderHook } from "@testing-library/react-hooks";
+import { useSwapProviders, initialState } from "../../../exchange/swap/hooks";
+import * as mocks from "../../../exchange/swap/mock";
+import { setEnv } from "../../../env";
+
+describe("exchange/swap/hooks", () => {
+  const OLD_ENV = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    // LLC internal variable
+    setEnv("MOCK", "true");
+
+    // All env variables including ones setted by LLM/LLD
+    process.env = { ...OLD_ENV };
+  });
+
+  afterAll(() => {
+    // Restore old environment
+    process.env = OLD_ENV;
+  });
+
+  test("fetches providers on mount", async () => {
+    const spy = jest.spyOn(mocks, "mockGetProviders");
+    renderHook(() => useSwapProviders());
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns initial state on mount", async () => {
+    const { result } = renderHook(() => useSwapProviders());
+
+    expect(result.current).toEqual(initialState);
+  });
+
+  test("returns providers", async () => {
+    const spy = jest.spyOn(mocks, "mockGetProviders");
+    const { result, waitForNextUpdate } = renderHook(() => useSwapProviders());
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBe(null);
+    expect(result.current.providers.length).toBe(2);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns sorted providers", async () => {
+    const providers = ["bitfinex", "kraken", "bitstamp", "changelly", "wyre"];
+    const pairs = [
+      { from: "bitcoin", to: "ethereum", tradeMethod: "float" },
+      { from: "bitcoin", to: "ethereum", tradeMethod: "fixed" },
+      { from: "ethereum", to: "bitcoin", tradeMethod: "float" },
+      { from: "ethereum", to: "bitcoin", tradeMethod: "fixed" },
+    ];
+    const mockedProviders = providers.map((provider) => ({ provider, pairs }));
+
+    jest.spyOn(mocks, "mockGetProviders").mockReturnValue(mockedProviders);
+    const { result, waitForNextUpdate } = renderHook(() => useSwapProviders());
+
+    await waitForNextUpdate();
+
+    expect(result.current.providers.length).toBe(mockedProviders.length);
+    expect(result.current.providers[0].provider).toBe("changelly");
+  });
+
+  test("returns sorted/filtered providers", async () => {
+    const providers = ["bitfinex", "kraken", "bitstamp", "changelly", "wyre"];
+    const pairs = [
+      { from: "bitcoin", to: "ethereum", tradeMethod: "float" },
+      { from: "bitcoin", to: "ethereum", tradeMethod: "fixed" },
+      { from: "ethereum", to: "bitcoin", tradeMethod: "float" },
+      { from: "ethereum", to: "bitcoin", tradeMethod: "fixed" },
+    ];
+    const mockedProviders = providers.map((provider) => ({ provider, pairs }));
+    const disabledProviders = providers.filter(
+      (provider) => provider !== "wyre"
+    );
+
+    process.env.SWAP_DISABLED_PROVIDERS = disabledProviders.join(",");
+
+    jest.spyOn(mocks, "mockGetProviders").mockReturnValue(mockedProviders);
+    const { result, waitForNextUpdate } = renderHook(() => useSwapProviders());
+
+    await waitForNextUpdate();
+
+    expect(result.current.providers.length).toBe(
+      mockedProviders.length - disabledProviders.length
+    );
+    expect(result.current.providers[0].provider).toBe("wyre");
+  });
+
+  test("returns error", async () => {
+    const mockedError = new Error("mocked error");
+
+    const spy = jest.spyOn(mocks, "mockGetProviders").mockImplementation(
+      () =>
+        new Promise(() => {
+          throw mockedError;
+        })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() => useSwapProviders());
+
+    await waitForNextUpdate();
+
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toEqual(mockedError);
+    expect(result.current.providers).toBe(null);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/exchange/swap/sortProvidersByWeight.test.js
+++ b/src/__tests__/exchange/swap/sortProvidersByWeight.test.js
@@ -1,0 +1,40 @@
+// @flow
+import sortProvidersByWeight from "../../../exchange/swap/sortProvidersByWeight";
+import type { AvailableProvider } from "../../../exchange/swap/types";
+
+jest.mock("../../../exchange/swap/providersPriority", () => ({
+  changelly: 1,
+  kraken: -1,
+}));
+
+describe("swap/sortProvidersByWeight", () => {
+  let providers: Array<AvailableProvider>;
+
+  beforeEach(() => {
+    const mockedPairs = [{ from: "ETH", to: "USD", tradeMethod: "float" }];
+
+    providers = [
+      { provider: "bitstamp", pairs: mockedPairs },
+      { provider: "changelly", pairs: mockedPairs },
+      { provider: "kraken", pairs: mockedPairs },
+      { provider: "bitfinex", pairs: mockedPairs },
+      { provider: "bitbay", pairs: mockedPairs },
+    ];
+  });
+
+  test("changelly is sorted as the first provider", () => {
+    const sortedProviders = providers.sort(sortProvidersByWeight);
+    const changellyIndex = sortedProviders.findIndex(
+      ({ provider }) => provider === "changelly"
+    );
+    expect(changellyIndex).toBe(0);
+  });
+
+  test("kraken is sorted as the last provider", () => {
+    const sortedProviders = providers.sort(sortProvidersByWeight);
+    const krakenIndex = sortedProviders.findIndex(
+      ({ provider }) => provider === "kraken"
+    );
+    expect(krakenIndex).toBe(sortedProviders.length - 1);
+  });
+});

--- a/src/exchange/swap/hooks.js
+++ b/src/exchange/swap/hooks.js
@@ -1,0 +1,60 @@
+// @flow
+import { useReducer, useEffect } from "react";
+import type { AvailableProvider } from "./types";
+import { getProviders } from "./index";
+import sortProvidersByWeight from "./sortProvidersByWeight";
+
+type State = {
+  isLoading: boolean,
+  error: ?Error,
+  providers: ?Array<AvailableProvider>,
+};
+
+type ActionType =
+  | { type: "SAVE_DATA", payload: $PropertyType<State, "providers"> }
+  | { type: "SAVE_ERROR", payload: $PropertyType<State, "error"> };
+
+const reducer = (state: State, action: ActionType) => {
+  switch (action.type) {
+    case "SAVE_DATA":
+      return { error: null, providers: action.payload, isLoading: false };
+    case "SAVE_ERROR":
+      return { error: action.payload, providers: null, isLoading: false };
+    default:
+      throw new Error("Uncorrect action type");
+  }
+};
+
+export const initialState = { isLoading: true, error: null, providers: null };
+
+const filterDisabledProviders = (provider: AvailableProvider) =>
+  !process.env.SWAP_DISABLED_PROVIDERS?.includes(provider.provider);
+
+export const useSwapProviders = () => {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const saveProviders = async () => {
+      try {
+        const allProviders = await getProviders();
+        const providers = allProviders
+          .filter(filterDisabledProviders)
+          .sort(sortProvidersByWeight);
+
+        if (isMounted) dispatch({ type: "SAVE_DATA", payload: providers });
+      } catch (error) {
+        if (isMounted) dispatch({ type: "SAVE_ERROR", payload: error });
+      }
+    };
+
+    saveProviders();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  return state;
+};

--- a/src/exchange/swap/providersPriority.js
+++ b/src/exchange/swap/providersPriority.js
@@ -1,0 +1,4 @@
+// @flow
+const providersPriorityMap = { changelly: 1 };
+
+export default providersPriorityMap;

--- a/src/exchange/swap/sortProvidersByWeight.js
+++ b/src/exchange/swap/sortProvidersByWeight.js
@@ -1,0 +1,26 @@
+// @flow
+import type { AvailableProvider } from "./types";
+import providerPriorityMap from "./providersPriority";
+
+/*
+  By proxying this map, we can return a default value if
+  the key doesn't exist . That's particularly useful in our
+  case as we only want to assign a weight to specific 
+  proprieties from an unknown and unterminated list of.
+ */
+const providersWeights = new Proxy(
+  {},
+  {
+    get: (_, propriety) =>
+      Object.prototype.hasOwnProperty.call(providerPriorityMap, propriety)
+        ? providerPriorityMap[propriety]
+        : 0,
+  }
+);
+
+const sortProvidersByWeight = (
+  provA: AvailableProvider,
+  provB: AvailableProvider
+) => (providersWeights[provA.provider] - providersWeights[provB.provider]) * -1;
+
+export default sortProvidersByWeight;


### PR DESCRIPTION
Create custom hooks to fetch, filter and sort swap providers.

## Context (issues, jira)

Main task [LL-6300]
Subtask [LL-6521]

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

Users only have to use the custom hook from one of his component.
Example

```javascript
const Swap = () => {
  const { providers, isLoading, error } = useSwapProviders();
  
  if (error) return <p>{error.message}</p>
  if (isLoading) return <p>loading...</p>

  return <ul>{providers.map(({provider}) => <li key={provider}>{provider}</li>)}</ul>;
};
```  

## Expectations

- [x] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->


[LL-6300]: https://ledgerhq.atlassian.net/browse/LL-6300
[LL-6521]: https://ledgerhq.atlassian.net/browse/LL-6521