### PR TITLE
fix dcr fees

### DIFF
--- a/src/families/bitcoin/getAccountNetworkInfo.ts
+++ b/src/families/bitcoin/getAccountNetworkInfo.ts
@@ -45,14 +45,16 @@ export async function getAccountNetworkInfo(
   if (feesPerByte.length !== 3) {
     throw new Error("cardinality of feesPerByte should be exactly 3");
   }
-  // Fix fees if suggested fee is too low, this is only for viacoin because the viacoin fees backend endpoint is broken
+  // Fix fees if suggested fee is too low, this is only for viacoin/decred because the fees backend endpoint is broken
   if (
-    account.currency.id === "viacoin" &&
+    (account.currency.id === "viacoin" || account.currency.id === "decred") &&
     feesPerByte[2].toNumber() < Math.ceil(relayFee * 100000)
   ) {
     feesPerByte[2] = new BigNumber(Math.ceil(relayFee * 100000)).plus(1);
     feesPerByte[1] = feesPerByte[2].plus(1);
-    feesPerByte[0] = feesPerByte[1].plus(1);
+    if (feesPerByte[1].plus(1).gt(feesPerByte[0])) {
+      feesPerByte[0] = feesPerByte[1].plus(1);
+    }
   }
   const feeItems = {
     items: feesPerByte.map((feePerByte, i) => ({

--- a/src/families/bitcoin/wallet-btc/utils.ts
+++ b/src/families/bitcoin/wallet-btc/utils.ts
@@ -200,7 +200,10 @@ export function maxTxSize(
   // Input: 32 PrevTxHash + 4 Index + 1 scriptSigLength + 4 sequence
   let inputsWeight = byteSize(inputCount) * baseByte; // Number of inputs
   inputsWeight += inputWeight(derivationMode) * inputCount;
-
+  // More bytes for decred, refer to https://github.com/LedgerHQ/lib-ledger-core/blob/fc9d762b83fc2b269d072b662065747a64ab2816/core/src/wallet/bitcoin/api_impl/BitcoinLikeTransactionApi.cpp#L162
+  if (currency.network.name === "Decred") {
+    inputsWeight += 64 * inputCount;
+  }
   const txWeight = fixed + inputsWeight + outputsWeight;
   return txWeight / 4;
 }


### PR DESCRIPTION
error the following error from the bot for decred:
LedgerAPI4xx: rejected transaction 3f844367886a3971cb6ecebd3cb4c3086e54148bdb73d5f24796bf4197d01b6e: transaction 3f844367886a3971cb6ecebd3cb4c3086e54148bdb73d5f24796bf4197d01b6e has insufficient priority (200761.2068965517 <= 5.76e+07)