### PR TITLE
LL-7642

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -8,6 +8,7 @@ export const ConnectManagerTimeout = createCustomErrorClass(
 export const GetAppAndVersionUnsupportedFormat = createCustomErrorClass(
   "GetAppAndVersionUnsupportedFormat"
 );
+export const AccountNeedResync = createCustomErrorClass("AccountNeedResync");
 
 export const LatestFirmwareVersionRequired = createCustomErrorClass(
   "LatestFirmwareVersionRequired"

--- a/src/families/bitcoin/js-prepareTransaction.ts
+++ b/src/families/bitcoin/js-prepareTransaction.ts
@@ -3,11 +3,13 @@ import type { Account } from "../../types";
 import type { Transaction } from "./types";
 import { getAccountNetworkInfo } from "./getAccountNetworkInfo";
 import { inferFeePerByte } from "./logic";
+import { AccountNeedResync } from "../../errors";
 
 const prepareTransaction = async (
   a: Account,
   t: Transaction
 ): Promise<Transaction> => {
+  if (a.id.startsWith("libcore")) throw new AccountNeedResync();
   let networkInfo = t.networkInfo;
 
   if (!networkInfo) {


### PR DESCRIPTION
## Context (issues, jira)

LL-7642

## Description / Usage

workaround that coming with a libcore account in preparetransaction would fail with 'AccountNeedResync' explicit error, that could be worded as "Please try again later" or "Please go back to account and wait full resynchronisation".

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
