### PR TITLE
Add filtering query param to eth tx API call

### DIFF
--- a/src/api/Ethereum.ts
+++ b/src/api/Ethereum.ts
@@ -138,6 +138,7 @@ export const apiForCurrency = (currency: CryptoCurrency): API => {
             noinput: true,
             no_input: true,
             no_token: true,
+            filtering: true,
             block_hash,
           },
         }),


### PR DESCRIPTION
## Context (issues, jira)

A new parameter on the explorers allows for filtering the transactions of an account to only return what is related to it (avoiding complete batch transfers with a lot of unrelated operations for example), which reduces the payload a lot and improves performances.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
