### PR TITLE
LL-6895 - Mock KYC status

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -366,6 +366,11 @@ const envDefinitions = {
     parser: stringParser,
     desc: "switch the app into a MOCK mode for test purpose, the value will be used as a seed for the rng. Avoid falsy values.",
   },
+  MOCK_SWAP_KYC: {
+    def: "",
+    parser: stringParser,
+    desc: "mock the server response for the exchange KYC check, options are 'open', 'pending', 'closed' or 'approved'.",
+  },
   OPERATION_ADDRESSES_LIMIT: {
     def: 100,
     parser: intParser,

--- a/src/exchange/swap/getKYCStatus.ts
+++ b/src/exchange/swap/getKYCStatus.ts
@@ -2,11 +2,15 @@ import network from "../../network";
 import { getSwapAPIBaseURL } from "./";
 import type { GetKYCStatus } from "./types";
 import { SwapCheckKYCStatusFailed } from "../../errors";
+import { getEnv } from "../../env";
+import { mockGetKYCStatus } from "./mock";
 export const getKYCStatus: GetKYCStatus = async (
   provider: string,
   id: string
 ) => {
-  //if (getEnv("MOCK")) return mockGetKYCStatus(id); // TODO implement
+  const mockedStatus = getEnv("MOCK_SWAP_KYC");
+  if (mockedStatus) return mockGetKYCStatus(id, mockedStatus);
+
   const res = await network({
     method: "GET",
     url: `${getSwapAPIBaseURL()}/provider/${provider}/user/${id}`,

--- a/src/exchange/swap/mock.ts
+++ b/src/exchange/swap/mock.ts
@@ -4,7 +4,9 @@ import type {
   ExchangeRate,
   GetMultipleStatus,
   GetProviders,
+  KYCStatus,
   SwapRequestEvent,
+  ValidKYCStatus,
 } from "./types";
 import { getAccountUnit } from "../../account";
 import type { Transaction, TokenCurrency, CryptoCurrency } from "../../types";
@@ -175,4 +177,13 @@ export const mockGetStatus: GetMultipleStatus = async (statusList) => {
   //Fake delay to show loading UI
   await new Promise((r) => setTimeout(r, 800));
   return statusList.map((s) => ({ ...s, status: "finished" }));
+};
+
+export const mockGetKYCStatus = async (
+  id: string,
+  status: ValidKYCStatus
+): Promise<KYCStatus> => {
+  //Fake delay to show the pending state in the UI
+  await new Promise((r) => setTimeout(r, 2000));
+  return { id, status };
 };


### PR DESCRIPTION
## Context (issues, jira)

[LL-6895]

## Description / Usage

Adds a new `MOCK_SWAP_KYC` environment variable that can be set to a valid status to mock the response from the backend.

This is required by the QA team to test both the rejected and validated states.

(cc @ychen-ledger)

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->


[LL-6895]: https://ledgerhq.atlassian.net/browse/LL-6895