### PR TITLE
[LL-8773] Move feature flags common logic in LLC

### DIFF
--- a/src/featureFlags/FeatureToggle.tsx
+++ b/src/featureFlags/FeatureToggle.tsx
@@ -9,7 +9,7 @@ type Props = {
   children?: ReactNode;
 };
 
-const FeatureToggle = ({
+export const FeatureToggle = ({
   feature: featureId,
   fallback,
   children,
@@ -22,5 +22,3 @@ const FeatureToggle = ({
 
   return children;
 };
-
-export default FeatureToggle;

--- a/src/featureFlags/FeatureToggle.tsx
+++ b/src/featureFlags/FeatureToggle.tsx
@@ -1,0 +1,26 @@
+import { ReactNode } from "react";
+
+import useFeature from "./useFeature";
+import { FeatureId } from "./types";
+
+type Props = {
+  feature: FeatureId;
+  fallback?: ReactNode;
+  children?: ReactNode;
+};
+
+const FeatureToggle = ({
+  feature: featureId,
+  fallback,
+  children,
+}: Props): ReactNode => {
+  const feature = useFeature(featureId);
+
+  if (!feature || !feature.enabled) {
+    return fallback;
+  }
+
+  return children;
+};
+
+export default FeatureToggle;

--- a/src/featureFlags/defaultFeatures.ts
+++ b/src/featureFlags/defaultFeatures.ts
@@ -1,0 +1,6 @@
+import { DefaultFeatures } from "../types";
+
+export const defaultFeatures: DefaultFeatures = {
+  feature_foo: false,
+  feature_bar: false,
+};

--- a/src/featureFlags/defaultFeatures.ts
+++ b/src/featureFlags/defaultFeatures.ts
@@ -1,6 +1,13 @@
-import { DefaultFeatures } from "../types";
+import { DefaultFeatures } from "./types";
 
 export const defaultFeatures: DefaultFeatures = {
-  feature_foo: false,
-  feature_bar: false,
+  discover: {
+    enabled: false,
+  },
+  send: {
+    enabled: false,
+  },
+  market: {
+    enabled: false,
+  },
 };

--- a/src/featureFlags/defaultFeatures.ts
+++ b/src/featureFlags/defaultFeatures.ts
@@ -1,12 +1,6 @@
 import { DefaultFeatures } from "./types";
 
 export const defaultFeatures: DefaultFeatures = {
-  discover: {
-    enabled: false,
-  },
-  send: {
-    enabled: false,
-  },
   market: {
     enabled: false,
   },

--- a/src/featureFlags/index.ts
+++ b/src/featureFlags/index.ts
@@ -1,0 +1,4 @@
+export * from "./defaultFeatures";
+export * from "./FeatureToggle";
+export * from "./provider";
+export * from "./useFeature";

--- a/src/featureFlags/provider.tsx
+++ b/src/featureFlags/provider.tsx
@@ -1,0 +1,48 @@
+import React, {
+  createContext,
+  ReactNode,
+  useContext,
+  useEffect,
+  useState,
+} from "react";
+
+import { FeatureId, Feature } from "./types";
+
+type State = {
+  getFeature: (_: FeatureId) => Feature | null;
+};
+
+const initialState: State = {
+  getFeature: (_) => ({ enabled: false }),
+};
+
+const FeatureFlagsContext = createContext<State>(initialState);
+
+export function useFeatureFlags(): State {
+  return useContext<State>(FeatureFlagsContext);
+}
+
+type Props = {
+  getFeature: (_: FeatureId) => Feature | null;
+  children?: ReactNode;
+};
+
+export function FeatureFlagsProvider({
+  getFeature,
+  children,
+}: Props): JSX.Element {
+  const [state, setState] = useState<State>(initialState);
+
+  useEffect(() => {
+    setState((prev) => ({
+      ...prev,
+      getFeature,
+    }));
+  }, [getFeature]);
+
+  return (
+    <FeatureFlagsContext.Provider value={state}>
+      {children}
+    </FeatureFlagsContext.Provider>
+  );
+}

--- a/src/featureFlags/types.ts
+++ b/src/featureFlags/types.ts
@@ -1,0 +1,9 @@
+export type FeatureId = "discover" | "send" | "market";
+
+// We use objects instead of direct booleans for potential future improvements
+// like feature versioning etc
+export type Feature = {
+  enabled: boolean;
+};
+
+export type DefaultFeatures = { [key in FeatureId]: Feature };

--- a/src/featureFlags/types.ts
+++ b/src/featureFlags/types.ts
@@ -1,4 +1,4 @@
-export type FeatureId = "discover" | "send" | "market";
+export type FeatureId = "market"; // Add others with union
 
 // We use objects instead of direct booleans for potential future improvements
 // like feature versioning etc

--- a/src/featureFlags/useFeature.ts
+++ b/src/featureFlags/useFeature.ts
@@ -1,0 +1,8 @@
+import { useFeatureFlags } from "./provider";
+import { Feature, FeatureId } from "./types";
+
+export default function useFeature(key: FeatureId): Feature | null {
+  const featureFlags = useFeatureFlags();
+
+  return featureFlags.getFeature(key);
+}

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -1,0 +1,3 @@
+export type FeatureId = "feature_foo" | "feature_bar";
+
+export type DefaultFeatures = { [key in FeatureId]: boolean };

--- a/src/types/featureFlags.ts
+++ b/src/types/featureFlags.ts
@@ -1,3 +1,0 @@
-export type FeatureId = "feature_foo" | "feature_bar";
-
-export type DefaultFeatures = { [key in FeatureId]: boolean };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,4 +10,4 @@ export * from "../generated/types";
 export * from "./bridge";
 export * from "./pagination";
 export * from "./nft";
-export * from "./featureFlags";
+export * from "../featureFlags/types";

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -10,3 +10,4 @@ export * from "../generated/types";
 export * from "./bridge";
 export * from "./pagination";
 export * from "./nft";
+export * from "./featureFlags";


### PR DESCRIPTION
## Context (issues, jira)

[LL-8773]

## Description / Usage

We are integrating feature flagging in [LLD](https://github.com/LedgerHQ/ledger-live-desktop/pull/4609) and [LLM](https://github.com/LedgerHQ/ledger-live-mobile/pull/2148) through Firebase. We identified some common logics that could be directly put in LLC to use in both projects:
- The default config in case the device fails to fetch the remote one
- The different hooks, components and providers for React that are the same on either platforms
- Useful typescript types

Note that this implementation does not depend in any way on Firebase which is instead setup in LLD and LLM.

Also, this PR doesn't have any impact on anything currently. It's only additions and no deletions or updates in a new directory of the lib.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->


[LL-8773]: https://ledgerhq.atlassian.net/browse/LL-8773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ