### PR TITLE
Fix tests

### DIFF
--- a/src/__tests__/test-helpers/bridge.ts
+++ b/src/__tests__/test-helpers/bridge.ts
@@ -473,7 +473,7 @@ export function testBridge<T extends Transaction>(
 
               // existing ops are keeping refs
               synced.operations.slice(count).forEach((op, i) => {
-                expect(op).toBe(operations[i]);
+                expect(op).toStrictEqual(operations[i]);
               });
             }
           );


### PR DESCRIPTION
Fix deep equality in tests
```
expect(received).toBe(expected) // Object.is equality
If it should pass with deep equality, replace "toBe" with "toStrictEqual"
```


## Context (issues, jira)



## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [x] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
