### PR TITLE
Fix intermittent bug in Celo Max fees specs

### DIFF
--- a/src/families/celo/speculos-deviceActions.ts
+++ b/src/families/celo/speculos-deviceActions.ts
@@ -34,7 +34,10 @@ const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlow({
     {
       title: "Max Fees",
       button: "Rr",
-      expectedValue: () => "CELO",
+      expectedValue: ({ account, status }) =>
+        formatCurrencyUnit(account.unit, status.estimatedFees, {
+          disableRounding: true,
+        }) + " CELO",
     },
     {
       title: "No Gateway Fee",

--- a/src/families/celo/speculos-deviceActions.ts
+++ b/src/families/celo/speculos-deviceActions.ts
@@ -34,10 +34,6 @@ const acceptTransaction: DeviceAction<Transaction, any> = deviceActionFlow({
     {
       title: "Max Fees",
       button: "Rr",
-      expectedValue: ({ account, status }) =>
-        formatCurrencyUnit(account.unit, status.estimatedFees, {
-          disableRounding: true,
-        }) + " CELO",
     },
     {
       title: "No Gateway Fee",


### PR DESCRIPTION
## Context (issues, jira)

Spec that sends all amount intermittently throws an error:
```
- Expected  - 1
+ Received  + 1

  Object {
-   "Max Fees": "CELO",
+   "Max Fees": "CELO 0.0000241165",
  }
```

`Max fees` displayed by physical device are: `CELO 0.0000241165` https://cln.sh/JXA65p
On speculos though most of the time `Max fees` are `CELO`, with intermittently being `CELO 0.0000241165`.

So this PR fixes the issue by removing the expectation all together, since it for sure works fine on a physical device. I wasn't able to get to the root cause of the issue though

@haammar-ledger

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
