### PR TITLE
LL-9042 Mark plugins as plugins based on description field

### DIFF
--- a/src/apps/hw.ts
+++ b/src/apps/hw.ts
@@ -5,6 +5,7 @@ import { concat, of, EMPTY, from, Observable, throwError, defer } from "rxjs";
 import { mergeMap, map } from "rxjs/operators";
 import type { Exec, AppOp, ListAppsEvent, ListAppsResult } from "./types";
 import type { App, DeviceInfo } from "../types/manager";
+import { AppType } from "../types/manager";
 import manager, { getProviderId } from "../manager";
 import installApp from "../hw/installApp";
 import uninstallApp from "../hw/uninstallApp";
@@ -313,6 +314,11 @@ export const listApps = (
             }
           }
 
+          const type =
+            application.description === AppType.PLUGIN
+              ? AppType.PLUGIN
+              : AppType.APP;
+
           const app: App = polyfillApp({
             id: version.id,
             name: version.name,
@@ -320,6 +326,7 @@ export const listApps = (
             version: version.version,
             currencyId,
             description: version.description,
+            type,
             dateModified: version.date_last_modified,
             icon: version.icon,
             authorName: application.authorName,

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -130,6 +130,7 @@ export type ApplicationVersion = {
   providers: Array<Id>;
   date_creation: string;
   date_last_modified: string;
+  type?: AppType;
   // dependencies: Id[],
   bytes: number | null | undefined;
   warning: string | null | undefined;
@@ -153,6 +154,11 @@ export type Application = {
   sourceURL: string | null | undefined;
   compatibleWalletsJSON: string | null | undefined;
 };
+export enum AppType {
+  APP = "app",
+  PLUGIN = "plugin",
+  TOOL = "tool", // Nb not used for now
+}
 // App is higher level on top of Application and ApplicationVersion
 // with all fields Live needs and in normalized form (but still serializable)
 export type App = {
@@ -185,6 +191,7 @@ export type App = {
   // -1 if coin not in marketcap, otherwise index in the tickers list of https://countervalues.api.live.ledger.com/tickers
   indexOfMarketCap: number;
   isDevTools: boolean;
+  type: AppType;
 };
 export type Category = {
   id: Id;


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LL-9042


## Description / Usage
There should be no changes at all (note that I'm just accessing a readily available prop), this will be seen on the respective LLD and LLM implementations that will leverage this change to show a different rendering for apps that are marked as plugins. 

> I left the comment about this being temporary since we will have api changes soon-ish that will introduce proper type.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
