### PR TITLE
LL-8919 Market counterValueFormatter number of fraction digits now depends on the value

### DIFF
--- a/src/market/utils/countervalueFormatter.ts
+++ b/src/market/utils/countervalueFormatter.ts
@@ -17,7 +17,7 @@ export const counterValueFormatter = ({
     style: currency ? "currency" : "decimal",
     currency,
     notation: shorten ? "compact" : "standard",
-    maximumFractionDigits: value >= 1000 ? 3 : 8,
+    maximumFractionDigits: shorten ? 3 : 8,
   }).format(value);
 };
 

--- a/src/market/utils/countervalueFormatter.ts
+++ b/src/market/utils/countervalueFormatter.ts
@@ -17,7 +17,7 @@ export const counterValueFormatter = ({
     style: currency ? "currency" : "decimal",
     currency,
     notation: shorten ? "compact" : "standard",
-    maximumFractionDigits: 8,
+    maximumFractionDigits: value >= 1000 ? 3 : 8,
   }).format(value);
 };
 


### PR DESCRIPTION
… maximum fraction digits instead of 8 when the value is greater than 1000


## Context (issues, jira)

[LL-8919]

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->


[LL-8919]: https://ledgerhq.atlassian.net/browse/LL-8919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ