### PR TITLE
LL-7703 Prevent 'device-locked' false positive in Mananger

### DIFF
--- a/src/hw/uninstallApp.ts
+++ b/src/hw/uninstallApp.ts
@@ -9,14 +9,19 @@ export default function uninstallApp(
   targetId: string | number,
   app: ApplicationVersion | App
 ): Observable<any> {
-  return ManagerAPI.install(transport, "uninstall-app", {
-    targetId,
-    perso: app.perso,
-    deleteKey: app.delete_key,
-    firmware: app.delete,
-    firmwareKey: app.delete_key,
-    hash: app.hash,
-  }).pipe(
+  return ManagerAPI.install(
+    transport,
+    "uninstall-app",
+    {
+      targetId,
+      perso: app.perso,
+      deleteKey: app.delete_key,
+      firmware: app.delete,
+      firmwareKey: app.delete_key,
+      hash: app.hash,
+    },
+    true
+  ).pipe(
     ignoreElements(),
     catchError((e: Error) => {
       if (!e || !e.message) return throwError(e);


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-7703


## Description / Usage
Your device is locked! Well, not really. See, what happened was that we setup a timeout for a device to respond before we considered it unresponsive. When doing a normal operation, the device tends to respond pretty quickly to our APDUs, so if it's not responding for 15 seconds in the middle of a bulk stream (think install, but also listApps, or firmware updates) it must mean the device is locked, or one of the handled cases such as an allow manager or identifier verification for fw.

This particular case was due to the way our firmware reorganizes its memory after an uninstall, it will move all the data to the left meaning that, if we have a lot of applications installed after the one we are uninstalling, it may take more than those 15 seconds to complete the task.

![defrag](https://user-images.githubusercontent.com/4631227/143885458-154b39e1-8b6f-4bb7-8a59-1d2965aca16c.gif)

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.


### For QA
Without this in place you can easily replicate the error by:
- Starting on a nano x with no apps, install Polkadot (I say this because it has no dependencies later)
- Install a bunch of applications after it to fill in the space
- Uninstall Polkadot. 
- It is expected that we show a "device locked" error, and that the device uninstalls successfully. 

With this in place we should be able to follow the above steps without the error showing.