### PR TITLE
LL-7776 Reduce number of syncSuccess events tracked

### DIFF
--- a/src/bridge/react/BridgeSync.tsx
+++ b/src/bridge/react/BridgeSync.tsx
@@ -103,6 +103,7 @@ function useHydrate({ accounts, hydrateCurrency }) {
 }
 
 const lastTimeAnalyticsTrackPerAccountId: Record<string, number> = {};
+const lastTimeSuccessSyncPerAccountId: Record<string, number> = {};
 const nothingState = {
   pending: false,
   error: null,
@@ -160,6 +161,16 @@ function useSyncQueue({
           const account = accounts.find((a) => a.id === accountId);
           if (!account) return;
           const subAccounts: SubAccount[] = account.subAccounts || [];
+
+          if (event === "SyncSuccess") {
+            // Nb Only emit SyncSuccess/SyncSuccessToken event once per launch
+            if (lastTimeSuccessSyncPerAccountId[accountId]) {
+              log("bridge", "skip sync tracking for " + accountId);
+              return;
+            }
+            lastTimeSuccessSyncPerAccountId[accountId] = startSyncTime;
+          }
+
           trackAnalytics(event, {
             duration: (Date.now() - startSyncTime) / 1000,
             currencyName: account.currency.name,

--- a/src/bridge/react/BridgeSync.tsx
+++ b/src/bridge/react/BridgeSync.tsx
@@ -165,7 +165,6 @@ function useSyncQueue({
           if (event === "SyncSuccess") {
             // Nb Only emit SyncSuccess/SyncSuccessToken event once per launch
             if (lastTimeSuccessSyncPerAccountId[accountId]) {
-              log("bridge", "skip sync tracking for " + accountId);
               return;
             }
             lastTimeSuccessSyncPerAccountId[accountId] = startSyncTime;


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-7776


## Description / Usage
<img width="987" alt="image" src="https://user-images.githubusercontent.com/4631227/138686305-7271f90f-0185-49c2-ad49-acf4b2d41cf9.png">

Prevent `syncSuccess` and `syncSuccessToken` events from reaching analytics if we've already emitted one for that account in the current application launch cycle. I didn't reuse the `lastTimeAnalyticsTrackPerAccountId` since we would miss a successful sync after a failed one. When the application relaunches this dictionary is cleared so a new `syncSuccess` event should be emitted the first time an account syncs.

We could reduce this further if we wanted to by grouping the token syncs but I'm following the comment by @gre on the matter on the Jira task.

**Gray events in the excalidraw are events we would not emit in this new logic that would be emitted otherwise.**

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
