### PR TITLE
LL-5936 - mitigate DEVICE_POLLING_TIMEOUT

### DIFF
--- a/src/hw/actions/app.ts
+++ b/src/hw/actions/app.ts
@@ -407,7 +407,6 @@ const implementations = {
       const POLLING = 2000;
       const INIT_DEBOUNCE = 5000;
       const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 5000;
       // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
       let pollingOnDevice;
       const sub = deviceSubject.subscribe((d) => {
@@ -435,17 +434,10 @@ const implementations = {
           return;
         }
 
-        let nbTimeout = 0;
-
         log("app/polling", "polling loop");
         connectSub = connectApp(pollingOnDevice, params)
           .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
             catchError((err, caught) => {
-              nbTimeout += 1;
-              if (nbTimeout < 4) {
-                return caught; // retry
-              }
               const productName = getDeviceModel(
                 pollingOnDevice.modelId
               ).productName;

--- a/src/hw/actions/manager.ts
+++ b/src/hw/actions/manager.ts
@@ -186,7 +186,6 @@ const implementations = {
       const POLLING = 2000;
       const INIT_DEBOUNCE = 5000;
       const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 5000;
       // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
       let pollingOnDevice;
       const sub = deviceSubject.subscribe((d) => {
@@ -218,17 +217,10 @@ const implementations = {
           return;
         }
 
-        let nbTimeout = 0;
-
         log("manager/polling", "polling loop");
         connectSub = connectManager(pollingOnDevice, managerRequest)
           .pipe(
-            timeout(DEVICE_POLLING_TIMEOUT),
             catchError((err, caught) => {
-              nbTimeout += 1;
-              if (nbTimeout < 4) {
-                return caught; // retry
-              }
               const productName = getDeviceModel(
                 pollingOnDevice.modelId
               ).productName;

--- a/src/hw/actions/manager.ts
+++ b/src/hw/actions/manager.ts
@@ -186,7 +186,7 @@ const implementations = {
       const POLLING = 2000;
       const INIT_DEBOUNCE = 5000;
       const DISCONNECT_DEBOUNCE = 5000;
-      const DEVICE_POLLING_TIMEOUT = 20000;
+      const DEVICE_POLLING_TIMEOUT = 5000;
       // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
       let pollingOnDevice;
       const sub = deviceSubject.subscribe((d) => {
@@ -218,11 +218,17 @@ const implementations = {
           return;
         }
 
+        let nbTimeout = 0;
+
         log("manager/polling", "polling loop");
         connectSub = connectManager(pollingOnDevice, managerRequest)
           .pipe(
             timeout(DEVICE_POLLING_TIMEOUT),
-            catchError((err) => {
+            catchError((err, caught) => {
+              nbTimeout += 1;
+              if (nbTimeout < 4) {
+                return caught; // retry
+              }
               const productName = getDeviceModel(
                 pollingOnDevice.modelId
               ).productName;


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LL-5936

I really don't understand rxjs.
I've seen 
<img width="737" alt="Capture d’écran 2021-09-13 à 14 20 14" src="https://user-images.githubusercontent.com/5071029/133082302-476b6123-743d-4bfc-97d7-8f1547b85667.png">

So that my proposition:
timeout is 5 sec and we retry 4 times so that we have the same 20 sec total as before but with 4 trials