### PR TITLE
LIVE-825 - Update market API to have an AND logic on filters instead of OR logic

### DIFF
--- a/src/market/api/api.ts
+++ b/src/market/api/api.ts
@@ -105,18 +105,26 @@ async function listPaginated({
 }: MarketListRequestParams): Promise<CurrencyData[]> {
   let ids = _ids;
 
-  if (liveCompatible) {
-    ids = ids.concat(LIVE_COINS_LIST);
-  }
-
-  if (starred.length > 0) {
-    ids = ids.concat(starred);
-  }
-
   if (search) {
     ids = SUPPORTED_COINS_LIST.filter(matchSearch(search)).map(({ id }) => id);
     if (!ids.length) {
       return [];
+    }
+  }
+
+  if (liveCompatible) {
+    if (ids.length > 0) {
+      ids = LIVE_COINS_LIST.filter((id) => ids.includes(id));
+    } else {
+      ids = ids.concat(LIVE_COINS_LIST);
+    }
+  }
+
+  if (starred.length > 0) {
+    if (ids.length > 0) {
+      ids = starred.filter((id) => ids.includes(id));
+    } else {
+      ids = ids.concat(starred);
     }
   }
 


### PR DESCRIPTION
## Context (issues, jira)

[LIVE-825]

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

Before you couldn't do a star filtering + live compatible filtering at the same time (same with search), because the different filters were acting like OR not AND.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->

No need to update LLD/LLM but it fixes the filtering logic of the market

[LIVE-825]: https://ledgerhq.atlassian.net/browse/LIVE-825?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ