### PR TITLE
LIVE-883 LIVE-885 Add more types for manager apps

### DIFF
--- a/src/apps/hw.ts
+++ b/src/apps/hw.ts
@@ -315,9 +315,10 @@ export const listApps = (
           }
 
           const type =
-            application.description === AppType.PLUGIN
-              ? AppType.PLUGIN
-              : AppType.APP;
+            application.description &&
+            Object.values(AppType).includes(application.description as AppType)
+              ? AppType[application.description]
+              : AppType.app;
 
           const app: App = polyfillApp({
             id: version.id,

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -155,9 +155,10 @@ export type Application = {
   compatibleWalletsJSON: string | null | undefined;
 };
 export enum AppType {
-  APP = "app",
-  PLUGIN = "plugin",
-  TOOL = "tool", // Nb not used for now
+  app = "app",
+  plugin = "plugin",
+  tool = "tool",
+  swap = "swap",
 }
 // App is higher level on top of Application and ApplicationVersion
 // with all fields Live needs and in normalized form (but still serializable)


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-883
https://ledgerhq.atlassian.net/browse/LIVE-885


## Description / Usage
The same way we started detecting plugins as such based on (temporarily, yes, there's ongoing work to use a proper field on the appstore) the description field, this introduces support for two new types, "swap" and "tool" which will allow LLD and LLM to show different renderings for those cases.

In particular for the Exchange app (swap) it will allow a direct CTA to the feature itself whereas for tool apps it will allow a redirection to a different Learn more url on our support site.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
