### PR TITLE
LIVE-1603 Support recovery mode unseeded manager access

### DIFF
--- a/src/hw/connectManager.ts
+++ b/src/hw/connectManager.ts
@@ -78,8 +78,7 @@ const cmd = ({
           concatMap((deviceInfo) => {
             timeoutSub.unsubscribe();
 
-            // FIXME Until we have proper flagging of the onboarded status.
-            if (!deviceInfo.onboarded) {
+            if (!deviceInfo.onboarded && !deviceInfo.isRecoveryMode) {
               throw new DeviceNotOnboarded();
             }
 

--- a/src/hw/getDeviceInfo.ts
+++ b/src/hw/getDeviceInfo.ts
@@ -68,11 +68,14 @@ export default async function getDeviceInfo(
   const managerAllowed = !!(flag & ManagerAllowedFlag);
   const pinValidated = !!(flag & PinValidatedFlag);
 
-  // FIXME Until we have proper flagging of the onboarded status.
+  let isRecoveryMode = false;
   let onboarded = true;
   if (flags.length === 4) {
+    // Nb Since LNS+ unseeded devices are visible + extra flags
+    isRecoveryMode = !!(flags[0] & 0x01);
     onboarded = !!(flags[0] & 0x04);
   }
+
   log(
     "hw",
     "deviceInfo: se@" +
@@ -93,6 +96,7 @@ export default async function getDeviceInfo(
     mcuTargetId,
     isOSU,
     isBootloader,
+    isRecoveryMode,
     managerAllowed,
     pinValidated,
     onboarded,

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -21,6 +21,7 @@ export type DeviceInfo = {
   targetId: string | number;
   // a technical id
   isBootloader: boolean;
+  isRecoveryMode?: boolean;
   isOSU: boolean;
   providerName: string | null | undefined;
   managerAllowed: boolean;


### PR DESCRIPTION
## Context (issues, jira)
https://ledgerhq.atlassian.net/browse/LIVE-1603


## Description / Usage
With the hotfix for the release of the Ledger Nano S Plus we introduced a regression that impacted our production since they use the Live with devices in recovery mode for updating the firmware. We have to also check if the device is in recovery mode or not.

There's an LLD PR to test https://github.com/LedgerHQ/ledger-live-desktop/pull/4807
<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
