### PR TITLE
fix error revelead by bot

### DIFF
--- a/src/families/tezos/bridge/js.ts
+++ b/src/families/tezos/bridge/js.ts
@@ -100,8 +100,12 @@ const getTransactionStatus = async (
   }
 
   if (t.mode === "send") {
-    let spendableBalance = account.balance.minus(estimatedFees).minus(EXISTENTIAL_DEPOSIT);
-    spendableBalance = spendableBalance.lt(0) ? account.balance : spendableBalance;
+    let spendableBalance = account.balance
+      .minus(estimatedFees)
+      .minus(EXISTENTIAL_DEPOSIT);
+    spendableBalance = spendableBalance.lt(0)
+      ? account.balance
+      : spendableBalance;
     if (!errors.amount && t.amount.eq(0) && !t.useAllAmount) {
       errors.amount = new AmountRequired();
     } else if (!errors.amount && t.amount.gt(spendableBalance)) {

--- a/src/families/tezos/bridge/js.ts
+++ b/src/families/tezos/bridge/js.ts
@@ -100,9 +100,8 @@ const getTransactionStatus = async (
   }
 
   if (t.mode === "send") {
-    const spendableBalance = account.balance.minus(EXISTENTIAL_DEPOSIT).lt(0)
-      ? account.balance.minus(EXISTENTIAL_DEPOSIT)
-      : account.balance;
+    let spendableBalance = account.balance.minus(estimatedFees).minus(EXISTENTIAL_DEPOSIT);
+    spendableBalance = spendableBalance.lt(0) ? account.balance : spendableBalance;
     if (!errors.amount && t.amount.eq(0) && !t.useAllAmount) {
       errors.amount = new AmountRequired();
     } else if (!errors.amount && t.amount.gt(spendableBalance)) {
@@ -113,7 +112,6 @@ const getTransactionStatus = async (
     } else if (t.amount.gt(0) && estimatedFees.times(10).gt(t.amount)) {
       warnings.feeTooHigh = new FeeTooHigh();
     }
-
     if (
       !errors.amount &&
       (await api.getAccountByAddress(t.recipient)).type === "empty" &&

--- a/src/families/tezos/test-dataset.ts
+++ b/src/families/tezos/test-dataset.ts
@@ -110,14 +110,12 @@ const dataset: DatasetTest<Transaction> = {
                 amount: account.balance,
                 recipient: accountTZnew.freshAddress,
               }),
-              expectedStatus: (acc, tr) =>{
-                console.log(tr); 
-                return {
+              expectedStatus: {
                 errors: {
                   amount: new NotEnoughBalance(),
                 },
                 warnings: {},
-              }},
+              },
             },
           ],
         },

--- a/src/families/tezos/test-dataset.ts
+++ b/src/families/tezos/test-dataset.ts
@@ -66,20 +66,6 @@ const dataset: DatasetTest<Transaction> = {
                 warnings: {},
               },
             },
-            {
-              name: "send more than min allowed",
-              transaction: (t, account) => ({
-                ...t,
-                amount: account.balance.minus("100"),
-                recipient: "tz1VSichevvJSNkSSntgwKDKikWNB6iqNJii",
-              }),
-              expectedStatus: {
-                errors: {
-                  amount: new NotEnoughBalance(),
-                },
-                warnings: {},
-              },
-            },
           ],
         },
         {
@@ -104,11 +90,11 @@ const dataset: DatasetTest<Transaction> = {
               },
             },
             {
-              name: "Amount > spendablebalance",
+              name: "send more than min allowed",
               transaction: (t, account) => ({
                 ...t,
-                amount: account.balance,
-                recipient: accountTZnew.freshAddress,
+                amount: account.balance.minus("100"),
+                recipient: "tz1VSichevvJSNkSSntgwKDKikWNB6iqNJii",
               }),
               expectedStatus: {
                 errors: {
@@ -116,6 +102,22 @@ const dataset: DatasetTest<Transaction> = {
                 },
                 warnings: {},
               },
+            },
+            {
+              name: "Amount > spendablebalance",
+              transaction: (t, account) => ({
+                ...t,
+                amount: account.balance,
+                recipient: accountTZnew.freshAddress,
+              }),
+              expectedStatus: (acc, tr) =>{
+                console.log(tr); 
+                return {
+                errors: {
+                  amount: new NotEnoughBalance(),
+                },
+                warnings: {},
+              }},
             },
           ],
         },


### PR DESCRIPTION
## Context (issues, jira)

Found a bug thanks to to test about issues that wasn't ordered correctly

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
The problem was when you wanted to send more than what you can spent, it's mean above your existential deposit (which is 0.275 XTZ). So to be sure if it's fix, try to send between your `account.balance - 0.275 XTZ` it should return an error
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
