### PR TITLE
LL-8903 Less blocking lastSeenDevice logic

### DIFF
--- a/src/hw/connectApp.ts
+++ b/src/hw/connectApp.ts
@@ -1,5 +1,5 @@
 import semver from "semver";
-import { Observable, concat, from, of, throwError, defer } from "rxjs";
+import { Observable, concat, from, of, throwError, defer, merge } from "rxjs";
 import { mergeMap, concatMap, map, catchError, delay } from "rxjs/operators";
 import {
   TransportStatusError,
@@ -107,10 +107,11 @@ export const openAppFromDashboard = (
   transport: Transport,
   appName: string
 ): Observable<ConnectAppEvent> =>
-  concat(
-    // Nb Allows LLD/LLM to update lastSeenDevice
-    from(getDeviceInfo(transport)).pipe(
-      mergeMap((deviceInfo) =>
+  from(getDeviceInfo(transport)).pipe(
+    mergeMap((deviceInfo) =>
+      merge(
+        // Nb Allows LLD/LLM to update lastSeenDevice, this can run in parallel
+        // since there are no more device exchanges.
         from(manager.getLatestFirmwareForDevice(deviceInfo)).pipe(
           concatMap((latestFirmware) =>
             of<ConnectAppEvent>({
@@ -119,39 +120,41 @@ export const openAppFromDashboard = (
               latestFirmware,
             })
           )
+        ),
+        concat(
+          of<ConnectAppEvent>({
+            type: "ask-open-app",
+            appName,
+          }),
+          defer(() => from(openApp(transport, appName))).pipe(
+            concatMap(() =>
+              of<ConnectAppEvent>({
+                type: "device-permission-granted",
+              })
+            ),
+            catchError((e) => {
+              if (e && e instanceof TransportStatusError) {
+                // @ts-expect-error TransportStatusError to be typed on ledgerjs
+                switch (e.statusCode) {
+                  case 0x6984:
+                  case 0x6807:
+                    return streamAppInstall({
+                      transport,
+                      appNames: [appName],
+                      onSuccessObs: () =>
+                        from(openAppFromDashboard(transport, appName)),
+                    }) as Observable<ConnectAppEvent>;
+                  case 0x6985:
+                  case 0x5501:
+                    return throwError(new UserRefusedOnDevice());
+                }
+              }
+
+              return throwError(e);
+            })
+          )
         )
       )
-    ),
-    of<ConnectAppEvent>({
-      type: "ask-open-app",
-      appName,
-    }),
-    defer(() => from(openApp(transport, appName))).pipe(
-      concatMap(() =>
-        of<ConnectAppEvent>({
-          type: "device-permission-granted",
-        })
-      ),
-      catchError((e) => {
-        if (e && e instanceof TransportStatusError) {
-          // @ts-expect-error TransportStatusError to be typed on ledgerjs
-          switch (e.statusCode) {
-            case 0x6984:
-            case 0x6807:
-              return streamAppInstall({
-                transport,
-                appNames: [appName],
-                onSuccessObs: () =>
-                  from(openAppFromDashboard(transport, appName)),
-              }) as Observable<ConnectAppEvent>;
-            case 0x6985:
-            case 0x5501:
-              return throwError(new UserRefusedOnDevice());
-          }
-        }
-
-        return throwError(e);
-      })
     )
   );
 


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-8903


## Description / Usage
 The original work from LL-8903 meant that if we had bad internet connection we would be blocking the openApp action for a few more seconds than needed. This change makes it non blocking, we just request the `getDeviceInfo` from the device, needed for the latest firmware API call, and if there's time to emit the `device-update-last-seen` event we do, if there's no time to emit it then we just continue. This idea of making it non blocking comes from Benito by the way, all kudos to him

Particularly interested in @gre and @valpinkman taking a look at the solution for the rxjs part. I tried with the `takeUntil` we talked about but then it wouldn't emit the inner events of the condition, this seems to work nicely.

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
