### PR TITLE
Process raw txs to combine send and fees in only one tx

### DIFF
--- a/src/families/filecoin/bridge/account.ts
+++ b/src/families/filecoin/bridge/account.ts
@@ -2,7 +2,6 @@ import {
   AmountRequired,
   FeeNotLoaded,
   InvalidAddress,
-  InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
   RecipientRequired,
 } from "@ledgerhq/errors";
@@ -71,8 +70,6 @@ const getTransactionStatus = async (
   const { recipient, amount, gasPremium, gasFeeCap, gasLimit } = t;
 
   if (!recipient) errors.recipient = new RecipientRequired();
-  else if (address === recipient)
-    errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
   else if (!validateAddress(recipient).isValid)
     errors.recipient = new InvalidAddress();
   else if (!validateAddress(address).isValid)

--- a/src/families/filecoin/bridge/utils/types.ts
+++ b/src/families/filecoin/bridge/utils/types.ts
@@ -23,6 +23,7 @@ export interface TransactionResponse {
   hash: string;
   timestamp: number;
   height: number;
+  fee?: string;
 }
 
 export interface BalanceResponse {

--- a/src/families/filecoin/bridge/utils/utils.ts
+++ b/src/families/filecoin/bridge/utils/utils.ts
@@ -14,27 +14,59 @@ import { encodeAccountId } from "../../../../account";
 import flatMap from "lodash/flatMap";
 import { Transaction } from "../../types";
 
+type TxsById = {
+  [id: string]: {
+    Send: TransactionResponse;
+    Fee?: TransactionResponse;
+  };
+};
+
 export const getUnit = () => getCryptoCurrencyById("filecoin").units[0];
+
+export const processTxs = (
+  txs: TransactionResponse[]
+): TransactionResponse[] => {
+  const txsById = txs.reduce((result: TxsById, currentTx) => {
+    const { hash, type } = currentTx;
+    const txById = result[hash] || {};
+
+    if (type == "Send" || type == "Fee") txById[type] = currentTx;
+
+    result[hash] = txById;
+    return result;
+  }, {});
+
+  const processedTxs: TransactionResponse[] = [];
+  for (const txId in txsById) {
+    const { Fee: feeTx, Send: sendTx } = txsById[txId];
+
+    if (feeTx) sendTx.fee = feeTx.amount.toString();
+
+    processedTxs.push(sendTx);
+  }
+
+  return processedTxs;
+};
 
 export const mapTxToOps =
   (id, { address }: GetAccountShapeArg0) =>
   (tx: TransactionResponse): Operation[] => {
-    const { to, from, hash, timestamp, amount } = tx;
+    const { to, from, hash, timestamp, amount, fee } = tx;
     const ops: Operation[] = [];
     const date = new Date(timestamp * 1000);
     const value = parseCurrencyUnit(getUnit(), amount.toString());
 
     const isSending = address === from;
     const isReceiving = address === to;
-    const fee = new BigNumber(0);
+    const feeToUse = new BigNumber(fee || 0);
 
     if (isSending) {
       ops.push({
         id: `${id}-${hash}-OUT`,
         hash,
         type: "OUT",
-        value: value.plus(fee),
-        fee,
+        value: value.plus(feeToUse),
+        fee: feeToUse,
         blockHeight: tx.height,
         blockHash: null,
         accountId: id,
@@ -51,7 +83,7 @@ export const mapTxToOps =
         hash,
         type: "IN",
         value,
-        fee,
+        fee: feeToUse,
         blockHeight: tx.height,
         blockHash: null,
         accountId: id,
@@ -120,13 +152,13 @@ export const getAccountShape: GetAccountShape = async (info) => {
 
   const blockHeight = await fetchBlockHeight();
   const balance = await fetchBalances(address);
-  const txs = await fetchTxs(address);
+  const rawTxs = await fetchTxs(address);
 
   const result = {
     id: accountId,
     balance: new BigNumber(balance.total_balance),
     spendableBalance: new BigNumber(balance.spendable_balance),
-    operations: flatMap(txs, mapTxToOps(accountId, info)),
+    operations: flatMap(processTxs(rawTxs), mapTxToOps(accountId, info)),
     blockHeight: blockHeight.current_block_identifier.index,
   };
 

--- a/src/families/filecoin/test-dataset.ts
+++ b/src/families/filecoin/test-dataset.ts
@@ -2,7 +2,6 @@ import { BigNumber } from "bignumber.js";
 import {
   AmountRequired,
   InvalidAddress,
-  InvalidAddressBecauseDestinationIsAlsoSource,
   NotEnoughBalance,
 } from "@ledgerhq/errors";
 
@@ -56,27 +55,6 @@ const filecoin = {
         balance: "1000",
       },
       transactions: [
-        {
-          name: "recipient and sender must not be the same",
-          transaction: fromTransactionRaw({
-            family: "filecoin",
-            method: 1,
-            version: 1,
-            nonce: 100,
-            gasFeeCap: "1000",
-            gasLimit: 100,
-            gasPremium: "200",
-            recipient: SEED_IDENTIFIER,
-            amount: "100000000",
-          }),
-          expectedStatus: {
-            amount: new BigNumber("100000000"),
-            errors: {
-              recipient: new InvalidAddressBecauseDestinationIsAlsoSource(),
-            },
-            warnings: {},
-          },
-        },
         {
           name: "Not a valid address",
           transaction: fromTransactionRaw({


### PR DESCRIPTION
## Context (issues, jira)
The backend service generates two registers per transaction: one for the fee and one for the transaction itself. We must combine both of them on only one register.


## Description / Usage
We create a temporal index by tx hash in order to group fee and send tx together, and after we create one tx with fees included, if they are present. 

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

