### PR TITLE
LIVE-1123: low amount user shouldn't be able to set everything he want

### DIFF
--- a/src/families/tezos/bridge/js.ts
+++ b/src/families/tezos/bridge/js.ts
@@ -107,7 +107,9 @@ const getTransactionStatus = async (
       errors.amount = new AmountRequired();
     } else if (!errors.amount && t.amount.gt(spendableBalance)) {
       errors.amount = new NotEnoughBalance();
-      amount = new BigNumber(0);
+      if (t.useAllAmount) {
+        amount = new BigNumber(0);
+      }
     } else if (t.amount.gt(0) && estimatedFees.times(10).gt(t.amount)) {
       warnings.feeTooHigh = new FeeTooHigh();
     }

--- a/src/families/tezos/bridge/js.ts
+++ b/src/families/tezos/bridge/js.ts
@@ -12,6 +12,7 @@ import {
   FeeTooHigh,
   InvalidAddressBecauseDestinationIsAlsoSource,
   RecommendUndelegation,
+  NotEnoughBalanceBecauseDestinationNotCreated,
 } from "@ledgerhq/errors";
 import { validateRecipient } from "../../../bridge/shared";
 import type {
@@ -35,8 +36,11 @@ import { signOperation } from "../signOperation";
 import { patchOperationWithHash } from "../../../operation";
 import { log } from "@ledgerhq/logs";
 import { InvalidAddressBecauseAlreadyDelegated } from "../../../errors";
+import api from "../api/tzkt";
 
 const receive = makeAccountBridgeReceive();
+
+const EXISTENTIAL_DEPOSIT = new BigNumber(275000);
 
 const createTransaction: () => Transaction = () => ({
   family: "tezos",
@@ -71,6 +75,7 @@ const getTransactionStatus = async (
   } = {};
 
   const estimatedFees = t.estimatedFees || new BigNumber(0);
+  let amount = t.amount;
 
   const { tezosResources } = account;
   if (!tezosResources) throw new Error("tezosResources is missing");
@@ -95,12 +100,26 @@ const getTransactionStatus = async (
   }
 
   if (t.mode === "send") {
-    if (!errors.amount && t.amount.eq(0)) {
+    const spendableBalance = account.balance.minus(EXISTENTIAL_DEPOSIT).lt(0)
+      ? account.balance.minus(EXISTENTIAL_DEPOSIT)
+      : account.balance;
+    if (!errors.amount && t.amount.eq(0) && !t.useAllAmount) {
       errors.amount = new AmountRequired();
-    } else if (!errors.amount && t.amount.lt(0)) {
+    } else if (!errors.amount && t.amount.gt(spendableBalance)) {
       errors.amount = new NotEnoughBalance();
+      amount = new BigNumber(0);
     } else if (t.amount.gt(0) && estimatedFees.times(10).gt(t.amount)) {
       warnings.feeTooHigh = new FeeTooHigh();
+    }
+
+    if (
+      !errors.amount &&
+      (await api.getAccountByAddress(t.recipient)).type === "empty" &&
+      t.amount.lt(EXISTENTIAL_DEPOSIT)
+    ) {
+      errors.amount = new NotEnoughBalanceBecauseDestinationNotCreated("", {
+        minimalAmount: "0.275 XTZ",
+      });
     }
 
     const thresholdWarning = 0.5 * 10 ** account.currency.units[0].magnitude;
@@ -146,8 +165,8 @@ const getTransactionStatus = async (
     errors,
     warnings,
     estimatedFees,
-    amount: t.amount,
-    totalSpent: t.amount.plus(estimatedFees),
+    amount: amount,
+    totalSpent: amount.plus(estimatedFees),
   };
   return Promise.resolve(result);
 };
@@ -222,7 +241,6 @@ const prepareTransaction = async (
       default:
         throw new Error("unsupported mode=" + transaction.mode);
     }
-
     if (t.useAllAmount) {
       const totalFees = out.suggestedFeeMutez + out.burnFeeMutez;
       const maxAmount = account.balance

--- a/src/families/tezos/synchronisation.ts
+++ b/src/families/tezos/synchronisation.ts
@@ -14,6 +14,24 @@ import { DerivationType } from "@taquito/ledger-signer";
 import { compressPublicKey } from "@taquito/ledger-signer/dist/lib/utils";
 import { b58cencode, prefix, Prefix } from "@taquito/utils";
 
+function isStringHex(s: string): boolean {
+  const res: number[] = [];
+  for (let i = 0; i < s.length; i += 2) {
+    const ss = s.slice(i, i + 2);
+    const x = parseInt(ss, 16);
+    if (Number.isNaN(x)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function encodeHexToPubKey(publicKeyHex: string) {
+  return b58cencode(
+    compressPublicKey(Buffer.from(publicKeyHex, "hex"), DerivationType.ED25519),
+    prefix[Prefix.EDPK]
+  );
+}
 function restorePublicKey(
   publicKey: string,
   initialAccount: Account | undefined,
@@ -23,19 +41,16 @@ function restorePublicKey(
   if (initialAccount) {
     const { tezosResources } = initialAccount;
     if (tezosResources) {
+      if (isStringHex(tezosResources.publicKey)) {
+        return encodeHexToPubKey(tezosResources.publicKey)
+      }
       return tezosResources.publicKey;
     }
     const { xpubOrAddress } = decodeAccountId(initialAccount.id);
     if (xpubOrAddress) return xpubOrAddress;
   }
   invariant(rest.publicKey, "publicKey must not be empty");
-  return b58cencode(
-    compressPublicKey(
-      Buffer.from(rest.publicKey, "hex"),
-      DerivationType.ED25519
-    ),
-    prefix[Prefix.EDPK]
-  );
+  return encodeHexToPubKey(rest.publicKey);
 }
 
 export const getAccountShape: GetAccountShape = async (infoInput) => {

--- a/src/families/tezos/synchronisation.ts
+++ b/src/families/tezos/synchronisation.ts
@@ -15,7 +15,6 @@ import { compressPublicKey } from "@taquito/ledger-signer/dist/lib/utils";
 import { b58cencode, prefix, Prefix } from "@taquito/utils";
 
 function isStringHex(s: string): boolean {
-  const res: number[] = [];
   for (let i = 0; i < s.length; i += 2) {
     const ss = s.slice(i, i + 2);
     const x = parseInt(ss, 16);

--- a/src/families/tezos/synchronisation.ts
+++ b/src/families/tezos/synchronisation.ts
@@ -42,7 +42,7 @@ function restorePublicKey(
     const { tezosResources } = initialAccount;
     if (tezosResources) {
       if (isStringHex(tezosResources.publicKey)) {
-        return encodeHexToPubKey(tezosResources.publicKey)
+        return encodeHexToPubKey(tezosResources.publicKey);
       }
       return tezosResources.publicKey;
     }


### PR DESCRIPTION
## Context (issues, jira)

https://ledgerhq.atlassian.net/browse/LIVE-1123

## Description / Usage

So for low balance account, there was a bug that couldn't calculate the fees correctly because api return an error so it made a weird behaviour on getTransactionStatus

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
