### PR TITLE
feat/LIVE 1190

### DIFF
--- a/cli/src/commands-index.ts
+++ b/cli/src/commands-index.ts
@@ -45,6 +45,7 @@ import signMessage from "./commands/signMessage";
 import speculosList from "./commands/speculosList";
 import swap from "./commands/swap";
 import sync from "./commands/sync";
+import synchronousOnboarding from "./commands/synchronousOnboarding";
 import testDetectOpCollision from "./commands/testDetectOpCollision";
 import testGetTrustedInputFromTxHash from "./commands/testGetTrustedInputFromTxHash";
 import user from "./commands/user";
@@ -100,6 +101,7 @@ export default {
   speculosList,
   swap,
   sync,
+  synchronousOnboarding,
   testDetectOpCollision,
   testGetTrustedInputFromTxHash,
   user,

--- a/cli/src/commands/synchronousOnboarding.ts
+++ b/cli/src/commands/synchronousOnboarding.ts
@@ -1,8 +1,8 @@
 import { from, interval, Observable } from "rxjs";
 import { withDevice } from "@ledgerhq/live-common/lib/hw/deviceAccess";
-import getOnboardingStatus from "@ledgerhq/live-common/lib/hw/getOnboardingStatus";
 import { concatMap, tap } from "rxjs/operators";
-import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
+import getVersion from "@ledgerhq/live-common/lib/hw/getVersion";
+import getOnboardingStatus from "@ledgerhq/live-common/lib/hw/getOnboardingStatus";
 
 export default {
   description:
@@ -19,9 +19,10 @@ export default {
   }: Partial<{
     device: string;
   }>) => interval(1000).pipe(
-      concatMap(() => withDevice(device || "")((t) => from(getDeviceInfo(t)))),
+      concatMap(() => withDevice(device || "")((t) => from(getVersion(t)))),
       // pairwise()
-      tap( ({onboarding}) => {
+      tap( ({flags}) => {
+        const onboarding = getOnboardingStatus(flags);
         if(!onboarding){
           return
         }

--- a/cli/src/commands/synchronousOnboarding.ts
+++ b/cli/src/commands/synchronousOnboarding.ts
@@ -1,0 +1,14 @@
+import { from, interval, Observable } from "rxjs";
+import { withDevice } from "@ledgerhq/live-common/lib/hw/deviceAccess";
+import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
+import { deviceOpt } from "../scan";
+import { concatMap, finalize, take } from "rxjs/operators";
+export default {
+  job: ({
+    device,
+  }: Partial<{
+    device: string;
+  }>) => interval(1000).pipe(
+      concatMap(() => withDevice(device || "")((t) => from(getDeviceInfo(t)))),
+    )
+};

--- a/cli/src/commands/synchronousOnboarding.ts
+++ b/cli/src/commands/synchronousOnboarding.ts
@@ -1,14 +1,60 @@
 import { from, interval, Observable } from "rxjs";
 import { withDevice } from "@ledgerhq/live-common/lib/hw/deviceAccess";
-import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
-import { deviceOpt } from "../scan";
-import { concatMap, finalize, take } from "rxjs/operators";
+import getOnboardingStatus from "@ledgerhq/live-common/lib/hw/getOnboardingStatus";
+import { concatMap, tap } from "rxjs/operators";
+
 export default {
+  description:
+    "track the onboarding status of your nano",
+  args: [
+    {
+      name: "refresh",
+      alias: "r",
+      desc: "refresh rate in milliseconds",
+    },
+  ],
   job: ({
     device,
   }: Partial<{
     device: string;
   }>) => interval(1000).pipe(
-      concatMap(() => withDevice(device || "")((t) => from(getDeviceInfo(t)))),
+      concatMap(() => withDevice(device || "")((t) => from(getOnboardingStatus(t)))),
+      // pairwise()
+      tap((onboarding => {
+        if(!onboarding){
+          return
+        }
+
+        let sentence;
+        if(onboarding.isOnboarded){
+          sentence = "ONBOARDED";
+        }
+        else {
+          if(onboarding.isRecoveryMode){
+            sentence = "IN RECOVERY MODE";
+          }
+          else {
+            if(onboarding.isSeedRecovery){
+              sentence = "SEED RECOVERY";
+            }
+            // New seed
+            else {
+              sentence = "NEW SEED";
+              if(onboarding.isConfirming){
+                sentence += " - CONFIRMING";
+              }
+              // writing
+              else {
+                sentence += " - WRITING";
+              }
+            }
+            sentence += ` : ${onboarding.currentWord} / ${onboarding.seedSize}`;
+          }
+        }
+
+        console.log(`---------------------
+    ${sentence}
+---------------------`);
+      }))
     )
 };

--- a/cli/src/commands/synchronousOnboarding.ts
+++ b/cli/src/commands/synchronousOnboarding.ts
@@ -2,6 +2,7 @@ import { from, interval, Observable } from "rxjs";
 import { withDevice } from "@ledgerhq/live-common/lib/hw/deviceAccess";
 import getOnboardingStatus from "@ledgerhq/live-common/lib/hw/getOnboardingStatus";
 import { concatMap, tap } from "rxjs/operators";
+import getDeviceInfo from "@ledgerhq/live-common/lib/hw/getDeviceInfo";
 
 export default {
   description:
@@ -18,9 +19,9 @@ export default {
   }: Partial<{
     device: string;
   }>) => interval(1000).pipe(
-      concatMap(() => withDevice(device || "")((t) => from(getOnboardingStatus(t)))),
+      concatMap(() => withDevice(device || "")((t) => from(getDeviceInfo(t)))),
       // pairwise()
-      tap((onboarding => {
+      tap( ({onboarding}) => {
         if(!onboarding){
           return
         }
@@ -55,6 +56,6 @@ export default {
         console.log(`---------------------
     ${sentence}
 ---------------------`);
-      }))
+      })
     )
 };

--- a/cli/src/live-common-setup.ts
+++ b/cli/src/live-common-setup.ts
@@ -26,6 +26,7 @@ import { disconnectAll } from "@ledgerhq/live-common/lib/api";
 
 checkLibs({
   NotEnoughBalance,
+  // Can't run CI on windows without it
   // @ts-ignore
   React,
   log,

--- a/cli/src/live-common-setup.ts
+++ b/cli/src/live-common-setup.ts
@@ -26,6 +26,7 @@ import { disconnectAll } from "@ledgerhq/live-common/lib/api";
 
 checkLibs({
   NotEnoughBalance,
+  // @ts-ignore
   React,
   log,
   Transport,

--- a/src/hw/getDeviceInfo.ts
+++ b/src/hw/getDeviceInfo.ts
@@ -13,23 +13,6 @@ import { isDashboardName } from "./isDashboardName";
 const ManagerAllowedFlag = 0x08;
 const PinValidatedFlag = 0x80;
 
-// Cf https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/3258089508/Synchronous+onboarding
-const onboardingFlag = 0x04;
-const recoveryModeFlag = 0x01;
-const seedRecoveryFlag = 0x80;
-const seedSizeFlag = 0x60;
-const currentWordFlag = 0x1F;
-const confirmingWordsFlag = 0x01;
-
-// const flagsList = [
-//   { 
-//     flagName: "onboarded",
-//     path: "onboarding", // Use object-path
-//     byteIndex: 0,
-//     hex: 0x01,
-//   },
-// ]
-
 export default async function getDeviceInfo(
   transport: Transport
 ): Promise<DeviceInfo> {
@@ -76,26 +59,6 @@ export default async function getDeviceInfo(
   const managerAllowed = !!(flag & ManagerAllowedFlag);
   const pinValidated = !!(flag & PinValidatedFlag);
 
-  const getSeedSize = (seedByte, sizeFlag) => {
-    const seedSizeByFlagValue = {
-      64: 12,
-      32: 18,
-      0: 24
-    };
-    const flagValue = (seedByte & sizeFlag) as SeedSize
-
-    return seedSizeByFlagValue[flagValue] || undefined;
-  }
-
-  const onboarding: OnboardingInfo = {
-    isOnboarded: !!(flags[0] & onboardingFlag),
-    isRecoveryMode: !!(flags[0] & recoveryModeFlag),
-    isSeedRecovery: !!(flags[2] & seedRecoveryFlag),
-    currentWord: (flags[2] & currentWordFlag) + 1,
-    seedSize: getSeedSize(flags[2], seedSizeFlag),
-    isConfirming: !!(flags[3] & confirmingWordsFlag),
-  };
-
   log(
     "hw",
     "deviceInfo: se@" +
@@ -119,6 +82,5 @@ export default async function getDeviceInfo(
     isBootloader,
     managerAllowed,
     pinValidated,
-    onboarding
   };
 }

--- a/src/hw/getDeviceInfo.ts
+++ b/src/hw/getDeviceInfo.ts
@@ -10,6 +10,7 @@ import getAppAndVersion from "./getAppAndVersion";
 import type { DeviceInfo } from "../types/manager";
 import { PROVIDERS } from "../manager/provider";
 import { isDashboardName } from "./isDashboardName";
+import getOnboardingStatus from "./getOnboardingStatus";
 const ManagerAllowedFlag = 0x08;
 const PinValidatedFlag = 0x80;
 
@@ -38,6 +39,7 @@ export default async function getDeviceInfo(
     throw new DeviceOnDashboardExpected();
   }
 
+  const onboarding = await getOnboardingStatus(transport);
   const res = await getVersion(transport);
   const {
     isBootloader,
@@ -82,5 +84,6 @@ export default async function getDeviceInfo(
     isBootloader,
     managerAllowed,
     pinValidated,
+    onboarding,
   };
 }

--- a/src/hw/getDeviceInfo.ts
+++ b/src/hw/getDeviceInfo.ts
@@ -69,7 +69,7 @@ export default async function getDeviceInfo(
       (isOSU ? " (osu)" : isBootloader ? " (bootloader)" : "")
   );
 
-  const onboarding = await getOnboardingStatus(flags);
+  const onboarding = getOnboardingStatus(flags);
 
   return {
     version,

--- a/src/hw/getDeviceInfo.ts
+++ b/src/hw/getDeviceInfo.ts
@@ -39,7 +39,6 @@ export default async function getDeviceInfo(
     throw new DeviceOnDashboardExpected();
   }
 
-  const onboarding = await getOnboardingStatus(transport);
   const res = await getVersion(transport);
   const {
     isBootloader,
@@ -69,6 +68,8 @@ export default async function getDeviceInfo(
       mcuVersion +
       (isOSU ? " (osu)" : isBootloader ? " (bootloader)" : "")
   );
+
+  const onboarding = await getOnboardingStatus(flags);
 
   return {
     version,

--- a/src/hw/getDeviceInfo.ts
+++ b/src/hw/getDeviceInfo.ts
@@ -7,11 +7,29 @@ import { log } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import getVersion from "./getVersion";
 import getAppAndVersion from "./getAppAndVersion";
-import type { DeviceInfo } from "../types/manager";
+import type { DeviceInfo, OnboardingInfo, SeedSize } from "../types/manager";
 import { PROVIDERS } from "../manager/provider";
 import { isDashboardName } from "./isDashboardName";
 const ManagerAllowedFlag = 0x08;
 const PinValidatedFlag = 0x80;
+
+// Cf https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/3258089508/Synchronous+onboarding
+const onboardingFlag = 0x04;
+const recoveryModeFlag = 0x01;
+const seedRecoveryFlag = 0x80;
+const seedSizeFlag = 0x60;
+const currentWordFlag = 0x1F;
+const confirmingWordsFlag = 0x01;
+
+// const flagsList = [
+//   { 
+//     flagName: "onboarded",
+//     path: "onboarding", // Use object-path
+//     byteIndex: 0,
+//     hex: 0x01,
+//   },
+// ]
+
 export default async function getDeviceInfo(
   transport: Transport
 ): Promise<DeviceInfo> {
@@ -57,6 +75,27 @@ export default async function getDeviceInfo(
   const flag = flags.length > 0 ? flags[0] : 0;
   const managerAllowed = !!(flag & ManagerAllowedFlag);
   const pinValidated = !!(flag & PinValidatedFlag);
+
+  const getSeedSize = (seedByte, sizeFlag) => {
+    const seedSizeByFlagValue = {
+      64: 12,
+      32: 18,
+      0: 24
+    };
+    const flagValue = (seedByte & sizeFlag) as SeedSize
+
+    return seedSizeByFlagValue[flagValue] || undefined;
+  }
+
+  const onboarding: OnboardingInfo = {
+    isOnboarded: !!(flags[0] & onboardingFlag),
+    isRecoveryMode: !!(flags[0] & recoveryModeFlag),
+    isSeedRecovery: !!(flags[2] & seedRecoveryFlag),
+    currentWord: (flags[2] & currentWordFlag) + 1,
+    seedSize: getSeedSize(flags[2], seedSizeFlag),
+    isConfirming: !!(flags[3] & confirmingWordsFlag),
+  };
+
   log(
     "hw",
     "deviceInfo: se@" +
@@ -65,6 +104,7 @@ export default async function getDeviceInfo(
       mcuVersion +
       (isOSU ? " (osu)" : isBootloader ? " (bootloader)" : "")
   );
+  
   return {
     version,
     mcuVersion,
@@ -79,5 +119,6 @@ export default async function getDeviceInfo(
     isBootloader,
     managerAllowed,
     pinValidated,
+    onboarding
   };
 }

--- a/src/hw/getDeviceInfo.ts
+++ b/src/hw/getDeviceInfo.ts
@@ -7,7 +7,7 @@ import { log } from "@ledgerhq/logs";
 import Transport from "@ledgerhq/hw-transport";
 import getVersion from "./getVersion";
 import getAppAndVersion from "./getAppAndVersion";
-import type { DeviceInfo, OnboardingInfo, SeedSize } from "../types/manager";
+import type { DeviceInfo } from "../types/manager";
 import { PROVIDERS } from "../manager/provider";
 import { isDashboardName } from "./isDashboardName";
 const ManagerAllowedFlag = 0x08;
@@ -67,7 +67,7 @@ export default async function getDeviceInfo(
       mcuVersion +
       (isOSU ? " (osu)" : isBootloader ? " (bootloader)" : "")
   );
-  
+
   return {
     version,
     mcuVersion,

--- a/src/hw/getOnboardingStatus.ts
+++ b/src/hw/getOnboardingStatus.ts
@@ -1,51 +1,50 @@
 /* eslint-disable no-bitwise */
-  import Transport from "@ledgerhq/hw-transport";
-  import getVersion from "./getVersion";
-  import type { OnboardingInfo, SeedSize } from "../types/onboarding";
-  
-  // Cf https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/3258089508/Synchronous+onboarding
-  const onboardingFlag = 0x04;
-  const recoveryModeFlag = 0x01;
-  const seedRecoveryFlag = 0x80;
-  const seedSizeFlag = 0x60;
-  const currentWordFlag = 0x1F;
-  const confirmingWordsFlag = 0x01;
-  
-  // Before closing the PR
-  // const flagsList = [
-  //   { 
-  //     flagName: "onboarded",
-  //     path: "onboarding", // Use object-path
-  //     byteIndex: 0,
-  //     hex: 0x01,
-  //   },
-  // ]
-  
-  export default async function getOnboardingStatus(
-    transport: Transport
-  ): Promise<OnboardingInfo> {
-    const { flags } = await getVersion(transport);
-  
-    const getSeedSize = (seedByte, sizeFlag) => {
-      const seedSizeByFlagValue = {
-        64: 12,
-        32: 18,
-        0: 24
-      };
-      const flagValue = (seedByte & sizeFlag) as SeedSize
-  
-      return seedSizeByFlagValue[flagValue] || undefined;
-    }
-  
-    const onboarding: OnboardingInfo = {
-      isOnboarded: !!(flags[0] & onboardingFlag),
-      isRecoveryMode: !!(flags[0] & recoveryModeFlag),
-      isSeedRecovery: !!(flags[2] & seedRecoveryFlag),
-      currentWord: (flags[2] & currentWordFlag) + 1,
-      seedSize: getSeedSize(flags[2], seedSizeFlag),
-      isConfirming: !!(flags[3] & confirmingWordsFlag),
+import Transport from "@ledgerhq/hw-transport";
+import getVersion from "./getVersion";
+import type { OnboardingInfo, SeedSize } from "../types/onboarding";
+
+// Cf https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/3258089508/Synchronous+onboarding
+const onboardingFlag = 0x04;
+const recoveryModeFlag = 0x01;
+const seedRecoveryFlag = 0x80;
+const seedSizeFlag = 0x60;
+const currentWordFlag = 0x1f;
+const confirmingWordsFlag = 0x01;
+
+// Before closing the PR
+// const flagsList = [
+//   {
+//     flagName: "onboarded",
+//     path: "onboarding", // Use object-path
+//     byteIndex: 0,
+//     hex: 0x01,
+//   },
+// ]
+
+export default async function getOnboardingStatus(
+  transport: Transport
+): Promise<OnboardingInfo> {
+  const { flags } = await getVersion(transport);
+
+  const getSeedSize = (seedByte, sizeFlag) => {
+    const seedSizeByFlagValue = {
+      64: 12,
+      32: 18,
+      0: 24,
     };
-    
-    return onboarding;
-  }
-  
+    const flagValue = (seedByte & sizeFlag) as SeedSize;
+
+    return seedSizeByFlagValue[flagValue] || undefined;
+  };
+
+  const onboarding: OnboardingInfo = {
+    isOnboarded: !!(flags[0] & onboardingFlag),
+    isRecoveryMode: !!(flags[0] & recoveryModeFlag),
+    isSeedRecovery: !!(flags[2] & seedRecoveryFlag),
+    currentWord: (flags[2] & currentWordFlag) + 1,
+    seedSize: getSeedSize(flags[2], seedSizeFlag),
+    isConfirming: !!(flags[3] & confirmingWordsFlag),
+  };
+
+  return onboarding;
+}

--- a/src/hw/getOnboardingStatus.ts
+++ b/src/hw/getOnboardingStatus.ts
@@ -16,7 +16,7 @@ export default async function getOnboardingStatus(
 ): Promise<OnboardingInfo> {
   const { flags } = await getVersion(transport);
 
-  if(!flags || flags.length < 4){
+  if (!flags || flags.length < 4) {
     return {};
   }
 

--- a/src/hw/getOnboardingStatus.ts
+++ b/src/hw/getOnboardingStatus.ts
@@ -11,16 +11,6 @@ const seedSizeFlag = 0x60;
 const currentWordFlag = 0x1f;
 const confirmingWordsFlag = 0x01;
 
-// Before closing the PR
-// const flagsList = [
-//   {
-//     flagName: "onboarded",
-//     path: "onboarding", // Use object-path
-//     byteIndex: 0,
-//     hex: 0x01,
-//   },
-// ]
-
 export default async function getOnboardingStatus(
   transport: Transport
 ): Promise<OnboardingInfo> {

--- a/src/hw/getOnboardingStatus.ts
+++ b/src/hw/getOnboardingStatus.ts
@@ -26,6 +26,10 @@ export default async function getOnboardingStatus(
 ): Promise<OnboardingInfo> {
   const { flags } = await getVersion(transport);
 
+  if(!flags || flags.length < 4){
+    return {};
+  }
+
   const getSeedSize = (seedByte, sizeFlag) => {
     const seedSizeByFlagValue = {
       64: 12,

--- a/src/hw/getOnboardingStatus.ts
+++ b/src/hw/getOnboardingStatus.ts
@@ -1,6 +1,4 @@
 /* eslint-disable no-bitwise */
-import Transport from "@ledgerhq/hw-transport";
-import getVersion from "./getVersion";
 import type { OnboardingInfo, SeedSize } from "../types/onboarding";
 
 // Cf https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/3258089508/Synchronous+onboarding
@@ -12,10 +10,8 @@ const currentWordFlag = 0x1f;
 const confirmingWordsFlag = 0x01;
 
 export default async function getOnboardingStatus(
-  transport: Transport
+  flags: Buffer
 ): Promise<OnboardingInfo> {
-  const { flags } = await getVersion(transport);
-
   if (!flags || flags.length < 4) {
     return {};
   }

--- a/src/hw/getOnboardingStatus.ts
+++ b/src/hw/getOnboardingStatus.ts
@@ -1,0 +1,51 @@
+/* eslint-disable no-bitwise */
+  import Transport from "@ledgerhq/hw-transport";
+  import getVersion from "./getVersion";
+  import type { OnboardingInfo, SeedSize } from "../types/onboarding";
+  
+  // Cf https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/3258089508/Synchronous+onboarding
+  const onboardingFlag = 0x04;
+  const recoveryModeFlag = 0x01;
+  const seedRecoveryFlag = 0x80;
+  const seedSizeFlag = 0x60;
+  const currentWordFlag = 0x1F;
+  const confirmingWordsFlag = 0x01;
+  
+  // Before closing the PR
+  // const flagsList = [
+  //   { 
+  //     flagName: "onboarded",
+  //     path: "onboarding", // Use object-path
+  //     byteIndex: 0,
+  //     hex: 0x01,
+  //   },
+  // ]
+  
+  export default async function getOnboardingStatus(
+    transport: Transport
+  ): Promise<OnboardingInfo> {
+    const { flags } = await getVersion(transport);
+  
+    const getSeedSize = (seedByte, sizeFlag) => {
+      const seedSizeByFlagValue = {
+        64: 12,
+        32: 18,
+        0: 24
+      };
+      const flagValue = (seedByte & sizeFlag) as SeedSize
+  
+      return seedSizeByFlagValue[flagValue] || undefined;
+    }
+  
+    const onboarding: OnboardingInfo = {
+      isOnboarded: !!(flags[0] & onboardingFlag),
+      isRecoveryMode: !!(flags[0] & recoveryModeFlag),
+      isSeedRecovery: !!(flags[2] & seedRecoveryFlag),
+      currentWord: (flags[2] & currentWordFlag) + 1,
+      seedSize: getSeedSize(flags[2], seedSizeFlag),
+      isConfirming: !!(flags[3] & confirmingWordsFlag),
+    };
+    
+    return onboarding;
+  }
+  

--- a/src/hw/getOnboardingStatus.ts
+++ b/src/hw/getOnboardingStatus.ts
@@ -9,9 +9,8 @@ const seedSizeFlag = 0x60;
 const currentWordFlag = 0x1f;
 const confirmingWordsFlag = 0x01;
 
-export default async function getOnboardingStatus(
-  flags: Buffer
-): Promise<OnboardingInfo> {
+export default function getOnboardingStatus(flags: Buffer
+): OnboardingInfo {
   if (!flags || flags.length < 4) {
     return {};
   }

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -27,7 +27,7 @@ export type DeviceInfo = {
   providerName: string | null | undefined;
   managerAllowed: boolean;
   pinValidated: boolean;
-  onboarding: OnboardingInfo;
+  onboarding?: OnboardingInfo;
   // more precised raw versions
   seVersion?: string;
   mcuBlVersion?: string;

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -11,6 +11,20 @@ export type LedgerScriptParams = {
   hash: string;
   perso: string;
 };
+export type SeedSize = 12 | 18 | 24;
+export type OnboardingInfo = {
+  isOnboarded: boolean;
+  // in recovery mode vs in normal mode
+  isRecoveryMode?: boolean;
+  // seed Recovery vs new seed
+  isSeedRecovery?: boolean;
+  // confirming vs writing
+  isConfirming?: boolean;
+  seedSize?: SeedSize;
+  // Starting from 1 to totalNbSeedWords
+  currentWord?: number;
+}
+
 export type DeviceInfo = {
   mcuVersion: string;
   // the raw mcu version
@@ -25,6 +39,7 @@ export type DeviceInfo = {
   providerName: string | null | undefined;
   managerAllowed: boolean;
   pinValidated: boolean;
+  onboarding?: OnboardingInfo;
   // more precised raw versions
   seVersion?: string;
   mcuBlVersion?: string;

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -39,7 +39,6 @@ export type DeviceInfo = {
   providerName: string | null | undefined;
   managerAllowed: boolean;
   pinValidated: boolean;
-  onboarding?: OnboardingInfo;
   // more precised raw versions
   seVersion?: string;
   mcuBlVersion?: string;

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -1,5 +1,6 @@
 import type { CryptoCurrency } from "./currencies";
 import type { DeviceModelId } from "@ledgerhq/devices";
+import { OnboardingInfo } from "./onboarding";
 // FIXME we need to clearly differentiate what is API types and what is our inner own type
 export type Id = number;
 export type LedgerScriptParams = {
@@ -26,6 +27,7 @@ export type DeviceInfo = {
   providerName: string | null | undefined;
   managerAllowed: boolean;
   pinValidated: boolean;
+  onboarding: OnboardingInfo;
   // more precised raw versions
   seVersion?: string;
   mcuBlVersion?: string;

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -23,7 +23,7 @@ export type OnboardingInfo = {
   seedSize?: SeedSize;
   // Starting from 1 to totalNbSeedWords
   currentWord?: number;
-}
+};
 
 export type DeviceInfo = {
   mcuVersion: string;

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -11,19 +11,6 @@ export type LedgerScriptParams = {
   hash: string;
   perso: string;
 };
-export type SeedSize = 12 | 18 | 24;
-export type OnboardingInfo = {
-  isOnboarded: boolean;
-  // in recovery mode vs in normal mode
-  isRecoveryMode?: boolean;
-  // seed Recovery vs new seed
-  isSeedRecovery?: boolean;
-  // confirming vs writing
-  isConfirming?: boolean;
-  seedSize?: SeedSize;
-  // Starting from 1 to totalNbSeedWords
-  currentWord?: number;
-};
 
 export type DeviceInfo = {
   mcuVersion: string;

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -11,4 +11,4 @@ export type OnboardingInfo = {
   seedSize?: SeedSize;
   // Starting from 1 to totalNbSeedWords
   currentWord?: number;
-}
+};

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -1,7 +1,7 @@
 export type SeedSize = 12 | 18 | 24;
 
 export type OnboardingInfo = {
-  isOnboarded: boolean;
+  isOnboarded?: boolean;
   // in recovery mode vs in normal mode
   isRecoveryMode?: boolean;
   // seed Recovery vs new seed

--- a/src/types/onboarding.ts
+++ b/src/types/onboarding.ts
@@ -1,0 +1,14 @@
+export type SeedSize = 12 | 18 | 24;
+
+export type OnboardingInfo = {
+  isOnboarded: boolean;
+  // in recovery mode vs in normal mode
+  isRecoveryMode?: boolean;
+  // seed Recovery vs new seed
+  isSeedRecovery?: boolean;
+  // confirming vs writing
+  isConfirming?: boolean;
+  seedSize?: SeedSize;
+  // Starting from 1 to totalNbSeedWords
+  currentWord?: number;
+}


### PR DESCRIPTION
## Context (issues, jira)
[LIVE-1190]
Creating a new Live Common method to parse new nano firmware (>2.0.0) onboarding informations.
Description of buffers are accessible [here](https://ledgerhq.atlassian.net/wiki/spaces/FW/pages/3258089508/Synchronous+onboarding)

## Description / Usage

You can use the new method from LLC named : getOnboardingStatus
And you can also use it from CLI : ledger-live synchronousOnboarding
I added one parameter to manage the refresh rate or crash test the maximum ping a Nano can handle

And here are some example of how it works

https://user-images.githubusercontent.com/90627435/154672209-1fe147ff-7b2f-43d4-890b-47a93bbaecdd.mp4


https://user-images.githubusercontent.com/90627435/154672225-961e1330-c122-4bfd-8031-7fc50d4a5aa2.mp4


https://user-images.githubusercontent.com/90627435/154672232-b85810ab-4a60-4f80-8997-f9d5065af76b.mp4


https://user-images.githubusercontent.com/90627435/154672237-087a837e-f12d-4df4-ba23-d0f4856d461d.mp4



## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [*] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.


[LIVE-1190]: https://ledgerhq.atlassian.net/browse/LIVE-1190?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ