### PR TITLE
LL-9216 be less strict on breaking on non user accounts

### DIFF
--- a/src/families/tezos/synchronisation.ts
+++ b/src/families/tezos/synchronisation.ts
@@ -84,13 +84,12 @@ export const getAccountShape: GetAccountShape = async (infoInput) => {
       },
     };
   }
-  invariant(
-    apiAccount.type === "user",
-    "unsupported account of type ",
-    apiAccount.type
-  );
 
-  const apiOperations = await fetchAllTransactions(address, lastId);
+  const fullySupported = apiAccount.type === "user";
+
+  const apiOperations = fullySupported
+    ? await fetchAllTransactions(address, lastId)
+    : [];
 
   const { revealed, counter, publicKey } = apiAccount;
 


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LL-9216 
on tezos implementation, some users may have baker accounts, that PR make scan accounts non breaking but these accounts will miss the operations history because there are a more complex set of operations in this case and it would be some extra work to support them – we do not officially support these accounts so the point is to fix the synchronisation and scan accounts **as a first step.**