### PR TITLE
Make node-ble transport optional again

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -27,13 +27,15 @@
   "peerDependencies": {
     "@ledgerhq/hw-transport-node-ble": "5.7.0"
   },
+  "optionalDependencies": {
+    "@ledgerhq/hw-transport-node-ble": "^6.24.1"
+  },
   "dependencies": {
     "@ledgerhq/cryptoassets": "6.24.1",
     "@ledgerhq/errors": "6.10.0",
     "@ledgerhq/hw-app-btc": "6.24.1",
     "@ledgerhq/hw-transport-http": "6.24.1",
     "@ledgerhq/hw-transport-mocker": "6.24.1",
-    "@ledgerhq/hw-transport-node-ble": "^6.24.1",
     "@ledgerhq/hw-transport-node-hid": "6.24.1",
     "@ledgerhq/hw-transport-node-speculos": "6.24.1",
     "@ledgerhq/ledger-core": "6.14.5",

--- a/cli/src/live-common-setup.ts
+++ b/cli/src/live-common-setup.ts
@@ -32,7 +32,9 @@ checkLibs({
   connect,
 });
 import implementLibcore from "@ledgerhq/live-common/lib/libcore/platforms/nodejs";
-import BluetoothTransport from "@ledgerhq/hw-transport-node-ble";
+
+type BluetoothTransport = any;
+
 implementLibcore({
   lib: () => require("@ledgerhq/ledger-core"),
   // eslint-disable-line global-require
@@ -78,6 +80,7 @@ if (process.env.DEVICE_PROXY_URL) {
   registerTransportModule({
     id: "http",
     open: () =>
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       retry(() => Tr.create(3000, 5000), {
         context: "open-http-proxy",
@@ -118,6 +121,8 @@ async function init() {
 
   const getTransport = async (): Promise<BluetoothTransport> => {
     if (!TransportNodeBle) {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore
       const { default: mod } = await import("@ledgerhq/hw-transport-node-ble");
       TransportNodeBle = mod;
     }
@@ -131,13 +136,9 @@ async function init() {
     const [, q] = m;
     if (cacheBle[query]) return cacheBle[query];
     const t = await (!q
-      ? (
-          (await getTransport().constructor) as typeof BluetoothTransport
-        ).create()
+      ? ((await getTransport().constructor) as typeof TransportNodeBle).create()
       : new Observable(
-          (
-            (await getTransport().constructor) as typeof BluetoothTransport
-          ).listen
+          ((await getTransport().constructor) as typeof TransportNodeBle).listen
         )
           .pipe(
             first(
@@ -166,7 +167,7 @@ async function init() {
       let s: any;
 
       getTransport().then((module) => {
-        (module.constructor as typeof BluetoothTransport).listen(o);
+        (module.constructor as typeof TransportNodeBle).listen(o);
         s = module;
       });
 
@@ -182,7 +183,7 @@ async function init() {
       query.startsWith("ble")
         ? cacheBle[query]
           ? (
-              (await getTransport().constructor) as typeof BluetoothTransport
+              (await getTransport().constructor) as typeof TransportNodeBle
             ).disconnect(cacheBle[query].id)
           : Promise.resolve()
         : undefined,


### PR DESCRIPTION
CI breaks on Windows due to not compiling node-ble on CLI. Which really is an optional dependency, we would gain time not even installing it. CLI users are free to install it manually.