### PR TITLE
LL-8133 Improve tx size estimation function

### DIFF
--- a/src/__tests__/families/bitcoin/wallet-btc/wallet.estimateMaxSpendable.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/wallet.estimateMaxSpendable.test.ts
@@ -57,9 +57,10 @@ describe("testing estimateMaxSpendable", () => {
     expect(maxSpendable.toNumber()).toEqual(
       balance -
         feesPerByte *
-          utils.estimateTxSize(
+          utils.maxTxSizeCeil(
             2,
-            1,
+            [],
+            true,
             account.xpub.crypto,
             account.xpub.derivationMode
           )

--- a/src/__tests__/families/bitcoin/wallet-btc/wallet.integration.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/wallet.integration.test.ts
@@ -63,7 +63,7 @@ describe("testing wallet", () => {
       fromAccount: account,
       txInfo,
     });
-    expect(tx).toEqual("d6154bba4915d07453bb09d4fa02d62e975b4475");
+    expect(Buffer.from(tx, "hex")).toHaveLength(20);
   });
 
   it("should allow to build a transaction splitting outputs", async () => {
@@ -87,7 +87,7 @@ describe("testing wallet", () => {
       fromAccount: account,
       txInfo,
     });
-    expect(tx).toEqual("d922a70d6a66b96cdaba4565270a21f97eb23a6d");
+    expect(Buffer.from(tx, "hex")).toHaveLength(20);
   });
 
   it("should throw during sync if there is an error in explorer", async () => {

--- a/src/__tests__/families/bitcoin/wallet-btc/xpub.pickingStrategies.integration.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/xpub.pickingStrategies.integration.test.ts
@@ -3,7 +3,10 @@ import * as bip39 from "bip39";
 import * as bitcoin from "bitcoinjs-lib";
 import coininfo from "coininfo";
 import BigNumber from "bignumber.js";
-import { DerivationModes } from "../../../../families/bitcoin/wallet-btc/types";
+import {
+  DerivationModes,
+  OutputInfo,
+} from "../../../../families/bitcoin/wallet-btc/types";
 import Xpub from "../../../../families/bitcoin/wallet-btc/xpub";
 import BitcoinLikeExplorer from "../../../../families/bitcoin/wallet-btc/explorer";
 import Crypto from "../../../../families/bitcoin/wallet-btc/crypto/bitcoin";
@@ -41,6 +44,17 @@ describe("testing xpub legacy transactions", () => {
     signer,
     xpub,
   };
+
+  function outputs(amount: number): OutputInfo[] {
+    return [
+      {
+        address: "mwXTtHo8Yy3aNKUUZLkBDrTcKT9qG9TqLb",
+        isChange: false,
+        script: Buffer.from([]),
+        value: new BigNumber(amount),
+      },
+    ];
+  }
 
   it("merge output strategy should be correct", async () => {
     // Initialize the xpub with 2 txs. So that it has 2 utxo
@@ -134,17 +148,15 @@ describe("testing xpub legacy transactions", () => {
     );
     let res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(10000),
-      0,
-      1
+      outputs(10000),
+      0
     );
     expect(res.unspentUtxos.length).toEqual(1); // only 1 utxo is enough
     expect(Number(res.unspentUtxos[0].value)).toEqual(300000000); // use cheaper utxo first
     res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(500000000),
-      0,
-      1
+      outputs(500000000),
+      0
     );
     expect(res.unspentUtxos.length).toEqual(2); // need 2 utxo
     expect(
@@ -161,17 +173,15 @@ describe("testing xpub legacy transactions", () => {
     );
     let res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(10000),
-      0,
-      1
+      outputs(10000),
+      0
     );
     expect(res.unspentUtxos.length).toEqual(1); // only 1 utxo is enough
     expect(Number(res.unspentUtxos[0].value)).toEqual(5000000000); // use old utxo first
     res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(5200000000),
-      0,
-      1
+      outputs(5200000000),
+      0
     );
     expect(res.unspentUtxos.length).toEqual(2); // need 2 utxo
     expect(
@@ -323,45 +333,40 @@ describe("testing xpub legacy transactions", () => {
     );
     let res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(10000),
-      10,
-      1
+      outputs(10000),
+      10
     );
     expect(res.unspentUtxos.length).toEqual(1);
     expect(Number(res.unspentUtxos[0].value)).toEqual(100000000);
 
     res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(290000000),
-      10,
-      1
+      outputs(290000000),
+      10
     );
     expect(res.unspentUtxos.length).toEqual(1);
     expect(Number(res.unspentUtxos[0].value)).toEqual(300000000);
 
     res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(500000000),
-      10,
-      1
+      outputs(500000000),
+      10
     );
     expect(res.unspentUtxos.length).toEqual(1);
     expect(Number(res.unspentUtxos[0].value)).toEqual(600000000);
 
     res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(800000000),
-      10,
-      1
+      outputs(800000000),
+      10
     );
     expect(res.unspentUtxos.length).toEqual(1);
     expect(Number(res.unspentUtxos[0].value)).toEqual(5000000000);
 
     res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(5000000000),
-      10,
-      1
+      outputs(5000000000),
+      10
     );
     expect(res.unspentUtxos.length).toEqual(2);
     expect(
@@ -370,9 +375,8 @@ describe("testing xpub legacy transactions", () => {
 
     res = await utxoPickingStrategy.selectUnspentUtxosToUse(
       dataset.xpub,
-      new BigNumber(5600000000),
-      10,
-      1
+      outputs(5600000000),
+      10
     );
     expect(res.unspentUtxos.length).toEqual(3);
     expect(

--- a/src/__tests__/families/bitcoin/wallet-btc/xpub.txs.NP2WPKH.integration.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/xpub.txs.NP2WPKH.integration.test.ts
@@ -178,9 +178,10 @@ describe.skip("testing xpub segwit transactions", () => {
     await xpubs[1].xpub.sync();
 
     expectedFee1 =
-      utils.estimateTxSize(
+      utils.maxTxSizeCeil(
         inputs.length,
-        outputs.length,
+        outputs.map((o) => o.address),
+        false,
         crypto,
         DerivationModes.SEGWIT
       ) * 100;

--- a/src/__tests__/families/bitcoin/wallet-btc/xpub.txs.P2WPKH.integration.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/xpub.txs.P2WPKH.integration.test.ts
@@ -167,9 +167,10 @@ describe.skip("testing xpub native segwit transactions", () => {
     await xpubs[1].xpub.sync();
 
     expectedFee1 =
-      utils.estimateTxSize(
+      utils.maxTxSizeCeil(
         inputs.length,
-        outputs.length,
+        outputs.map((o) => o.address),
+        false,
         crypto,
         DerivationModes.NATIVE_SEGWIT
       ) * 100;

--- a/src/__tests__/families/bitcoin/wallet-btc/xpub.txs.integration.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/xpub.txs.integration.test.ts
@@ -148,9 +148,10 @@ describe.skip("testing xpub legacy transactions", () => {
     }
 
     expectedFee1 =
-      utils.estimateTxSize(
+      utils.maxTxSizeCeil(
         inputs.length,
-        outputs.length,
+        outputs.map((o) => o.address),
+        false,
         crypto,
         DerivationModes.LEGACY
       ) * 100;
@@ -280,9 +281,10 @@ describe.skip("testing xpub legacy transactions", () => {
     await xpubs[1].xpub.sync();
 
     expectedFee2 =
-      utils.estimateTxSize(
+      utils.maxTxSizeCeil(
         inputs.length,
-        outputs.length,
+        outputs.map((o) => o.address),
+        false,
         crypto,
         DerivationModes.LEGACY
       ) * 100;

--- a/src/families/bitcoin/js-buildTransaction.ts
+++ b/src/families/bitcoin/js-buildTransaction.ts
@@ -44,7 +44,8 @@ export const buildTransaction = async (
     walletAccount,
     transaction.feePerByte.toNumber(), //!\ wallet-btc handles fees as JS number
     transaction.utxoStrategy.excludeUTXOs,
-    transaction.utxoStrategy.pickUnconfirmedRBF
+    transaction.utxoStrategy.pickUnconfirmedRBF,
+    [transaction.recipient]
   );
   log("btcwallet", "building transaction", transaction);
   const txInfo = await wallet.buildAccountTx({

--- a/src/families/bitcoin/js-estimateMaxSpendable.ts
+++ b/src/families/bitcoin/js-estimateMaxSpendable.ts
@@ -30,7 +30,8 @@ const estimateMaxSpendable = async ({
     walletAccount,
     feePerByte.toNumber(), //!\ wallet-btc handles fees as JS number
     transaction?.utxoStrategy?.excludeUTXOs || [],
-    transaction?.utxoStrategy?.pickUnconfirmedRBF || false
+    transaction?.utxoStrategy?.pickUnconfirmedRBF || false,
+    transaction ? [transaction.recipient] : []
   );
   return maxSpendable.lt(0) ? new BigNumber(0) : maxSpendable;
 };

--- a/src/families/bitcoin/wallet-btc/pickingstrategies/types.ts
+++ b/src/families/bitcoin/wallet-btc/pickingstrategies/types.ts
@@ -1,4 +1,5 @@
 import BigNumber from "bignumber.js";
+import { OutputInfo } from "..";
 import { ICrypto } from "../crypto/types";
 import { Output } from "../storage/types";
 import Xpub from "../xpub";
@@ -29,9 +30,8 @@ export abstract class PickingStrategy {
 
   abstract selectUnspentUtxosToUse(
     xpub: Xpub,
-    amount: BigNumber,
-    feePerByte: number,
-    nbOutputsWithoutChange: number
+    outputs: OutputInfo[],
+    feePerByte: number
   ): Promise<{
     unspentUtxos: Output[];
     totalValue: BigNumber;

--- a/src/families/bitcoin/wallet-btc/utils.ts
+++ b/src/families/bitcoin/wallet-btc/utils.ts
@@ -6,6 +6,7 @@ import { DerivationModes } from "./types";
 import { Currency, ICrypto } from "./crypto/types";
 import cryptoFactory from "./crypto/factory";
 import { fallbackValidateAddress } from "./crypto/base";
+import { UnsupportedDerivation } from "../../../errors";
 
 export function parseHexString(str: any) {
   const result: Array<number> = [];
@@ -91,58 +92,129 @@ export function byteSize(count: number) {
   return 9;
 }
 
-// refer to https://github.com/LedgerHQ/lib-ledger-core/blob/fc9d762b83fc2b269d072b662065747a64ab2816/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp#L217
-export function accurateTxSize(
-  inputCount: number,
-  outputCount: number,
-  currency: ICrypto,
-  derivationMode: string
-) {
-  let txSize = 0;
-  let fixedSize = 0;
-  // Fixed size computation
-  fixedSize = 4; // Transaction version
-  if (currency.network.usesTimestampedTransaction) fixedSize += 4; // Timestamp
-  fixedSize += byteSize(inputCount); // Number of inputs
-  fixedSize += byteSize(outputCount); // Number of outputs
-  fixedSize += 4; // Timelock
+const baseByte = 4;
+function fixedWeight(currency: ICrypto, derivationMode: string): number {
+  let fixedWeight = 4 * baseByte; // Transaction version
+  if (currency.network.usesTimestampedTransaction) fixedWeight += 4 * baseByte; // Timestamp
+  fixedWeight += 4 * baseByte; // Timelock
   if (derivationMode !== DerivationModes.LEGACY) {
-    fixedSize += 0.5; // Segwit marker & segwit flag
+    fixedWeight += 2; // Segwit marker & segwit flag, 1 WU per byte
   }
-  // refer to https://medium.com/coinmonks/on-bitcoin-transaction-sizes-part-2-9445373d17f4
-  // and https://bitcoin.stackexchange.com/questions/96017/what-are-the-sizes-of-single-sig-and-2-of-3-multisig-taproot-inputs
-  // and https://bitcoinops.org/en/tools/calc-size/
-  if (derivationMode === DerivationModes.TAPROOT) {
-    txSize = fixedSize + 57.75 * inputCount + 43 * outputCount;
-    return txSize;
-  }
-  const isSegwit =
-    derivationMode === DerivationModes.NATIVE_SEGWIT ||
-    derivationMode === DerivationModes.SEGWIT;
-  if (isSegwit) {
-    // Native Segwit: 32 PrevTxHash + 4 Index + 1 null byte + 4 sequence
-    // P2SH: 32 PrevTxHash + 4 Index + 23 scriptPubKey + 4 sequence
-    const isNativeSegwit = derivationMode === DerivationModes.NATIVE_SEGWIT;
-    const inputSize = isNativeSegwit ? 41 : 63;
-    const noWitness = fixedSize + inputSize * inputCount + 43 * outputCount; //43 is the biggest output(taproot output) size, we use the biggest one for safety
-    // Include flag and marker size (one byte each)
-    const witnessSize = noWitness + 108 * inputCount + 2;
-    txSize = (noWitness * 3 + witnessSize) / 4;
-  } else {
-    txSize = fixedSize + 148 * inputCount + 43 * outputCount;
-  }
-  return txSize;
+  return fixedWeight;
 }
 
-export function estimateTxSize(
+function inputWeight(derivationMode: string): number {
+  let inputWeight = (32 + 4 + 1 + 4) * baseByte;
+  if (derivationMode === DerivationModes.TAPROOT) {
+    inputWeight += 1 + 1 + 65;
+  } else if (derivationMode === DerivationModes.NATIVE_SEGWIT) {
+    inputWeight += 1 + 1 + 72 + 1 + 33;
+  } else if (derivationMode === DerivationModes.SEGWIT) {
+    inputWeight += 22 * baseByte + 1 + 1 + 72 + 1 + 33;
+  } else if (derivationMode === DerivationModes.LEGACY) {
+    inputWeight += 107 * baseByte;
+  } else {
+    throw UnsupportedDerivation(`Derivation mode ${derivationMode} unknown`);
+  }
+  return inputWeight;
+}
+
+function outputWeight(derivationMode: string): number {
+  let outputSize = 8 + 1; // amount + script size
+  if (derivationMode === DerivationModes.TAPROOT) {
+    outputSize += 34; // "1" + PUSH32 + <32 bytes>
+  } else if (derivationMode === DerivationModes.NATIVE_SEGWIT) {
+    outputSize += 22; // "0" + PUSH20 + <20 bytes>
+  } else if (derivationMode === DerivationModes.SEGWIT) {
+    outputSize += 23; // HASH160 + PUSH20 + <20 bytes> + EQUAL
+  } else if (derivationMode === DerivationModes.LEGACY) {
+    outputSize += 25; // DUP + HASH160 + PUSH20 + <20 bytes> + EQUALVERIFY + CHECKSIG
+  } else {
+    throw UnsupportedDerivation(derivationMode);
+  }
+  return outputSize * 4;
+}
+
+export function outputSize(currency: ICrypto, addr: string): number {
+  const scriptLen = currency.toOutputScript(addr).length;
+  return 1 + 8 + scriptLen;
+}
+
+/**
+ * Calculates the maximun size of an imaginary transaction in virtual bytes
+ * (vB). 1vB = 4 WU (weight units). If a cryptocurrency doesn't use segwit, then
+ * 1 byte = 1 vB. Weight units are used for segwit transactions, where certain
+ * bytes of the transaction is counted as 4 WU and some as 1 WU. The resulting
+ * size is then ceil(totalWU/4) vB.
+ *
+ * refer to https://medium.com/coinmonks/on-bitcoin-transaction-sizes-part-2-9445373d17f4
+ * and https://bitcoin.stackexchange.com/questions/96017/what-are-the-sizes-of-single-sig-and-2-of-3-multisig-taproot-inputs
+ * and https://bitcoinops.org/en/tools/calc-size/
+ *
+ * Suggested improvement: I assume that these calculations won't be exactly
+ * correct for altcoins (but I don't know). Therefore we should move this
+ * functionality into ICrypto, to make it easier to provide slightly different
+ * calculations for different cryptocurrencies.
+ *
+ * The reason for the name maxTxSize, instead of just txSize, is that the size
+ * of modern ecdsa signatures aren't know beforehand. They are either 71 or
+ * 72 bytes. This function always count with 72 byte signatures.
+ *
+ * The size of schnorr signatures is expected to be 65 bytes, since the Bitcoin
+ * hardware app appends the optional sighash type 01 at the end of the
+ * signature. If the app removes that optional byte, this functions should be
+ * updated to use 64 byte schnorr signatures, even if 65 still is an acceptable
+ * maximum.
+ *
+ * @param inputCount Number of inputs of the imaginary transaction
+ * @param outputAddrs The addresses of the outputs, excluding change.
+ * @param includeChange Indicates whether we should add a change output. The
+ * change output will have the same derivation mode as the inputs. See
+ * derivationMode parameter.
+ * @param currency The currency for which the calculation is done.
+ * @param derivationMode The derivation mode used for calculating the size of
+ * the inputs.
+ */
+export function maxTxSize(
   inputCount: number,
-  outputCount: number,
+  outputAddrs: string[],
+  includeChange: boolean,
   currency: ICrypto,
   derivationMode: string
-) {
-  return Math.ceil(
-    accurateTxSize(inputCount, outputCount, currency, derivationMode)
-  ); // We don't allow floating value
+): number {
+  const fixed = fixedWeight(currency, derivationMode);
+
+  let outputsWeight = byteSize(outputAddrs.length) * baseByte; // Number of outputs;
+  outputAddrs.forEach((addr) => {
+    outputsWeight += outputSize(currency, addr) * baseByte;
+  });
+  if (includeChange) {
+    outputsWeight += outputWeight(derivationMode);
+  }
+
+  // Input: 32 PrevTxHash + 4 Index + 1 scriptSigLength + 4 sequence
+  let inputsWeight = byteSize(inputCount) * baseByte; // Number of inputs
+  inputsWeight += inputWeight(derivationMode) * inputCount;
+
+  const txWeight = fixed + inputsWeight + outputsWeight;
+  return txWeight / 4;
+}
+
+export function maxTxSizeCeil(
+  inputCount: number,
+  outputAddrs: string[],
+  includeChange: boolean,
+  currency: ICrypto,
+  derivationMode: string
+): number {
+  const s = maxTxSize(
+    inputCount,
+    outputAddrs,
+    includeChange,
+    currency,
+    derivationMode
+  );
+  return Math.ceil(s);
 }
 
 // refer to https://github.com/LedgerHQ/lib-ledger-core/blob/fc9d762b83fc2b269d072b662065747a64ab2816/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp#L253

--- a/src/families/bitcoin/wallet-btc/xpub.ts
+++ b/src/families/bitcoin/wallet-btc/xpub.ts
@@ -288,9 +288,8 @@ class Xpub extends EventEmitter {
       needChangeoutput,
     } = await params.utxoPickingStrategy.selectUnspentUtxosToUse(
       this,
-      params.amount,
-      params.feePerByte,
-      outputs.length
+      outputs,
+      params.feePerByte
     );
 
     const txHexs = await Promise.all(
@@ -320,9 +319,10 @@ class Xpub extends EventEmitter {
       (utxo, index) => [txs[index].account, txs[index].index]
     );
 
-    const txSize = utils.estimateTxSize(
+    const txSize = utils.maxTxSizeCeil(
       unspentUtxoSelected.length,
-      outputs.length + 1,
+      outputs.map((o) => o.address),
+      true,
       this.crypto,
       this.derivationMode
     );


### PR DESCRIPTION
* rename estimateTxSize -> maxTxSize
* Provide output addresses to maxTxSize
* Provide outputs to UTXO picking strategies


## Context (issues, jira)



## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [x] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
