### PR TITLE
LIVE-1374: align optimistic with sync operation

### DIFF
--- a/src/families/tezos/api/tzkt.ts
+++ b/src/families/tezos/api/tzkt.ts
@@ -36,6 +36,8 @@ type CommonOperationType = {
   timestamp: string;
   level: number;
   block: string;
+  gasLimit?: number;
+  storageLimit?: number;
   status?: "applied" | "failed" | "backtracked" | "skipped";
 };
 

--- a/src/families/tezos/bridge/js.ts
+++ b/src/families/tezos/bridge/js.ts
@@ -331,13 +331,11 @@ const estimateMaxSpendable = async ({
   return s.amount;
 };
 
-const broadcast = async ({ signedOperation: { operation } }) => {
+const broadcast = async ({ signedOperation: { operation, signature } }) => {
   const tezos = new TezosToolkit(getEnv("API_TEZOS_NODE"));
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
   // @ts-ignore
-  const hash = await tezos.contract.context.injector.inject(
-    operation.extra.opbytes
-  );
+  const hash = await tezos.contract.context.injector.inject(signature);
   return patchOperationWithHash(operation, hash);
 };
 

--- a/src/families/tezos/signOperation.ts
+++ b/src/families/tezos/signOperation.ts
@@ -49,7 +49,7 @@ export const signOperation = ({
 
         let type = "OUT";
 
-        let res, signature, opbytes;
+        let res, opbytes;
         const params = {
           fee: transaction.fees?.toNumber() || 0,
           storageLimit: transaction.storageLimit?.toNumber() || 0,
@@ -73,7 +73,6 @@ export const signOperation = ({
               amount: transaction.amount.toNumber(),
               ...params,
             });
-            signature = res.raw.opOb.signature;
             opbytes = res.raw.opbytes;
             break;
           case "delegate":
@@ -119,7 +118,6 @@ export const signOperation = ({
           extra: {
             storageLimit: transaction.storageLimit,
             gasLimit: transaction.gasLimit,
-            opbytes,
           },
           blockHash: null,
           blockHeight: null,
@@ -133,7 +131,7 @@ export const signOperation = ({
           type: "signed",
           signedOperation: {
             operation,
-            signature,
+            signature: opbytes,
             expirationDate: null,
           },
         });

--- a/src/families/tezos/synchronisation.ts
+++ b/src/families/tezos/synchronisation.ts
@@ -220,6 +220,8 @@ const txToOp =
       level: blockHeight,
       block: blockHash,
       timestamp,
+      storageLimit,
+      gasLimit,
     } = tx;
 
     if (!hash) {
@@ -254,7 +256,7 @@ const txToOp =
       blockHash,
       accountId,
       date: new Date(timestamp),
-      extra: { id },
+      extra: { gasLimit: gasLimit, storageLimit: storageLimit, id },
       hasFailed,
     };
   };


### PR DESCRIPTION
## Context (issues, jira)

https://ledgerhq.atlassian.net/browse/LIVE-1374

## Description / Usage

When synchronisation was done some extra info wasn't display, but it was display in optimistic, so during sync align both of them now

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
