### PR TITLE
LIVE-1469 Handle onboarded devices in device actions

### DIFF
--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,6 +23,7 @@ export const LowerThanMinimumRelayFee = createCustomErrorClass(
 export const TransactionRefusedOnDevice = createCustomErrorClass(
   "TransactionRefusedOnDevice"
 );
+export const DeviceNotOnboarded = createCustomErrorClass("DeviceNotOnboarded");
 export const InvalidAddressBecauseAlreadyDelegated = createCustomErrorClass(
   "InvalidAddressBecauseAlreadyDelegated"
 );

--- a/src/hw/connectManager.ts
+++ b/src/hw/connectManager.ts
@@ -12,6 +12,7 @@ import getDeviceInfo from "./getDeviceInfo";
 import getAppAndVersion from "./getAppAndVersion";
 import appSupportsQuitApp from "../appSupportsQuitApp";
 import { isDashboardName } from "./isDashboardName";
+import { DeviceNotOnboarded } from "../errors";
 import type { AppAndVersion } from "./connectApp";
 import quitApp from "./quitApp";
 export type Input = {
@@ -76,6 +77,11 @@ const cmd = ({
         .pipe(
           concatMap((deviceInfo) => {
             timeoutSub.unsubscribe();
+
+            // FIXME Until we have proper flagging of the onboarded status.
+            if (!deviceInfo.onboarded) {
+              throw new DeviceNotOnboarded();
+            }
 
             if (deviceInfo.isBootloader) {
               return of({

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -30,6 +30,7 @@ export type DeviceInfo = {
   mcuBlVersion?: string;
   mcuTargetId?: number;
   seTargetId?: number;
+  onboarded?: boolean;
 };
 export type DeviceModelInfo = {
   modelId: DeviceModelId;


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-1469


## Description / Usage
The latest firmware version in the upcoming LNS+ and on existing devices allow us to detect a device before it's onboarded but we can't interact with it the normal way because, well, it's not seeded. So we need to handle that case and show a meaningful error message to our users and guide them to the onboarding.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
