### PR TITLE
LL-8572 Improve UX for connectApp flows

### DIFF
--- a/src/hw/actions/app.ts
+++ b/src/hw/actions/app.ts
@@ -462,13 +462,13 @@ const implementations = {
 
               if (disconnectT) {
                 // any connect app event unschedule the disconnect debounced event
-                clearTimeout(disconnectT);
                 disconnectT = null;
+                clearTimeout(disconnectT);
               }
 
               if (event.type === "unresponsiveDevice") {
                 return; // ignore unresponsive case which happens for polling
-              } else if (event.type === "disconnected" && !event.expected) {
+              } else if (event.type === "disconnected") {
                 // the disconnect event is delayed to debounce the reconnection that happens when switching apps
                 disconnectT = setTimeout(() => {
                   disconnectT = null;
@@ -486,7 +486,6 @@ const implementations = {
                     device,
                   });
                 }
-                if (event.type === "disconnected") return; // do not emit the expected disconnect, we already have the deviceChange
                 o.next(event);
               }
             },
@@ -592,7 +591,7 @@ export const createAction = (
             }
 
             // default debounce (to be tweak)
-            return interval(1000);
+            return interval(2000);
           }),
           takeWhile((s: State) => !s.requiresAppInstallation && !s.error, true)
         ) // the state simply goes into a React state

--- a/src/hw/actions/app.ts
+++ b/src/hw/actions/app.ts
@@ -2,6 +2,7 @@ import invariant from "invariant";
 import {
   concat,
   of,
+  timer,
   interval,
   Observable,
   throwError,
@@ -11,7 +12,6 @@ import {
 import {
   scan,
   debounce,
-  debounceTime,
   catchError,
   timeout,
   switchMap,
@@ -161,7 +161,7 @@ const reducer = (state: State, e: Event): State => {
       return { ...state, unresponsive: true };
 
     case "disconnected":
-      return getInitialState();
+      return { ...getInitialState(), isLoading: !!e.expected };
 
     case "deviceChange":
       return { ...getInitialState(e.device), device: e.device };
@@ -384,13 +384,14 @@ function inferCommandParams(appRequest: AppRequest) {
   };
 }
 
+const DISCONNECT_DEBOUNCE = 5000;
 const implementations = {
   // in this paradigm, we know that deviceSubject is reflecting the device events
   // so we just trust deviceSubject to reflect the device context (switch between apps, dashboard,...)
   event: ({ deviceSubject, connectApp, params }) =>
     deviceSubject.pipe(
-      // debounce a bit the connect/disconnect event that we don't need
-      debounceTime(1000), // each time there is a device change, we pipe to the command
+      // debounce a bit the disconnect events that we don't need
+      debounce((device) => timer(!device ? DISCONNECT_DEBOUNCE : 0)),
       switchMap((device) =>
         concat(
           of({
@@ -406,7 +407,6 @@ const implementations = {
     Observable.create((o) => {
       const POLLING = 2000;
       const INIT_DEBOUNCE = 5000;
-      const DISCONNECT_DEBOUNCE = 5000;
       const DEVICE_POLLING_TIMEOUT = 20000;
       // this pattern allows to actually support events based (like if deviceSubject emits new device changes) but inside polling paradigm
       let pollingOnDevice;
@@ -462,13 +462,13 @@ const implementations = {
 
               if (disconnectT) {
                 // any connect app event unschedule the disconnect debounced event
-                disconnectT = null;
                 clearTimeout(disconnectT);
+                disconnectT = null;
               }
 
               if (event.type === "unresponsiveDevice") {
                 return; // ignore unresponsive case which happens for polling
-              } else if (event.type === "disconnected") {
+              } else if (event.type === "disconnected" && !event.expected) {
                 // the disconnect event is delayed to debounce the reconnection that happens when switching apps
                 disconnectT = setTimeout(() => {
                   disconnectT = null;
@@ -486,7 +486,7 @@ const implementations = {
                     device,
                   });
                 }
-
+                if (event.type === "disconnected") return; // do not emit the expected disconnect, we already have the deviceChange
                 o.next(event);
               }
             },
@@ -592,7 +592,7 @@ export const createAction = (
             }
 
             // default debounce (to be tweak)
-            return interval(2000);
+            return interval(1000);
           }),
           takeWhile((s: State) => !s.requiresAppInstallation && !s.error, true)
         ) // the state simply goes into a React state

--- a/src/hw/connectApp.ts
+++ b/src/hw/connectApp.ts
@@ -53,6 +53,7 @@ export type ConnectAppEvent =
     }
   | {
       type: "disconnected";
+      expected?: boolean;
     }
   | {
       type: "device-permission-requested";
@@ -144,6 +145,7 @@ const attemptToQuitApp = (
         concatMap(() =>
           of<ConnectAppEvent>({
             type: "disconnected",
+            expected: true,
           })
         ),
         catchError((e) => throwError(e))


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-8572

## Description / Usage
While investigating this issue for both  LLD and LLM integrations I saw several problems that led to situations where we displayed a "Connect and unlock your device" while the device was still connected. 
- After a successful `quitApp` we emitted a disconnect event in order to restart the flow for LLM, this impacted LLD in showing the connect animation when not needed, since the event driven paradigm will detect the re-connection and start the flow again. Since we still need the disconnect event for polling I simply added a `expected` flag so that the reducer will show the `isLoading` animation on LLD instead of the connect one, since we know there will be a connection afterwards.
- There's also a case where for the wired implementation the debounces were conflicting, meaning we would react to the disconnect one for a second and then see the connect one, simply conditionally debouncing the disconnects a bit more like we had for LLM mitigated the issue further.
<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Testing
I believe there might still be cases where we _could_ see the connect your device animation as a false positive but this should be better than the current production version. Simply go over flows for both LLM and LLD with different setups and see if it's better than now:
- Without the target app, to trigger inline install
- While being in the wrong app, to trigger the quitApp
- Needing "Allow manager" 
- Confirming a receive
- etc

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->

## Videos
Here is a sample flow that was impacted by the issue. On LLD, while inside the BTC app, start an ETH add account flow. This should be the same in both cases but notice how one of them asks the user twice to connect the device and the other one doesn't.




https://user-images.githubusercontent.com/4631227/145415853-d09bb478-8afe-414c-818a-5d328fb788e3.mov



https://user-images.githubusercontent.com/4631227/145415176-545e53bc-c1b5-4575-a547-1592b42f8ce6.mov


