### PR TITLE
LL-6016 (ServiceStatusProvider): add filtered context hooks

### DIFF
--- a/src/notifications/ServiceStatusProvider/index.tsx
+++ b/src/notifications/ServiceStatusProvider/index.tsx
@@ -18,7 +18,7 @@ type Props = {
   children: React.ReactNode;
   autoUpdateDelay: number;
   networkApi?: ServiceStatusApi;
-  context: ServiceStatusUserSettings;
+  context?: ServiceStatusUserSettings;
 };
 
 type API = {
@@ -64,7 +64,7 @@ export function useFilteredServiceStatus(
   const filteredIncidents = useMemo(() => {
     return filterServiceStatusIncidents(
       incidents,
-      filters.tickers || context.tickers
+      filters.tickers || context?.tickers
     );
   }, [incidents, context, filters.tickers]);
 

--- a/src/notifications/ServiceStatusProvider/index.tsx
+++ b/src/notifications/ServiceStatusProvider/index.tsx
@@ -5,7 +5,12 @@ import React, {
   useCallback,
   ReactElement,
 } from "react";
-import type { State, ServiceStatusApi } from "./types";
+import type {
+  State,
+  ServiceStatusUserSettings,
+  Incident,
+  ServiceStatusApi,
+} from "./types";
 import defaultNetworkApi from "./api";
 import { useMachine } from "@xstate/react";
 import { serviceStatusMachine } from "./machine";
@@ -13,10 +18,13 @@ type Props = {
   children: React.ReactNode;
   autoUpdateDelay: number;
   networkApi?: ServiceStatusApi;
+  context: ServiceStatusUserSettings;
 };
+
 type API = {
   updateData: () => Promise<void>;
 };
+
 export type StatusContextType = State & API;
 const ServiceStatusContext = createContext<StatusContextType>({
   incidents: [],
@@ -24,14 +32,50 @@ const ServiceStatusContext = createContext<StatusContextType>({
   lastUpdateTime: undefined,
   error: undefined,
   updateData: () => Promise.resolve(),
+  context: { tickers: [] },
 });
+
 export function useServiceStatus(): StatusContextType {
   return useContext(ServiceStatusContext);
 }
+
+export function filterServiceStatusIncidents(
+  incidents: Incident[],
+  tickers: string[] = []
+): Incident[] {
+  if (!tickers || tickers.length === 0) return [];
+
+  const tickersRegex = new RegExp(tickers.join("|"), "i");
+  return incidents.filter(
+    ({ components }) =>
+      !components || // dont filter out if no components
+      components.length === 0 ||
+      components.some(({ name }) => tickersRegex.test(name)) // component name should hold currency name
+  );
+}
+
+// filter out service status incidents by given currencies or fallback on context currencies
+export function useFilteredServiceStatus(
+  filters: ServiceStatusUserSettings = { tickers: [] }
+): StatusContextType {
+  const stateData = useContext(ServiceStatusContext);
+  const { incidents, context } = stateData;
+
+  const filteredIncidents = useMemo(() => {
+    return filterServiceStatusIncidents(
+      incidents,
+      filters.tickers || context.tickers
+    );
+  }, [incidents, context, filters.tickers]);
+
+  return { ...stateData, incidents: filteredIncidents };
+}
+
 export const ServiceStatusProvider = ({
   children,
   autoUpdateDelay,
   networkApi = defaultNetworkApi,
+  context,
 }: Props): ReactElement => {
   const fetchData = useCallback(async () => {
     const serviceStatusSummary = await networkApi.fetchStatusSummary();
@@ -59,7 +103,7 @@ export const ServiceStatusProvider = ({
     }),
     [send]
   );
-  const value = { ...(state.context || {}), ...api };
+  const value = { ...(state.context || {}), ...api, context };
   return (
     <ServiceStatusContext.Provider value={value}>
       {children}

--- a/src/notifications/ServiceStatusProvider/machine.ts
+++ b/src/notifications/ServiceStatusProvider/machine.ts
@@ -5,6 +5,7 @@ const initialState: State = {
   error: null,
   lastUpdateTime: null,
   isLoading: false,
+  context: { tickers: [] },
 };
 export const serviceStatusMachine = Machine({
   id: "serviceStatus",

--- a/src/notifications/ServiceStatusProvider/types.ts
+++ b/src/notifications/ServiceStatusProvider/types.ts
@@ -25,14 +25,14 @@ export type IncidentUpdate = {
   incident_id?: string;
   status?: string;
   updated_at?: string;
-  context: ServiceStatusUserSettings;
+  context?: ServiceStatusUserSettings;
 };
 export type State = {
   incidents: Incident[];
   isLoading: boolean;
   lastUpdateTime: number | null | undefined;
   error: Error | null | undefined;
-  context: ServiceStatusUserSettings;
+  context?: ServiceStatusUserSettings;
 };
 export type ServiceStatusSummary = {
   incidents: Incident[] | null | undefined;

--- a/src/notifications/ServiceStatusProvider/types.ts
+++ b/src/notifications/ServiceStatusProvider/types.ts
@@ -1,3 +1,8 @@
+type Component = {
+  id: string;
+  name: string;
+};
+
 export type Incident = {
   created_at: string;
   id: string;
@@ -10,6 +15,7 @@ export type Incident = {
   shortlink: string | null | undefined;
   status: string;
   updated_at: string | null | undefined;
+  components?: Component[];
 };
 export type IncidentUpdate = {
   body: string;
@@ -19,16 +25,22 @@ export type IncidentUpdate = {
   incident_id?: string;
   status?: string;
   updated_at?: string;
+  context: ServiceStatusUserSettings;
 };
 export type State = {
   incidents: Incident[];
   isLoading: boolean;
   lastUpdateTime: number | null | undefined;
   error: Error | null | undefined;
+  context: ServiceStatusUserSettings;
 };
 export type ServiceStatusSummary = {
   incidents: Incident[] | null | undefined;
 };
 export type ServiceStatusApi = {
   fetchStatusSummary: () => Promise<ServiceStatusSummary>;
+};
+
+export type ServiceStatusUserSettings = {
+  tickers: string[];
 };


### PR DESCRIPTION
## Context (issues, jira)
(ServiceStatusProvider): add filtered context hooks
this should not break the current work since it adds a new hook and doesnt modify the existing.

We use components name in order to filter out status incidents by ticker in order to not colide between values such as Bitcoin or Bitcoin cash.
[LL-6016]


## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->




[LL-6016]: https://ledgerhq.atlassian.net/browse/LL-6016