### PR TITLE
Provide Currency to wallet-btc:isValidAddress()

### DIFF
--- a/src/__tests__/families/bitcoin/logic.ts
+++ b/src/__tests__/families/bitcoin/logic.ts
@@ -1,0 +1,40 @@
+import { getCryptoCurrencyById } from "../../../currencies";
+import { isValidRecipient } from "../../../families/bitcoin/logic";
+import { InvalidAddress } from "@ledgerhq/errors";
+
+describe("Test isValidRecipient", () => {
+  function t(address: string, currencyId: string, expectValid: boolean) {
+    const currency = getCryptoCurrencyById(currencyId);
+    if (expectValid) {
+      return expect(
+        isValidRecipient({ currency, recipient: address })
+      ).resolves.toBeNull();
+    } else {
+      return expect(
+        isValidRecipient({ currency, recipient: address })
+      ).rejects.toBeInstanceOf(InvalidAddress);
+    }
+  }
+  test("Fail on non-existing currency", () => {
+    t("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", "ontology", false);
+  });
+  test("Fail on mainnet addr on bitcoin_testnet", () => {
+    t("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", "bitcoin_testnet", false);
+  });
+  test("Success on valid address", () => {
+    t("bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4", "bitcoin", true);
+  });
+  test("Success on valid qtum address", () => {
+    t("xCREYTgvdk3XzFNpdXkj35fZX4hJK2Ckpd", "qtum", true);
+  });
+  test("Fail on invalid qtum address", () => {
+    t("xCREYTgvdk3XzFNpdXkj35fZX4hJK2Ckpe", "qtum", false);
+  });
+  test("Fail on invalid bch address", () => {
+    t("qr6m7j9njldwwzlg9v7v53unlr4jkmx6eylep8ekg3", "bitcoin_cash", false);
+  });
+  // TODO Enable once fixed in wallet-btc
+  test.skip("Success on valid bch address", () => {
+    t("qr6m7j9njldwwzlg9v7v53unlr4jkmx6eylep8ekg2", "bitcoin_cash", true);
+  });
+});

--- a/src/families/bitcoin/logic.ts
+++ b/src/families/bitcoin/logic.ts
@@ -61,9 +61,9 @@ export const isValidRecipient = async (params: {
   try {
     // Optimistically assume params.currency.id is an actual Currency
     valid = isValidAddress(params.recipient, <Currency>params.currency.id);
-  } catch (e) {
+  } catch (e: any) {
     // isValidAddress() will throw Error if c is not an actual Currency
-    return Promise.reject(new CurrencyNotSupported(e.message));
+    return Promise.reject(new InvalidAddress(e.message));
   }
   if (!valid) {
     return Promise.reject(

--- a/src/families/bitcoin/logic.ts
+++ b/src/families/bitcoin/logic.ts
@@ -1,7 +1,11 @@
 import cashaddr from "cashaddrjs";
 import bchaddr from "bchaddrjs";
-import { isValidAddress } from "@ledgerhq/wallet-btc";
-import { RecipientRequired, InvalidAddress } from "@ledgerhq/errors";
+import { Currency, isValidAddress } from "@ledgerhq/wallet-btc";
+import {
+  RecipientRequired,
+  InvalidAddress,
+  CurrencyNotSupported,
+} from "@ledgerhq/errors";
 import type { Account, CryptoCurrency, CryptoCurrencyIds } from "./../../types";
 import type {
   BitcoinOutput,
@@ -52,7 +56,15 @@ export const isValidRecipient = async (params: {
   if (!params.recipient) {
     return Promise.reject(new RecipientRequired(""));
   }
-  const valid = isValidAddress(params.recipient);
+
+  let valid: boolean;
+  try {
+    // Optimistically assume params.currency.id is an actual Currency
+    valid = isValidAddress(params.recipient, <Currency>params.currency.id);
+  } catch (e) {
+    // isValidAddress() will throw Error if c is not an actual Currency
+    return Promise.reject(new CurrencyNotSupported(e.message));
+  }
   if (!valid) {
     return Promise.reject(
       new InvalidAddress("Invalid address for currency " + params.currency.name)


### PR DESCRIPTION
## Context (issues, jira)

LL-7116

## Description / Usage

The method signature `isValidAddress()` in project `wallet-btc` has changed to include an optional argument of type Currency. This PR adds that argument to the call to `isValidAddress()`.

If the provided argument is not an actual Currency literal type (as defined in `wallet-btc`), an error, eg "Currency 'ontology' doesn't exist" will be shown.

This change is dependent on unreleased wallet-btc code. So before we merge this, we need to merge and release the PR in `wallet-btc`: https://github.com/LedgerHQ/wallet-btc/pull/53