### PR TITLE
LL-7917 - SWAP - Cleanup marketcap tickers call

### DIFF
--- a/src/currencies/sortByMarketcap.ts
+++ b/src/currencies/sortByMarketcap.ts
@@ -81,7 +81,15 @@ export const getMarketcapTickers: () => Promise<string[]> = makeLRUCache(() =>
 export const useMarketcapTickers = (): string[] | null | undefined => {
   const [tickers, setMarketcapTickers] = useState(marketcapTickersCache);
   useEffect(() => {
-    getMarketcapTickers().then(setMarketcapTickers);
+    let isMounted = true;
+
+    getMarketcapTickers().then((data) => {
+      if (isMounted) setMarketcapTickers(data);
+    });
+
+    return () => {
+      isMounted = false;
+    };
   }, []);
   return tickers;
 };


### PR DESCRIPTION
## Context (issues, jira)

[LL-7917]

Adding a cleanup callback to this useEffect will remove the warning when we use it in our tests. In addition to that, the cleanup function prevents memory leaks and removes some unnecessary and unwanted behaviours.

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [x] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->


[LL-7917]: https://ledgerhq.atlassian.net/browse/LL-7917?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ