### PR TITLE
LL-8880 Allow transaction device actions to have dependencies

### DIFF
--- a/src/hw/actions/transaction.ts
+++ b/src/hw/actions/transaction.ts
@@ -33,6 +33,8 @@ type TransactionRequest = {
   transaction: Transaction;
   status: TransactionStatus;
   appName?: string;
+  dependencies?: AppRequest[];
+  requireLatestFirmware?: boolean;
 };
 type TransactionResult =
   | {
@@ -112,7 +114,8 @@ export const createAction = (
     reduxDevice: Device | null | undefined,
     txRequest: TransactionRequest
   ): TransactionState => {
-    const { transaction, appName } = txRequest;
+    const { transaction, appName, dependencies, requireLatestFirmware } =
+      txRequest;
     const mainAccount = getMainAccount(
       txRequest.account,
       txRequest.parentAccount
@@ -120,6 +123,8 @@ export const createAction = (
     const appState = createAppAction(connectAppExec).useHook(reduxDevice, {
       account: mainAccount,
       appName,
+      dependencies,
+      requireLatestFirmware,
     });
     const { device, opened, inWrongDeviceForAccount, error } = appState;
     const [state, setState] = useState(initialState);

--- a/src/hw/actions/transaction.ts
+++ b/src/hw/actions/transaction.ts
@@ -17,7 +17,7 @@ import { getMainAccount } from "../../account";
 import { getAccountBridge } from "../../bridge";
 import type { ConnectAppEvent, Input as ConnectAppInput } from "../connectApp";
 import type { Action, Device } from "./types";
-import type { AppState } from "./app";
+import type { AppRequest, AppState } from "./app";
 import { createAction as createAppAction } from "./app";
 type State = {
   signedOperation: SignedOperation | null | undefined;


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-8880


## Description / Usage
In the context of platformization we are currently unable to require dependencies (or latest firmware for that matter), this manifested itself as a side effect when interacting with plugins and ethereum, although it would've eventually happened in a different context. This PR enables us to pass the dependencies down to the inner `connectApp` command, which will in turn solve the dependencies like it does for instance on the Swap flow where the Exchange app is a dependency alongside the currency apps.

I've also passed down the `requireLatestFirmware` flag because product wants to add this latest firmware wall on platform.
I am not to blame here.

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
