### PR TITLE
add check for recipient not equal to sender on crypto.org

### DIFF
--- a/src/families/crypto_org/js-getTransactionStatus.ts
+++ b/src/families/crypto_org/js-getTransactionStatus.ts
@@ -5,6 +5,7 @@ import {
   InvalidAddress,
   FeeNotLoaded,
   AmountRequired,
+  InvalidAddressBecauseDestinationIsAlsoSource,
 } from "@ledgerhq/errors";
 import type { Account, TransactionStatus } from "../../types";
 import type { Transaction } from "./types";
@@ -46,6 +47,8 @@ const getTransactionStatus = async (
     errors.recipient = new RecipientRequired();
   } else if (!isValidAddress(t.recipient, a.currency.id)) {
     errors.recipient = new InvalidAddress();
+  } else if (t.mode === "send" && a.freshAddress === t.recipient) {
+    errors.recipient = new InvalidAddressBecauseDestinationIsAlsoSource();
   }
 
   return Promise.resolve({


### PR DESCRIPTION
## Context (issues, jira)



## Description / Usage

Add check for recipient not to be equal to sender on Crypto.org integration

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
