### PR TITLE
LL-7235 Prevent endless spinner at start of initSwap device action

### DIFF
--- a/src/hw/actions/initSwap.ts
+++ b/src/hw/actions/initSwap.ts
@@ -149,7 +149,7 @@ export const createAction = (
     const hasError = error || state.error;
     useEffect(() => {
       if (!opened || !device) {
-        setState({ ...initialState, isLoading: !hasError });
+        setState({ ...initialState, isLoading: !!device });
         return;
       }
 
@@ -175,7 +175,7 @@ export const createAction = (
               error,
             })
           ),
-          scan(reducer, initialState)
+          scan(reducer, { ...initialState, isLoading: !hasError })
         )
         .subscribe(setState);
       return () => {


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-7235


## Description / Usage
The current code in production, which has been like so for over 6 months will default to a loading state when there's no errors and no device. This doesn't break the flow and still allows the user to complete a swap but it's terrible UX because we fail to tell the user to actually connect the device in the first place 🤦🏼 

I don't remember why I introduced the `hasErrors` to determine if we are in a loading hook state or not, but it seems like the right place to have that would be at the reducer level and not where it was before. This seems to work perfectly with the correct "connect your device" rendering if no device is plugged in. 

I was also able to complete a swap without any issues

https://user-images.githubusercontent.com/4631227/133415631-fb6aaf23-993c-41ee-aca4-19de1748001c.mov



## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

I can't check any of the above boxes because it's not covered directly by tests, but also it _does_ change something in the user land, it should show the connect your device rendering instead of a loader, so up to core to decide if this needs further coverage or you trust me.