### PR TITLE
increase the CI tests timeout

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "jest": "rimraf libcoredb && mkdir libcoredb && cross-env TZ=America/New_York jest",
     "test": "yarn jest",
     "ci-lint": "yarn lint",
-    "ci-test-common": "env-cmd -f ./.ci.env yarn test --ci --updateSnapshot && git diff --exit-code src",
+    "ci-test-common": "env-cmd -f ./.ci.env yarn test --ci --updateSnapshot --maxConcurrency=2 && git diff --exit-code src",
     "ci-setup-cli": "yalc publish && cd cli && yalc add @ledgerhq/live-common && yarn && yarn build && yarn link",
     "ci-test-cli": "cd cli && yarn test",
     "ci-test-bot": "env-cmd -f ./.ci.env yarn jest --testMatch '**/*.bot.ts'"

--- a/src/__tests__/families/bitcoin/wallet-btc/wallet.estimateMaxSpendable.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/wallet.estimateMaxSpendable.test.ts
@@ -73,5 +73,5 @@ describe("testing estimateMaxSpendable", () => {
       true
     );
     expect(maxSpendable.toNumber()).toEqual(0);
-  }, 60000);
+  });
 });

--- a/src/__tests__/test-helpers/setup.ts
+++ b/src/__tests__/test-helpers/setup.ts
@@ -2,7 +2,7 @@ import BigNumber from "bignumber.js";
 import { setSupportedCurrencies } from "../../currencies";
 import { setPlatformVersion } from "../../platform/version";
 
-jest.setTimeout(180000);
+jest.setTimeout(5 * 60 * 1000);
 
 expect.extend({
   toBeBigNumber(value) {

--- a/src/families/tezos/synchronisation.test.ts
+++ b/src/families/tezos/synchronisation.test.ts
@@ -24,7 +24,7 @@ const accounts = [
   "tz1fAfYNSkgci3ko2xikDtYtcSf1X1YdAKoK",
 ];
 
-jest.setTimeout(30 * 1000);
+jest.setTimeout(120 * 1000);
 
 accounts.forEach((address) => {
   describe(address + " account works", () => {


### PR DESCRIPTION
CI can be slow to run these test for a few reasons and we need to increase it

may help some failing cases of bitcoin/ethereum timeout in dataset tests