### PR TITLE
LL-8982 Add error for 0 qty ERC1155 NFT send

### DIFF
--- a/src/families/ethereum/modules/erc1155.ts
+++ b/src/families/ethereum/modules/erc1155.ts
@@ -14,6 +14,7 @@ import { prepareTransaction } from "./erc721";
 const notOwnedNft = createCustomErrorClass("NotOwnedNft");
 const notEnoughNftOwned = createCustomErrorClass("NotEnoughNftOwned");
 const notTokenIdsProvided = createCustomErrorClass("NotTokenIdsProvided");
+const quantityNeedsToBePositive = createCustomErrorClass("QuantityNeedsToBePositive");
 
 export type Modes = "erc1155.transfer";
 
@@ -42,6 +43,12 @@ const erc1155Transfer: ModeModule = {
       if (result.estimatedFees.gt(a.spendableBalance)) {
         result.errors.amount = new NotEnoughBalanceInParentAccount();
       }
+
+      t.quantities?.forEach((quantity) => {
+        if(quantity.isLessThan(1)) {
+          result.errors.amount = new quantityNeedsToBePositive();
+        }
+      });
 
       const enoughTokensOwned: true | Error =
         t.tokenIds?.reduce((acc, tokenId, index) => {

--- a/src/families/ethereum/modules/erc1155.ts
+++ b/src/families/ethereum/modules/erc1155.ts
@@ -14,7 +14,9 @@ import { prepareTransaction } from "./erc721";
 const notOwnedNft = createCustomErrorClass("NotOwnedNft");
 const notEnoughNftOwned = createCustomErrorClass("NotEnoughNftOwned");
 const notTokenIdsProvided = createCustomErrorClass("NotTokenIdsProvided");
-const quantityNeedsToBePositive = createCustomErrorClass("QuantityNeedsToBePositive");
+const quantityNeedsToBePositive = createCustomErrorClass(
+  "QuantityNeedsToBePositive"
+);
 
 export type Modes = "erc1155.transfer";
 
@@ -45,7 +47,7 @@ const erc1155Transfer: ModeModule = {
       }
 
       t.quantities?.forEach((quantity) => {
-        if(quantity.isLessThan(1)) {
+        if (quantity.isLessThan(1)) {
           result.errors.amount = new quantityNeedsToBePositive();
         }
       });


### PR DESCRIPTION
## Context (issues, jira)
[LL-8982]


## Description / Usage
The user won't be able to use '0' for quantity when sending an ERC1155 NFT
![image](https://user-images.githubusercontent.com/6013294/151202634-c41fb412-d401-476a-adb6-5e0f5cf6a7b8.png)


## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

To be tested by QA

[LL-8982]: https://ledgerhq.atlassian.net/browse/LL-8982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ