### PR TITLE
LL-9064 Solana fix too optimistic send

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@polkadot/types": "6.11.1",
     "@polkadot/types-known": "6.11.1",
     "@solana/spl-token": "^0.1.8",
-    "@solana/web3.js": "^1.31.0",
+    "@solana/web3.js": "^1.32.0",
     "@taquito/ledger-signer": "^11.1.0",
     "@taquito/taquito": "11.1.0",
     "@types/bchaddrjs": "^0.4.0",

--- a/src/families/solana/api/chain/index.ts
+++ b/src/families/solana/api/chain/index.ts
@@ -9,6 +9,7 @@ import {
   Connection,
   FeeCalculator,
   PublicKey,
+  sendAndConfirmRawTransaction,
   SignaturesForAddressOptions,
 } from "@solana/web3.js";
 import { Awaited } from "../../logic";
@@ -96,8 +97,11 @@ export function getChainAPI(config: Config): ChainAPI {
         .getParsedAccountInfo(new PublicKey(address))
         .then((r) => r.value),
 
-    sendRawTransaction: (buffer: Buffer) =>
-      connection().sendRawTransaction(buffer),
+    sendRawTransaction: (buffer: Buffer) => {
+      return sendAndConfirmRawTransaction(connection(), buffer, {
+        commitment: "confirmed",
+      });
+    },
 
     findAssocTokenAccAddress: (owner: string, mint: string) =>
       Token.getAssociatedTokenAddress(

--- a/yarn.lock
+++ b/yarn.lock
@@ -1453,10 +1453,30 @@
     buffer-layout "^1.2.0"
     dotenv "10.0.0"
 
-"@solana/web3.js@^1.21.0", "@solana/web3.js@^1.31.0":
+"@solana/web3.js@^1.21.0":
   version "1.31.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.31.0.tgz#7a313d4c1a90b77f27ddbfe845a10d6883e06452"
   integrity sha512-7nHHx1JNFnrt15e9y8m38I/EJCbaB+bFC3KZVM1+QhybCikFxGMtGA5r7PDC3GEL1R2RZA8yKoLkDKo3vzzqnw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    "@ethersproject/sha2" "^5.5.0"
+    "@solana/buffer-layout" "^3.0.0"
+    bn.js "^5.0.0"
+    borsh "^0.4.0"
+    bs58 "^4.0.1"
+    buffer "6.0.1"
+    cross-fetch "^3.1.4"
+    jayson "^3.4.4"
+    js-sha3 "^0.8.0"
+    rpc-websockets "^7.4.2"
+    secp256k1 "^4.0.2"
+    superstruct "^0.14.2"
+    tweetnacl "^1.0.0"
+
+"@solana/web3.js@^1.32.0":
+  version "1.32.0"
+  resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.32.0.tgz#b9821de52d0e773c363516c3dcef9be701295d82"
+  integrity sha512-jquZ/VBvM3zXAaTJvdWd9mlP0WiZaZqjji0vw5UAsb5IKIossrLhHtyUqMfo41Qkdwu1aVwf7YWG748i4XIJnw==
   dependencies:
     "@babel/runtime" "^7.12.5"
     "@ethersproject/sha2" "^5.5.0"


### PR DESCRIPTION
## Context (issues, jira)

Solana send (broadcast) is too optimistic.

## Description / Usage

Wait broadcasted transaction to reach at least `confirmed` status.

## Expectations

No more too optimistic operations. Broadcast fails if blockchain doesn't confirm the transaction within timeout (30 seconds atm).