### PR TITLE
LIVE-826 - Learn page URL - Add environment var to enable learn staging URL

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -560,6 +560,11 @@ const envDefinitions = {
     parser: stringParser,
     desc: "Market data api",
   },
+  USE_LEARN_STAGING_URL: {
+    def: false,
+    parser: boolParser,
+    desc: "use the staging URL for the learn page"
+  },
 };
 
 const getDefinition = (name: string): EnvDef<any> | null | undefined =>

--- a/src/env.ts
+++ b/src/env.ts
@@ -563,7 +563,7 @@ const envDefinitions = {
   USE_LEARN_STAGING_URL: {
     def: false,
     parser: boolParser,
-    desc: "use the staging URL for the learn page"
+    desc: "use the staging URL for the learn page",
   },
 };
 


### PR DESCRIPTION
## Context (issues, jira)

We are developing a new "Learn" screen in LLD and LLM and it's basically an iframe loading an URL.
This URL can be a staging or a prod URL.
This PR introduces an environment variable that can be used to switch between the 2 kinds (prod or staging) of URL for the Learn page.
It will help us providing builds that the e-commerce team - the team developing that Learn website - can test with either URLs.
[LIVE-826]
## Description / Usage

Used in LLM to add a developer setting:
https://github.com/LedgerHQ/ledger-live-mobile/pull/2234/commits/61db1cc709251b3f0781e54ff4e7c99427412489

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->


[LIVE-826]: https://ledgerhq.atlassian.net/browse/LIVE-826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ