### PR TITLE
prevent estimateMaxSpendable to be negative

### DIFF
--- a/src/families/crypto_org/js-estimateMaxSpendable.ts
+++ b/src/families/crypto_org/js-estimateMaxSpendable.ts
@@ -19,7 +19,7 @@ const estimateMaxSpendable = async ({
 }): Promise<BigNumber> => {
   const a = getMainAccount(account, parentAccount);
   const fees = await getEstimatedFees();
-  return a.spendableBalance.minus(fees);
+  return BigNumber.max(0, a.spendableBalance.minus(fees));
 };
 
 export default estimateMaxSpendable;


### PR DESCRIPTION
## Context (issues, jira)

Prevent estimate spendable value to be negative

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
