### PR TITLE
LL-8903 Emit device information from connectApp

### DIFF
--- a/src/hw/actions/app.ts
+++ b/src/hw/actions/app.ts
@@ -40,6 +40,7 @@ import type { Device, Action } from "./types";
 import { shouldUpgrade } from "../../apps";
 import { ConnectAppTimeout } from "../../errors";
 import perFamilyAccount from "../../generated/account";
+import type { DeviceInfo, FirmwareUpdateContext } from "../../types/manager";
 
 type State = {
   isLoading: boolean;
@@ -60,6 +61,8 @@ type State = {
   allowManagerRequestedWording: string | null | undefined;
   allowManagerGranted: boolean;
   device: Device | null | undefined;
+  deviceInfo?: DeviceInfo | null | undefined;
+  latestFirmware?: FirmwareUpdateContext | null | undefined;
   error: Error | null | undefined;
   derivation:
     | {
@@ -146,6 +149,8 @@ const getInitialState = (device?: Device | null | undefined): State => ({
   allowManagerRequestedWording: null,
   allowManagerGranted: false,
   device: null,
+  deviceInfo: null,
+  latestFirmware: null,
   opened: false,
   appAndVersion: null,
   error: null,
@@ -159,6 +164,13 @@ const reducer = (state: State, e: Event): State => {
   switch (e.type) {
     case "unresponsiveDevice":
       return { ...state, unresponsive: true };
+
+    case "device-update-last-seen":
+      return {
+        ...state,
+        deviceInfo: e.deviceInfo,
+        latestFirmware: e.latestFirmware,
+      };
 
     case "disconnected":
       return getInitialState();
@@ -586,7 +598,11 @@ export const createAction = (
           scan(reducer, getInitialState()), // tap((s) => console.log("connectApp state", s)),
           // we debounce the UI state to not blink on the UI
           debounce((s: State) => {
-            if (s.allowOpeningRequestedWording || s.allowOpeningGranted) {
+            if (
+              s.allowOpeningRequestedWording ||
+              s.allowOpeningGranted ||
+              s.deviceInfo
+            ) {
               // no debounce for allow event
               return EMPTY;
             }

--- a/src/hw/connectApp.ts
+++ b/src/hw/connectApp.ts
@@ -55,6 +55,11 @@ export type ConnectAppEvent =
       type: "disconnected";
     }
   | {
+      type: "device-update-last-seen";
+      deviceInfo: DeviceInfo;
+      latestFirmware: FirmwareUpdateContext | null | undefined;
+    }
+  | {
       type: "device-permission-requested";
       wording: string;
     }
@@ -102,6 +107,20 @@ export const openAppFromDashboard = (
   appName: string
 ): Observable<ConnectAppEvent> =>
   concat(
+    // Nb Allows LLD/LLM to update lastSeenDevice
+    from(getDeviceInfo(transport)).pipe(
+      mergeMap((deviceInfo) =>
+        from(manager.getLatestFirmwareForDevice(deviceInfo)).pipe(
+          concatMap((latestFirmware) =>
+            of<ConnectAppEvent>({
+              type: "device-update-last-seen",
+              deviceInfo,
+              latestFirmware,
+            })
+          )
+        )
+      )
+    ),
     of<ConnectAppEvent>({
       type: "ask-open-app",
       appName,


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-8903


## Description / Usage
Leveraging the fact that on any device flow there is a point where we _know_ the device is in the dashboard, I've added the logic to request the device information (A very light unsecured APDU) from the device and query the manager API for the latest firmware available for that device. This allows us to solve a long running issue with analytics where the last seen device information is outdated or missing altogether since we only update it when accessing the manager (and during onboarding in an incoming pr from @tlaforge-ledger), but also improve the granularity of when we should show something that is relevant to a specific firmware such as the firmware update banner, right now the banner would remain visible even if the user updated the device unless they access the manager again (especially true for LLM).

This alone doesn't solve the `lastSeenDevice` problematic but merely emits the event to be handled from the LLD/LLM side on the `DeviceAction` component by responding to the change of state. My understanding is that the api call is heavily cached and the worst case scenario I noticed was a 700ms delay which, considering we have a [2000ms debounce in the device actions themselves](https://github.com/LedgerHQ/ledger-live-common/blob/master/src/hw/actions/app.ts#L593-L594), should be negligible.

Technically this will allow **all device actions** to update this data. We'd need to be careful when responding to the event on LLD/LLM not to override other data that might be present in the app state such as the list of applications, I consider doing a list apps unnecessarily heavy since all we want for analytics is the number of apps

The light green (top left) part of the excalidraw below shows the change added in this pr.
<img width="1415" alt="image" src="https://user-images.githubusercontent.com/4631227/148426968-b7e3b103-ae31-4627-bca5-a8cecdd36bbf.png">

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
