### PR TITLE
LIVE-921 Throw specific error when app not in provider

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -141,6 +141,9 @@ export const SatStackDescriptorNotImported = createCustomErrorClass(
 export const SwapNoAvailableProviders = createCustomErrorClass(
   "SwapNoAvailableProviders"
 );
+export const NoSuchAppOnProvider = createCustomErrorClass(
+  "NoSuchAppOnProvider"
+);
 export const SwapExchangeRateAmountTooLow = createCustomErrorClass(
   "SwapExchangeRateAmountTooLow"
 );


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-921


## Description / Usage
In the context of the linked Jira issue, the error was happening not because the application was missing but because _when the application was unknown_ we were doing a firmware check that caused an error from inside the `semver.lt` call. Fixing that logic would mean that we would enter the invariant case and throw an "Unknown app" error instead.

In order to be able to customize the rendering of the error, I created a new error and throw that instead.

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
