### PR TITLE
test for external contributions

### DIFF
--- a/.github/workflows/bot2.yml
+++ b/.github/workflows/bot2.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - name: install yarn
         run: npm i -g yarn
       - name: pull docker image

--- a/.github/workflows/bot3.yml
+++ b/.github/workflows/bot3.yml
@@ -45,6 +45,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - name: install yarn
         run: npm i -g yarn
       - name: pull docker image

--- a/.github/workflows/bot4.yml
+++ b/.github/workflows/bot4.yml
@@ -5,25 +5,36 @@ on:
       - bitcoin-js
 
 jobs:
+  check-org-member:
+    runs-on: ubuntu-latest
+    name: "check if member is from LedgerHQ"
+    steps:
+      - uses: ledgerhq/actions/packages/is-org-member@main
+        with:
+          user: ${{ github.actor }}
+          organisation: ledgerhq
+          token: ${{ github.token }}
+
   start-runner:
     name: "start ec2 instance (Linux)"
-    if: ${{ always() }}
+    needs: [check-org-member]
+    if: ${{ success() }}
     uses: ledgerhq/actions/.github/workflows/start-linux-runner.yml@main
     secrets:
       CI_BOT_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
   stop-runner:
     name: "stop ec2 instance (Linux)"
-    needs: [start-runner, run-bot]
+    needs: [check-org-member, start-runner, run-bot]
     uses: ledgerhq/actions/.github/workflows/stop-linux-runner.yml@main
-    if: ${{ always() }}
+    if: ${{ always() && needs.check-org-member.result == "failure" }}
     with:
       label: ${{ needs.start-runner.outputs.label }}
       ec2-instance-id: ${{ needs.start-runner.outputs.ec2-instance-id }}
     secrets:
       CI_BOT_TOKEN: ${{ secrets.CI_BOT_TOKEN }}
 
-  run-bot:
+  run-bot-hosted:
     needs: [start-runner]
     runs-on: ${{ needs.start-runner.outputs.label }}
     steps:
@@ -41,12 +52,65 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - name: install yarn
         run: npm i -g yarn
       - name: pull docker image
         run: docker pull ghcr.io/ledgerhq/speculos
       - name: kill apt-get
         run: sudo killall -w apt-get apt || echo OK
+      - name: Install linux deps
+        run: sudo apt-get install -y libusb-1.0-0-dev jq
+      - name: Install dependencies
+        run: |
+          yarn global add yalc
+          yarn --frozen-lockfile
+          yarn ci-setup-cli
+      - name: BOT
+        env:
+          SHOW_LEGACY_NEW_ACCOUNT: "1"
+          DEBUG_HTTP_RESPONSE: "1"
+          SEED: ${{ secrets.SEED4 }}
+          VERBOSE_FILE: bot-tests.txt
+          GITHUB_SHA: ${GITHUB_SHA}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_WORKFLOW: ${{ github.workflow }}
+          SLACK_API_TOKEN: ${{ secrets.SLACK_API_TOKEN }}
+          SLACK_CHANNEL: live-ft-bitcoin-js
+          BOT_FILTER_FAMILY: bitcoin
+          EXPERIMENTAL_EXPLORERS: true
+          EXPERIMENTAL_CURRENCIES_JS_BRIDGE: bitcoin,bitcoin_cash,bsc,litecoin,dash,qtum,zcash,bitcoin_gold,stratis,dogecoin,digibyte,komodo,pivx,zencash,vertcoin,peercoin,viacoin,stakenet,stealthcoin,decred,bitcoin_testnet,tezos
+        run: COINAPPS=$PWD/coin-apps yarn ci-test-bot
+        timeout-minutes: 120
+      - name: Run coverage
+        if: failure() || success()
+        run: CODECOV_TOKEN=${{ secrets.CODECOV_TOKEN }} npx codecov
+      - name: upload logs
+        if: failure() || success()
+        uses: actions/upload-artifact@v1
+        with:
+          name: bot-tests.txt
+          path: bot-tests.txt
+
+  run-bot:
+    needs: [check-org-member]
+    if: ${{ failure() }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Retrieving coin apps
+        uses: actions/checkout@v2
+        with:
+          repository: LedgerHQ/coin-apps
+          token: ${{ secrets.PAT }}
+          path: coin-apps
+      - uses: actions/setup-node@master
+        with:
+          node-version: 14.x
+          cache: yarn
+      - name: pull docker image
+        run: docker pull ghcr.io/ledgerhq/speculos
       - name: Install linux deps
         run: sudo apt-get install -y libusb-1.0-0-dev jq
       - name: Install dependencies

--- a/.github/workflows/bot5.yml
+++ b/.github/workflows/bot5.yml
@@ -41,6 +41,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - name: install yarn
         run: npm i -g yarn
       - name: pull docker image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - uses: actions/setup-python@v2
         with:
           python-version: "2.x"
@@ -81,6 +82,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - uses: actions/setup-python@v2
         with:
           python-version: "2.x"
@@ -125,6 +127,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - name: install yarn
         run: npm i -g yarn
       - uses: actions/setup-python@v2
@@ -154,6 +157,7 @@ jobs:
       - uses: actions/setup-node@master
         with:
           node-version: 14.x
+          cache: yarn
       - uses: actions/setup-python@v2
         with:
           python-version: "2.7.x"


### PR DESCRIPTION
## Description / Usage

This PR adds a new branching in the bot jobs (right now testing only with bitcoin-js bot, but can extend to others) that will trigger our own hosted runners in the case the author is in ledgerhq org, otherwise, fallback to github runners

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
