### PR TITLE
Split integration.test.ts from all.libcore.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jest": "rimraf libcoredb && mkdir libcoredb && cross-env TZ=America/New_York jest",
     "test": "yarn jest",
     "ci-lint": "yarn lint",
-    "ci-test-common": "env-cmd -f ./.ci.env yarn test --ci --updateSnapshot && git diff --exit-code src",
+    "ci-test-common": "env-cmd -f ./.ci.env yarn test --ci --updateSnapshot -w 10 && git diff --exit-code src",
     "ci-setup-cli": "yalc publish && cd cli && yalc add @ledgerhq/live-common && yarn && yarn build && yarn link",
     "ci-test-cli": "cd cli && yarn test",
     "ci-test-bot": "env-cmd -f ./.ci.env yarn jest --testMatch '**/*.bot.ts'"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jest": "rimraf libcoredb && mkdir libcoredb && cross-env TZ=America/New_York jest",
     "test": "yarn jest",
     "ci-lint": "yarn lint",
-    "ci-test-common": "env-cmd -f ./.ci.env yarn test --ci --updateSnapshot -w 10 && git diff --exit-code src",
+    "ci-test-common": "env-cmd -f ./.ci.env yarn test --ci --updateSnapshot && git diff --exit-code src",
     "ci-setup-cli": "yalc publish && cd cli && yalc add @ledgerhq/live-common && yarn && yarn build && yarn link",
     "ci-test-cli": "cd cli && yarn test",
     "ci-test-bot": "env-cmd -f ./.ci.env yarn jest --testMatch '**/*.bot.ts'"

--- a/src/__tests__/all.libcore.ts
+++ b/src/__tests__/all.libcore.ts
@@ -7,7 +7,7 @@ import { log } from "@ledgerhq/logs";
 import { setup } from "./test-helpers/libcore-setup";
 import { withLibcore, afterLibcoreGC } from "../libcore/access";
 import { delay } from "../promise";
-import { testBridge } from "./test-helpers/bridge";
+import { testBridgeOnlyLibcore } from "./test-helpers/bridge";
 import dataset from "../generated/test-dataset";
 import specifics from "../generated/test-specifics";
 import type { DatasetTest } from "../types";
@@ -35,7 +35,7 @@ families
     if (process.env.FAMILY && process.env.FAMILY !== family) return;
     if (shouldExcludeFamilies && maybeFamilyToOnlyRun !== family) return;
     const data: DatasetTest<any> = dataset[family];
-    return testBridge(family, data);
+    return testBridgeOnlyLibcore(family, data);
   })
   .filter(Boolean);
 // FIXME overkill atm but could help perf

--- a/src/__tests__/test-helpers/bridge.ts
+++ b/src/__tests__/test-helpers/bridge.ts
@@ -69,6 +69,23 @@ export function syncAccount<T extends Transaction>(
     .toPromise();
 }
 
+export function testBridgeOnlyLibcore<T extends Transaction>(
+  family: string,
+  data: DatasetTest<T>
+) {
+  const implementations = data.implementations.filter((i) => i === "libcore");
+  if (implementations.length === 0) return;
+  testBridge(family, { ...data, implementations });
+}
+export function testBridgeWithoutLibcore<T extends Transaction>(
+  family: string,
+  data: DatasetTest<T>
+) {
+  const implementations = data.implementations.filter((i) => i !== "libcore");
+  if (implementations.length === 0) return;
+  testBridge(family, { ...data, implementations });
+}
+
 export function testBridge<T extends Transaction>(
   family: string,
   data: DatasetTest<T>

--- a/src/__tests__/test-helpers/bridge.ts
+++ b/src/__tests__/test-helpers/bridge.ts
@@ -74,7 +74,10 @@ export function testBridgeOnlyLibcore<T extends Transaction>(
   data: DatasetTest<T>
 ) {
   const implementations = data.implementations.filter((i) => i === "libcore");
-  if (implementations.length === 0) return;
+  if (implementations.length === 0) {
+    test.skip("No JS implementation to test dataset of " + family, () => {});
+    return;
+  }
   testBridge(family, { ...data, implementations });
 }
 export function testBridgeWithoutLibcore<T extends Transaction>(
@@ -82,7 +85,13 @@ export function testBridgeWithoutLibcore<T extends Transaction>(
   data: DatasetTest<T>
 ) {
   const implementations = data.implementations.filter((i) => i !== "libcore");
-  if (implementations.length === 0) return;
+  if (implementations.length === 0) {
+    test.skip(
+      "No libcore implementation to test dataset of " + family,
+      () => {}
+    );
+    return;
+  }
   testBridge(family, { ...data, implementations });
 }
 
@@ -90,7 +99,6 @@ export function testBridge<T extends Transaction>(
   family: string,
   data: DatasetTest<T>
 ) {
-  test("dummy", () => expect(true).toBe(true)); // test to avoid error on "no test on this file"
   // covers all bridges through many different accounts
   // to test the common shared properties of bridges.
   const accountsRelated: Array<{
@@ -104,6 +112,7 @@ export function testBridge<T extends Transaction>(
     currency: CryptoCurrency;
   }> = [];
   const { implementations, currencies } = data;
+
   Object.keys(currencies).forEach((currencyId) => {
     const currencyData = currencies[currencyId];
     const currency = getCryptoCurrencyById(currencyId);

--- a/src/__tests__/test-helpers/bridge.ts
+++ b/src/__tests__/test-helpers/bridge.ts
@@ -90,6 +90,7 @@ export function testBridge<T extends Transaction>(
   family: string,
   data: DatasetTest<T>
 ) {
+  test("dummy", () => expect(true).toBe(true)); // test to avoid error on "no test on this file"
   // covers all bridges through many different accounts
   // to test the common shared properties of bridges.
   const accountsRelated: Array<{

--- a/src/__tests__/test-helpers/libcore-setup.ts
+++ b/src/__tests__/test-helpers/libcore-setup.ts
@@ -1,8 +1,5 @@
 /* eslint-disable no-console */
-import winston from "winston";
-import { listen } from "@ledgerhq/logs";
 import "./setup";
-import { EnvName, setEnvUnsafe } from "../../env";
 import implementLibcore from "../../libcore/platforms/nodejs";
 let setupCalled = null;
 export const setup = (testId) => {
@@ -19,39 +16,3 @@ export const setup = (testId) => {
     dbPath: "./libcoredb/" + testId,
   });
 };
-
-for (const k in process.env) setEnvUnsafe(k as EnvName, process.env[k]);
-
-const { VERBOSE, VERBOSE_FILE } = process.env;
-const logger = winston.createLogger({
-  level: "debug",
-  transports: [],
-});
-const { format } = winston;
-const { combine, timestamp, json } = format;
-const winstonFormat = combine(timestamp(), json());
-
-if (VERBOSE_FILE) {
-  logger.add(
-    new winston.transports.File({
-      format: winstonFormat,
-      filename: VERBOSE_FILE,
-      level: "debug",
-    })
-  );
-}
-
-logger.add(
-  new winston.transports.Console({
-    format: winstonFormat,
-    silent: !VERBOSE,
-  })
-);
-// eslint-disable-next-line no-unused-vars
-listen(({ type, message, ...rest }) => {
-  logger.log("debug", {
-    message: type + (message ? ": " + message : ""),
-    // $FlowFixMe
-    ...rest,
-  });
-});

--- a/src/__tests__/test-helpers/setup.ts
+++ b/src/__tests__/test-helpers/setup.ts
@@ -1,6 +1,9 @@
 import BigNumber from "bignumber.js";
 import { setSupportedCurrencies } from "../../currencies";
 import { setPlatformVersion } from "../../platform/version";
+import winston from "winston";
+import { listen } from "@ledgerhq/logs";
+import { EnvName, setEnvUnsafe } from "../../env";
 
 jest.setTimeout(180000);
 
@@ -55,3 +58,39 @@ setSupportedCurrencies([
   "crypto_org",
   "filecoin",
 ]);
+
+for (const k in process.env) setEnvUnsafe(k as EnvName, process.env[k]);
+
+const { VERBOSE, VERBOSE_FILE } = process.env;
+const logger = winston.createLogger({
+  level: "debug",
+  transports: [],
+});
+const { format } = winston;
+const { combine, timestamp, json } = format;
+const winstonFormat = combine(timestamp(), json());
+
+if (VERBOSE_FILE) {
+  logger.add(
+    new winston.transports.File({
+      format: winstonFormat,
+      filename: VERBOSE_FILE,
+      level: "debug",
+    })
+  );
+}
+
+logger.add(
+  new winston.transports.Console({
+    format: winstonFormat,
+    silent: !VERBOSE,
+  })
+);
+// eslint-disable-next-line no-unused-vars
+listen(({ type, message, ...rest }) => {
+  logger.log("debug", {
+    message: type + (message ? ": " + message : ""),
+    // $FlowFixMe
+    ...rest,
+  });
+});

--- a/src/families/algorand/integration.test.ts
+++ b/src/families/algorand/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("algorand", dataset);

--- a/src/families/bitcoin/integration.test.ts
+++ b/src/families/bitcoin/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("bitcoin", dataset);

--- a/src/families/cosmos/integration.test.ts
+++ b/src/families/cosmos/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("cosmos", dataset);

--- a/src/families/crypto_org/integration.test.ts
+++ b/src/families/crypto_org/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("crypto_org", dataset);

--- a/src/families/elrond/integration.test.ts
+++ b/src/families/elrond/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("elrond", dataset);

--- a/src/families/ethereum/integration.test.ts
+++ b/src/families/ethereum/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("ethereum", dataset);

--- a/src/families/filecoin/integration.test.ts
+++ b/src/families/filecoin/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("filecoin", dataset);

--- a/src/families/polkadot/integration.test.ts
+++ b/src/families/polkadot/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("polkadot", dataset);

--- a/src/families/ripple/integration.test.ts
+++ b/src/families/ripple/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("ripple", dataset);

--- a/src/families/stellar/integration.test.ts
+++ b/src/families/stellar/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("stellar", dataset);

--- a/src/families/tezos/integration.test.ts
+++ b/src/families/tezos/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("tezos", dataset);

--- a/src/families/tron/integration.test.ts
+++ b/src/families/tron/integration.test.ts
@@ -1,0 +1,5 @@
+import "../../__tests__/test-helpers/setup";
+import { testBridgeWithoutLibcore } from "../../__tests__/test-helpers/bridge";
+import dataset from "./test-dataset";
+
+testBridgeWithoutLibcore("tron", dataset);


### PR DESCRIPTION
the idea is to avoid the monolithic all.libcore.ts pattern and have each family holding their own test file.
for simplicity of the migration, i've made the family still having the dataset export system, but we can later drop it too.

- [ ] as we now run the stuff twice, we probably accidentally run "scan accounts" twice or some other test twice, which may be reason of slower tests