### PR TITLE
Live 719/add new platform providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "type": "git",
     "url": "https://github.com/LedgerHQ/ledger-live-common"
   },
-  "version": "21.32.5",
+  "version": "21.32.6",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "license": "Apache-2.0",

--- a/src/env.ts
+++ b/src/env.ts
@@ -545,6 +545,26 @@ const envDefinitions = {
     parser: stringParser,
     desc: 'json manifest for a local (test) platform app manifests. How to use: PLATFORM_LOCAL_MANIFEST_JSON="$(cat /path/to/file.json)"',
   },
+  PLATFORM_GLOBAL_CATALOG_API_URL: {
+    def: "https://cdn.live.ledger.com/platform/catalog/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests",
+  },
+  PLATFORM_GLOBAL_CATALOG_STAGING_API_URL: {
+    def: "https://cdn.live.ledger-stg.com/platform/catalog/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests (staging)",
+  },
+  PLATFORM_RAMP_CATALOG_API_URL: {
+    def: "https://cdn.live.ledger.com/platform/trade/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests",
+  },
+  PLATFORM_RAMP_CATALOG_STAGING_API_URL: {
+    def: "https://cdn.live.ledger-stg.com/platform/trade/v1/data.json",
+    parser: stringParser,
+    desc: "url used to fetch platform app manifests (staging)",
+  },
   PLATFORM_API_URL: {
     def: "",
     parser: stringParser,

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -23,6 +23,7 @@ export const LowerThanMinimumRelayFee = createCustomErrorClass(
 export const TransactionRefusedOnDevice = createCustomErrorClass(
   "TransactionRefusedOnDevice"
 );
+export const DeviceNotOnboarded = createCustomErrorClass("DeviceNotOnboarded");
 export const InvalidAddressBecauseAlreadyDelegated = createCustomErrorClass(
   "InvalidAddressBecauseAlreadyDelegated"
 );

--- a/src/families/solana/bridge/mock-data.ts
+++ b/src/families/solana/bridge/mock-data.ts
@@ -2,21 +2,593 @@
 import { PublicKey } from "@solana/web3.js";
 
 export const getMockedMethods = () => [
-
   // generated
-{"method":"getBalanceAndContext","params":["AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"],"answer":{"context":{"slot":109865128},"value":83389840}},
-{"method":"getSignaturesForAddress","params":["AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",{"limit":100}],"answer":[{"blockTime":1637781134,"confirmationStatus":"finalized","err":null,"memo":null,"signature":"A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk","slot":108521109},{"blockTime":1637780906,"confirmationStatus":"finalized","err":null,"memo":null,"signature":"25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna","slot":108520722}]},
-{"method":"getParsedConfirmedTransactions","params":[["A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk","25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna"]],"answer":[{"blockTime":1637781134,"meta":{"err":null,"fee":5000,"innerInstructions":[{"index":1,"instructions":[{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","space":165},"type":"allocate"},"program":"system","programId":new PublicKey(Buffer.from("00", 'hex'))},{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},"type":"assign"},"program":"system","programId":new PublicKey(Buffer.from("00", 'hex'))},{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","mint":"So11111111111111111111111111111111111111112","owner":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh","rentSysvar":"SysvarRent111111111111111111111111111111111"},"type":"initializeAccount"},"program":"spl-token","programId":new PublicKey(Buffer.from("06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9", 'hex'))}]}],"logMessages":["Program 11111111111111111111111111111111 invoke [1]","Program 11111111111111111111111111111111 success","Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]","Program log: Allocate space for the associated token account","Program 11111111111111111111111111111111 invoke [2]","Program 11111111111111111111111111111111 success","Program log: Assign the associated token account to the SPL Token program","Program 11111111111111111111111111111111 invoke [2]","Program 11111111111111111111111111111111 success","Program log: Initialize the associated token account","Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]","Program log: Instruction: InitializeAccount","Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3683 of 183452 compute units","Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success","Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 20880 of 200000 compute units","Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success"],"postBalances":[83389840,10000000,151314748907,1,1089991680,1009200,898174080],"postTokenBalances":[{"accountIndex":1,"mint":"So11111111111111111111111111111111111111112","uiTokenAmount":{"amount":"7960720","decimals":9,"uiAmount":0.00796072,"uiAmountString":"0.00796072"}}],"preBalances":[93394840,0,151314748907,1,1089991680,1009200,898174080],"preTokenBalances":[],"rewards":[],"status":{"Ok":null}},"slot":108521109,"transaction":{"message":{"accountKeys":[{"pubkey":new PublicKey(Buffer.from("8bc4d3e507c0550e3d02ffb5f6daf0772240af8a09e32d236615b4a227243702", 'hex')),"signer":true,"writable":true},{"pubkey":new PublicKey(Buffer.from("6e6279fa638560ce9c178033f5b88eacfb5fba6d46ec5902769f1b09eaabc017", 'hex')),"signer":false,"writable":true},{"pubkey":new PublicKey(Buffer.from("069b8857feab8184fb687f634618c035dac439dc1aeb3b5598a0f00000000001", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("00", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("06a7d517192c5c51218cc94c3d4af17f58daee089ba1fd44e3dbd98a00000000", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859", 'hex')),"signer":false,"writable":false}],"instructions":[{"parsed":{"info":{"destination":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","lamports":10000000,"source":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"},"type":"transfer"},"program":"system","programId":new PublicKey(Buffer.from("00", 'hex'))},{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","mint":"So11111111111111111111111111111111111111112","rentSysvar":"SysvarRent111111111111111111111111111111111","source":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh","systemProgram":"11111111111111111111111111111111","tokenProgram":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","wallet":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"},"type":"create"},"program":"spl-associated-token-account","programId":new PublicKey(Buffer.from("8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859", 'hex'))}],"recentBlockhash":"9tPbgLaETEenufCt5SzXMuWijgFJj549W9j5cJLbaogn"},"signatures":["A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk"]}},{"blockTime":1637780906,"meta":{"err":null,"fee":5000,"innerInstructions":[],"logMessages":["Program 11111111111111111111111111111111 invoke [1]","Program 11111111111111111111111111111111 success"],"postBalances":[0,93394840,1],"postTokenBalances":[],"preBalances":[93399840,0,1],"preTokenBalances":[],"rewards":[],"status":{"Ok":null}},"slot":108520722,"transaction":{"message":{"accountKeys":[{"pubkey":new PublicKey(Buffer.from("5c1c77c3d1e8edad4cfb2b2f7e4497d0d83f19e176713876a1d01eeb30a9bf3f", 'hex')),"signer":true,"writable":true},{"pubkey":new PublicKey(Buffer.from("8bc4d3e507c0550e3d02ffb5f6daf0772240af8a09e32d236615b4a227243702", 'hex')),"signer":false,"writable":true},{"pubkey":new PublicKey(Buffer.from("00", 'hex')),"signer":false,"writable":false}],"instructions":[{"parsed":{"info":{"destination":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh","lamports":93394840,"source":"7CZgkK494jMdoY8xpXY3ViLjpDGMbNikCzMtAT5cAjKk"},"type":"transfer"},"program":"system","programId":new PublicKey(Buffer.from("00", 'hex'))}],"recentBlockhash":"4NSL4VrfWd2eUccMD95dLQsdy5UGz8yhokpfH1et1R2c"},"signatures":["25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna"]}}]},
-{"method":"getBalanceAndContext","params":["6rEgdtB3sgjKJnRE172YEr9z6qUyr4nFW28vJokuD36A"],"answer":{"context":{"slot":109865129},"value":0}},
-{"method":"getSignaturesForAddress","params":["6rEgdtB3sgjKJnRE172YEr9z6qUyr4nFW28vJokuD36A",{"limit":100}],"answer":[]},
-{"method":"getSignaturesForAddress","params":["AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",{"until":"25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna","limit":100}],"answer":[{"blockTime":1637781134,"confirmationStatus":"finalized","err":null,"memo":null,"signature":"A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk","slot":108521109}]},
-{"method":"getParsedConfirmedTransactions","params":[["A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk"]],"answer":[{"blockTime":1637781134,"meta":{"err":null,"fee":5000,"innerInstructions":[{"index":1,"instructions":[{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","space":165},"type":"allocate"},"program":"system","programId":new PublicKey(Buffer.from("00", 'hex'))},{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","owner":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA"},"type":"assign"},"program":"system","programId":new PublicKey(Buffer.from("00", 'hex'))},{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","mint":"So11111111111111111111111111111111111111112","owner":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh","rentSysvar":"SysvarRent111111111111111111111111111111111"},"type":"initializeAccount"},"program":"spl-token","programId":new PublicKey(Buffer.from("06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9", 'hex'))}]}],"logMessages":["Program 11111111111111111111111111111111 invoke [1]","Program 11111111111111111111111111111111 success","Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]","Program log: Allocate space for the associated token account","Program 11111111111111111111111111111111 invoke [2]","Program 11111111111111111111111111111111 success","Program log: Assign the associated token account to the SPL Token program","Program 11111111111111111111111111111111 invoke [2]","Program 11111111111111111111111111111111 success","Program log: Initialize the associated token account","Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]","Program log: Instruction: InitializeAccount","Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3683 of 183452 compute units","Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success","Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 20880 of 200000 compute units","Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success"],"postBalances":[83389840,10000000,151314748907,1,1089991680,1009200,898174080],"postTokenBalances":[{"accountIndex":1,"mint":"So11111111111111111111111111111111111111112","uiTokenAmount":{"amount":"7960720","decimals":9,"uiAmount":0.00796072,"uiAmountString":"0.00796072"}}],"preBalances":[93394840,0,151314748907,1,1089991680,1009200,898174080],"preTokenBalances":[],"rewards":[],"status":{"Ok":null}},"slot":108521109,"transaction":{"message":{"accountKeys":[{"pubkey":new PublicKey(Buffer.from("8bc4d3e507c0550e3d02ffb5f6daf0772240af8a09e32d236615b4a227243702", 'hex')),"signer":true,"writable":true},{"pubkey":new PublicKey(Buffer.from("6e6279fa638560ce9c178033f5b88eacfb5fba6d46ec5902769f1b09eaabc017", 'hex')),"signer":false,"writable":true},{"pubkey":new PublicKey(Buffer.from("069b8857feab8184fb687f634618c035dac439dc1aeb3b5598a0f00000000001", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("00", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("06a7d517192c5c51218cc94c3d4af17f58daee089ba1fd44e3dbd98a00000000", 'hex')),"signer":false,"writable":false},{"pubkey":new PublicKey(Buffer.from("8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859", 'hex')),"signer":false,"writable":false}],"instructions":[{"parsed":{"info":{"destination":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","lamports":10000000,"source":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"},"type":"transfer"},"program":"system","programId":new PublicKey(Buffer.from("00", 'hex'))},{"parsed":{"info":{"account":"8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN","mint":"So11111111111111111111111111111111111111112","rentSysvar":"SysvarRent111111111111111111111111111111111","source":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh","systemProgram":"11111111111111111111111111111111","tokenProgram":"TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA","wallet":"AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"},"type":"create"},"program":"spl-associated-token-account","programId":new PublicKey(Buffer.from("8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859", 'hex'))}],"recentBlockhash":"9tPbgLaETEenufCt5SzXMuWijgFJj549W9j5cJLbaogn"},"signatures":["A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk"]}}]},
-{"method":"getRecentBlockhash","params":[],"answer":{"blockhash":"CfCUxX9U6hibcKxHV9Sy1CyG3Z2uTTitxAbina1ZXygF","feeCalculator":{"lamportsPerSignature":5000}}},
-{"method":"getBalance","params":["ARRKL4FT4LMwpkhUw4xNbfiHqR7UdePtzGLvkszgydqZ"],"answer":1000000},
-{"method":"getBalance","params":["7b6Q3ap8qRzfyvDw1Qce3fUV8C7WgFNzJQwYNTJm3KQo"],"answer":0},
-{"method":"getBalance","params":["6D8GtWkKJgToM5UoiByHqjQCCC9Dq1Hh7iNmU4jKSs14"],"answer":0},
+  {
+    method: "getBalanceAndContext",
+    params: ["AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh"],
+    answer: { context: { slot: 109865128 }, value: 83389840 },
+  },
+  {
+    method: "getSignaturesForAddress",
+    params: ["AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh", { limit: 100 }],
+    answer: [
+      {
+        blockTime: 1637781134,
+        confirmationStatus: "finalized",
+        err: null,
+        memo: null,
+        signature:
+          "A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk",
+        slot: 108521109,
+      },
+      {
+        blockTime: 1637780906,
+        confirmationStatus: "finalized",
+        err: null,
+        memo: null,
+        signature:
+          "25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna",
+        slot: 108520722,
+      },
+    ],
+  },
+  {
+    method: "getParsedConfirmedTransactions",
+    params: [
+      [
+        "A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk",
+        "25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna",
+      ],
+    ],
+    answer: [
+      {
+        blockTime: 1637781134,
+        meta: {
+          err: null,
+          fee: 5000,
+          innerInstructions: [
+            {
+              index: 1,
+              instructions: [
+                {
+                  parsed: {
+                    info: {
+                      account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                      space: 165,
+                    },
+                    type: "allocate",
+                  },
+                  program: "system",
+                  programId: new PublicKey(Buffer.from("00", "hex")),
+                },
+                {
+                  parsed: {
+                    info: {
+                      account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                      owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                    },
+                    type: "assign",
+                  },
+                  program: "system",
+                  programId: new PublicKey(Buffer.from("00", "hex")),
+                },
+                {
+                  parsed: {
+                    info: {
+                      account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                      mint: "So11111111111111111111111111111111111111112",
+                      owner: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                      rentSysvar: "SysvarRent111111111111111111111111111111111",
+                    },
+                    type: "initializeAccount",
+                  },
+                  program: "spl-token",
+                  programId: new PublicKey(
+                    Buffer.from(
+                      "06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9",
+                      "hex"
+                    )
+                  ),
+                },
+              ],
+            },
+          ],
+          logMessages: [
+            "Program 11111111111111111111111111111111 invoke [1]",
+            "Program 11111111111111111111111111111111 success",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
+            "Program log: Allocate space for the associated token account",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Assign the associated token account to the SPL Token program",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Initialize the associated token account",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: InitializeAccount",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3683 of 183452 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 20880 of 200000 compute units",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
+          ],
+          postBalances: [
+            83389840, 10000000, 151314748907, 1, 1089991680, 1009200, 898174080,
+          ],
+          postTokenBalances: [
+            {
+              accountIndex: 1,
+              mint: "So11111111111111111111111111111111111111112",
+              uiTokenAmount: {
+                amount: "7960720",
+                decimals: 9,
+                uiAmount: 0.00796072,
+                uiAmountString: "0.00796072",
+              },
+            },
+          ],
+          preBalances: [
+            93394840, 0, 151314748907, 1, 1089991680, 1009200, 898174080,
+          ],
+          preTokenBalances: [],
+          rewards: [],
+          status: { Ok: null },
+        },
+        slot: 108521109,
+        transaction: {
+          message: {
+            accountKeys: [
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "8bc4d3e507c0550e3d02ffb5f6daf0772240af8a09e32d236615b4a227243702",
+                    "hex"
+                  )
+                ),
+                signer: true,
+                writable: true,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "6e6279fa638560ce9c178033f5b88eacfb5fba6d46ec5902769f1b09eaabc017",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: true,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "069b8857feab8184fb687f634618c035dac439dc1aeb3b5598a0f00000000001",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(Buffer.from("00", "hex")),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "06a7d517192c5c51218cc94c3d4af17f58daee089ba1fd44e3dbd98a00000000",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+            ],
+            instructions: [
+              {
+                parsed: {
+                  info: {
+                    destination: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                    lamports: 10000000,
+                    source: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                  },
+                  type: "transfer",
+                },
+                program: "system",
+                programId: new PublicKey(Buffer.from("00", "hex")),
+              },
+              {
+                parsed: {
+                  info: {
+                    account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                    mint: "So11111111111111111111111111111111111111112",
+                    rentSysvar: "SysvarRent111111111111111111111111111111111",
+                    source: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                    systemProgram: "11111111111111111111111111111111",
+                    tokenProgram: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                    wallet: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                  },
+                  type: "create",
+                },
+                program: "spl-associated-token-account",
+                programId: new PublicKey(
+                  Buffer.from(
+                    "8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859",
+                    "hex"
+                  )
+                ),
+              },
+            ],
+            recentBlockhash: "9tPbgLaETEenufCt5SzXMuWijgFJj549W9j5cJLbaogn",
+          },
+          signatures: [
+            "A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk",
+          ],
+        },
+      },
+      {
+        blockTime: 1637780906,
+        meta: {
+          err: null,
+          fee: 5000,
+          innerInstructions: [],
+          logMessages: [
+            "Program 11111111111111111111111111111111 invoke [1]",
+            "Program 11111111111111111111111111111111 success",
+          ],
+          postBalances: [0, 93394840, 1],
+          postTokenBalances: [],
+          preBalances: [93399840, 0, 1],
+          preTokenBalances: [],
+          rewards: [],
+          status: { Ok: null },
+        },
+        slot: 108520722,
+        transaction: {
+          message: {
+            accountKeys: [
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "5c1c77c3d1e8edad4cfb2b2f7e4497d0d83f19e176713876a1d01eeb30a9bf3f",
+                    "hex"
+                  )
+                ),
+                signer: true,
+                writable: true,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "8bc4d3e507c0550e3d02ffb5f6daf0772240af8a09e32d236615b4a227243702",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: true,
+              },
+              {
+                pubkey: new PublicKey(Buffer.from("00", "hex")),
+                signer: false,
+                writable: false,
+              },
+            ],
+            instructions: [
+              {
+                parsed: {
+                  info: {
+                    destination: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                    lamports: 93394840,
+                    source: "7CZgkK494jMdoY8xpXY3ViLjpDGMbNikCzMtAT5cAjKk",
+                  },
+                  type: "transfer",
+                },
+                program: "system",
+                programId: new PublicKey(Buffer.from("00", "hex")),
+              },
+            ],
+            recentBlockhash: "4NSL4VrfWd2eUccMD95dLQsdy5UGz8yhokpfH1et1R2c",
+          },
+          signatures: [
+            "25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna",
+          ],
+        },
+      },
+    ],
+  },
+  {
+    method: "getBalanceAndContext",
+    params: ["6rEgdtB3sgjKJnRE172YEr9z6qUyr4nFW28vJokuD36A"],
+    answer: { context: { slot: 109865129 }, value: 0 },
+  },
+  {
+    method: "getSignaturesForAddress",
+    params: ["6rEgdtB3sgjKJnRE172YEr9z6qUyr4nFW28vJokuD36A", { limit: 100 }],
+    answer: [],
+  },
+  {
+    method: "getSignaturesForAddress",
+    params: [
+      "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+      {
+        until:
+          "25KWBvKtVgKR3yoRmozTY6wmiW8atwrnzAnTXdsms8jqg5aR8GnCDxdJzWXtzMZPvbsE6SUuBkGFXudy2mrcTYna",
+        limit: 100,
+      },
+    ],
+    answer: [
+      {
+        blockTime: 1637781134,
+        confirmationStatus: "finalized",
+        err: null,
+        memo: null,
+        signature:
+          "A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk",
+        slot: 108521109,
+      },
+    ],
+  },
+  {
+    method: "getParsedConfirmedTransactions",
+    params: [
+      [
+        "A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk",
+      ],
+    ],
+    answer: [
+      {
+        blockTime: 1637781134,
+        meta: {
+          err: null,
+          fee: 5000,
+          innerInstructions: [
+            {
+              index: 1,
+              instructions: [
+                {
+                  parsed: {
+                    info: {
+                      account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                      space: 165,
+                    },
+                    type: "allocate",
+                  },
+                  program: "system",
+                  programId: new PublicKey(Buffer.from("00", "hex")),
+                },
+                {
+                  parsed: {
+                    info: {
+                      account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                      owner: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                    },
+                    type: "assign",
+                  },
+                  program: "system",
+                  programId: new PublicKey(Buffer.from("00", "hex")),
+                },
+                {
+                  parsed: {
+                    info: {
+                      account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                      mint: "So11111111111111111111111111111111111111112",
+                      owner: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                      rentSysvar: "SysvarRent111111111111111111111111111111111",
+                    },
+                    type: "initializeAccount",
+                  },
+                  program: "spl-token",
+                  programId: new PublicKey(
+                    Buffer.from(
+                      "06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9",
+                      "hex"
+                    )
+                  ),
+                },
+              ],
+            },
+          ],
+          logMessages: [
+            "Program 11111111111111111111111111111111 invoke [1]",
+            "Program 11111111111111111111111111111111 success",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL invoke [1]",
+            "Program log: Allocate space for the associated token account",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Assign the associated token account to the SPL Token program",
+            "Program 11111111111111111111111111111111 invoke [2]",
+            "Program 11111111111111111111111111111111 success",
+            "Program log: Initialize the associated token account",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA invoke [2]",
+            "Program log: Instruction: InitializeAccount",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA consumed 3683 of 183452 compute units",
+            "Program TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA success",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL consumed 20880 of 200000 compute units",
+            "Program ATokenGPvbdGVxr1b2hvZbsiqW5xWH25efTNsLJA8knL success",
+          ],
+          postBalances: [
+            83389840, 10000000, 151314748907, 1, 1089991680, 1009200, 898174080,
+          ],
+          postTokenBalances: [
+            {
+              accountIndex: 1,
+              mint: "So11111111111111111111111111111111111111112",
+              uiTokenAmount: {
+                amount: "7960720",
+                decimals: 9,
+                uiAmount: 0.00796072,
+                uiAmountString: "0.00796072",
+              },
+            },
+          ],
+          preBalances: [
+            93394840, 0, 151314748907, 1, 1089991680, 1009200, 898174080,
+          ],
+          preTokenBalances: [],
+          rewards: [],
+          status: { Ok: null },
+        },
+        slot: 108521109,
+        transaction: {
+          message: {
+            accountKeys: [
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "8bc4d3e507c0550e3d02ffb5f6daf0772240af8a09e32d236615b4a227243702",
+                    "hex"
+                  )
+                ),
+                signer: true,
+                writable: true,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "6e6279fa638560ce9c178033f5b88eacfb5fba6d46ec5902769f1b09eaabc017",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: true,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "069b8857feab8184fb687f634618c035dac439dc1aeb3b5598a0f00000000001",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(Buffer.from("00", "hex")),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "06ddf6e1d765a193d9cbe146ceeb79ac1cb485ed5f5b37913a8cf5857eff00a9",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "06a7d517192c5c51218cc94c3d4af17f58daee089ba1fd44e3dbd98a00000000",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+              {
+                pubkey: new PublicKey(
+                  Buffer.from(
+                    "8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859",
+                    "hex"
+                  )
+                ),
+                signer: false,
+                writable: false,
+              },
+            ],
+            instructions: [
+              {
+                parsed: {
+                  info: {
+                    destination: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                    lamports: 10000000,
+                    source: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                  },
+                  type: "transfer",
+                },
+                program: "system",
+                programId: new PublicKey(Buffer.from("00", "hex")),
+              },
+              {
+                parsed: {
+                  info: {
+                    account: "8RtwWeqdFz4EFuZU3MAadfYMWSdRMamjFrfq6BXkHuNN",
+                    mint: "So11111111111111111111111111111111111111112",
+                    rentSysvar: "SysvarRent111111111111111111111111111111111",
+                    source: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                    systemProgram: "11111111111111111111111111111111",
+                    tokenProgram: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                    wallet: "AQbkEagmPgmsdAfS4X8V8UyJnXXjVPMvjeD15etqQ3Jh",
+                  },
+                  type: "create",
+                },
+                program: "spl-associated-token-account",
+                programId: new PublicKey(
+                  Buffer.from(
+                    "8c97258f4e2489f1bb3d1029148e0d830b5a1399daff1084048e7bd8dbe9f859",
+                    "hex"
+                  )
+                ),
+              },
+            ],
+            recentBlockhash: "9tPbgLaETEenufCt5SzXMuWijgFJj549W9j5cJLbaogn",
+          },
+          signatures: [
+            "A29zPnK1jPr2tGziTnaAvSnadYR2kLCv9sPywj9FJsaEFjtpwmUonspN3WJgz4u6XWmjtVpoFsDrygEnvW51cgk",
+          ],
+        },
+      },
+    ],
+  },
+  {
+    method: "getRecentBlockhash",
+    params: [],
+    answer: {
+      blockhash: "CfCUxX9U6hibcKxHV9Sy1CyG3Z2uTTitxAbina1ZXygF",
+      feeCalculator: { lamportsPerSignature: 5000 },
+    },
+  },
+  {
+    method: "getBalance",
+    params: ["ARRKL4FT4LMwpkhUw4xNbfiHqR7UdePtzGLvkszgydqZ"],
+    answer: 1000000,
+  },
+  {
+    method: "getBalance",
+    params: ["7b6Q3ap8qRzfyvDw1Qce3fUV8C7WgFNzJQwYNTJm3KQo"],
+    answer: 0,
+  },
+  {
+    method: "getBalance",
+    params: ["6D8GtWkKJgToM5UoiByHqjQCCC9Dq1Hh7iNmU4jKSs14"],
+    answer: 0,
+  },
 
- // manual
-{"method":"getTxFeeCalculator","params":[],"answer":{"lamportsPerSignature": 5000}},
-
+  // manual
+  {
+    method: "getTxFeeCalculator",
+    params: [],
+    answer: { lamportsPerSignature: 5000 },
+  },
 ];

--- a/src/hw/connectManager.ts
+++ b/src/hw/connectManager.ts
@@ -12,6 +12,7 @@ import getDeviceInfo from "./getDeviceInfo";
 import getAppAndVersion from "./getAppAndVersion";
 import appSupportsQuitApp from "../appSupportsQuitApp";
 import { isDashboardName } from "./isDashboardName";
+import { DeviceNotOnboarded } from "../errors";
 import type { AppAndVersion } from "./connectApp";
 import quitApp from "./quitApp";
 export type Input = {
@@ -76,6 +77,11 @@ const cmd = ({
         .pipe(
           concatMap((deviceInfo) => {
             timeoutSub.unsubscribe();
+
+            // FIXME Until we have proper flagging of the onboarded status.
+            if (!deviceInfo.onboarded) {
+              throw new DeviceNotOnboarded();
+            }
 
             if (deviceInfo.isBootloader) {
               return of({

--- a/src/platform/providers/GlobalCatalogProvider/api/index.ts
+++ b/src/platform/providers/GlobalCatalogProvider/api/index.ts
@@ -1,0 +1,42 @@
+import network from "../../../../network";
+import { getEnv } from "../../../../env";
+import type { GlobalCatalog } from "../types";
+import mockData from "./mock.json";
+
+export const providers = [
+  {
+    value: "production",
+    url: getEnv("PLATFORM_GLOBAL_CATALOG_API_URL"),
+  },
+  {
+    value: "staging",
+    url: getEnv("PLATFORM_GLOBAL_CATALOG_STAGING_API_URL"),
+  },
+];
+
+export function getProviderURL(value: string): string {
+  const provider = providers.find((provider) => provider.value === value);
+
+  if (!provider) {
+    throw new Error(`remote ramp catalog provider "${value}" not found`);
+  }
+  return provider.url;
+}
+
+const api = {
+  fetchGlobalCatalog: async (provider: string): Promise<GlobalCatalog> => {
+    if (getEnv("MOCK")) {
+      return mockData as GlobalCatalog;
+    }
+
+    const { data } = await network({
+      method: "GET",
+      headers: {
+        Origin: "http://localhost:3000",
+      },
+      url: getProviderURL(provider),
+    });
+    return data as GlobalCatalog;
+  },
+};
+export default api;

--- a/src/platform/providers/GlobalCatalogProvider/api/mock.json
+++ b/src/platform/providers/GlobalCatalogProvider/api/mock.json
@@ -1,0 +1,399 @@
+{
+  "promotedApps": [
+    {
+      "id": "Card",
+      "thumbnailUrl": ""
+    },
+    {
+      "id": "moonpay",
+      "thumbnailUrl": ""
+    },
+    {
+      "id": "paraswap",
+      "thumbnailUrl": ""
+    }
+  ],
+  "orderedCategories": [
+    "trade",
+    "earn",
+    "spend",
+    "nft",
+    "services",
+    "other"
+  ],
+  "appsMetadata": [
+    {
+      "type": "LIVE_APP",
+      "appId": "transak",
+      "platform": "all",
+      "branch": "experimental",
+      "currencies": "*",
+      "tags": [],
+      "categories": []
+    },
+    {
+      "type": "LIVE_APP",
+      "appId": "mercuryo",
+      "platform": "all",
+      "branch": "experimental",
+      "currencies": [
+        "bitcoin",
+        "ethereum",
+        "algorand",
+        "bitcoin cash",
+        "binance coin",
+        "tron",
+        "tether"
+      ],
+      "tags": [],
+      "categories": []
+    },
+    {
+      "appId": "changenow",
+      "type": "LIVE_APP",
+      "platform": "all",
+      "branch": "experimental",
+      "currencies": [
+        "bitcoin",
+        "ethereum"
+      ],
+      "tags": [],
+      "categories": []
+    },
+    {
+      "appId": "alkemi",
+      "type": "LIVE_APP",
+      "platform": "all",
+      "branch": "soon",
+      "currencies": [
+        "ethereum"
+      ],
+      "tags": [],
+      "categories": []
+    },
+    {
+      "appId": "paraswap v5",
+      "type": "LIVE_APP",
+      "platform": "all",
+      "branch": "experimental",
+      "currencies": [
+        "ethereum",
+        "bsc"
+      ],
+      "tags": [],
+      "categories": []
+    },
+    {
+      "appId": "Card",
+      "type": "LIVE_APP",
+      "tags": [
+        "card"
+      ],
+      "categories": [
+        "spend"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": "*"
+    },
+    {
+      "appId": "cl-card",
+      "type": "LIVE_APP",
+      "tags": [
+        "card"
+      ],
+      "categories": [
+        "spend"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": "*"
+    },
+    {
+      "appId": "moonpay",
+      "type": "LIVE_APP",
+      "tags": [
+        "buy"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "bitcoin",
+        "bitcoin_cash",
+        "bsc",
+        "digibyte",
+        "dogecoin",
+        "ethereum",
+        "litecoin",
+        "polkadot",
+        "ripple",
+        "stellar",
+        "tron"
+      ]
+    },
+    {
+      "appId": "ramp",
+      "type": "LIVE_APP",
+      "tags": [
+        "buy"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum",
+        "bitcoin",
+        "bsc",
+        "polkadot",
+        "ripple",
+        "litecoin",
+        "polygon",
+        "bitcoin_cash",
+        "stellar",
+        "dogecoin",
+        "tezos",
+        "elrond"
+      ]
+    },
+    {
+      "appId": "paraswap",
+      "type": "LIVE_APP",
+      "tags": [
+        "swap"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum",
+        "bsc"
+      ]
+    },
+    {
+      "appId": "lido",
+      "type": "LIVE_APP",
+      "tags": [
+        "stake"
+      ],
+      "categories": [
+        "earn"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "1inch",
+      "type": "LIVE_APP",
+      "tags": [
+        "swap"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "btcdirect",
+      "type": "LIVE_APP",
+      "tags": [
+        "buy"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "bitcoin",
+        "bitcoin_cash",
+        "ethereum",
+        "litecoin",
+        "ripple"
+      ]
+    },
+    {
+      "appId": "banxa",
+      "type": "LIVE_APP",
+      "tags": [
+        "buy"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "desktop",
+      "branch": "stable",
+      "currencies": [
+        "ethereum",
+        "bitcoin",
+        "litecoin",
+        "ripple",
+        "tether"
+      ]
+    },
+    {
+      "appId": "bitrefill",
+      "type": "LIVE_APP",
+      "tags": [
+        "gift card"
+      ],
+      "categories": [
+        "spend"
+      ],
+      "platform": "desktop",
+      "branch": "stable",
+      "currencies": [
+        "bitcoin",
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "wyre_buy",
+      "type": "LIVE_APP",
+      "tags": [
+        "buy"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum",
+        "bitcoin",
+        "algorand"
+      ]
+    },
+    {
+      "appId": "zerion",
+      "type": "LIVE_APP",
+      "tags": [
+        "portfolio"
+      ],
+      "categories": [
+        "services"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "rainbow",
+      "type": "LIVE_APP",
+      "tags": [
+        "nft"
+      ],
+      "categories": [
+        "nft"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "poap",
+      "type": "LIVE_APP",
+      "tags": [
+        "nft"
+      ],
+      "categories": [
+        "nft"
+      ],
+      "platform": "all",
+      "branch": "stable",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "aave",
+      "type": "LIVE_APP",
+      "tags": [
+        "lend"
+      ],
+      "categories": [
+        "earn"
+      ],
+      "platform": "all",
+      "branch": "soon",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "compound",
+      "type": "LIVE_APP",
+      "tags": [
+        "lend"
+      ],
+      "categories": [
+        "earn"
+      ],
+      "platform": "all",
+      "branch": "soon",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "deversifi",
+      "type": "LIVE_APP",
+      "tags": [
+        "swap"
+      ],
+      "categories": [
+        "trade"
+      ],
+      "platform": "all",
+      "branch": "soon",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "yearn",
+      "type": "LIVE_APP",
+      "tags": [
+        "lend"
+      ],
+      "categories": [
+        "earn"
+      ],
+      "platform": "all",
+      "branch": "experimental",
+      "currencies": [
+        "ethereum"
+      ]
+    },
+    {
+      "appId": "debug",
+      "type": "LIVE_APP",
+      "tags": [
+        "tools"
+      ],
+      "categories": [
+        "other"
+      ],
+      "platform": "all",
+      "branch": "debug",
+      "currencies": "*"
+    }
+  ]
+}

--- a/src/platform/providers/GlobalCatalogProvider/index.tsx
+++ b/src/platform/providers/GlobalCatalogProvider/index.tsx
@@ -1,0 +1,96 @@
+import React, {
+  useContext,
+  useEffect,
+  createContext,
+  useMemo,
+  useState,
+  useCallback,
+} from "react";
+import { Loadable, GlobalCatalog } from "./types";
+
+import api from "./api";
+
+const initialState: Loadable<GlobalCatalog> = {
+  isLoading: false,
+  value: null,
+  error: null,
+};
+
+export type GlobalCatalogDataAPI = {
+  fetchGlobalCatalog: () => Promise<GlobalCatalog>;
+};
+
+type GlobalCatalogContextType = {
+  state: Loadable<GlobalCatalog>;
+  updateCatalog: () => Promise<void>;
+};
+
+export const globalCatalogContext = createContext<GlobalCatalogContextType>({
+  state: initialState,
+  updateCatalog: () => Promise.resolve(),
+});
+
+type CatalogProviderProps = {
+  children: React.ReactNode;
+  provider: string;
+  updateFrequency: number;
+};
+
+export function useGlobalCatalog(): Loadable<GlobalCatalog> {
+  return useContext(globalCatalogContext).state;
+}
+
+export function GlobalCatalogProvider({
+  children,
+  provider,
+  updateFrequency,
+}: CatalogProviderProps): JSX.Element {
+  const [state, setState] = useState<Loadable<GlobalCatalog>>(initialState);
+
+  const updateCatalog = useCallback(async () => {
+    setState((currentState) => ({
+      ...currentState,
+      isLoading: true,
+      error: null,
+    }));
+
+    try {
+      const value = await api.fetchGlobalCatalog(provider);
+      setState(() => ({
+        isLoading: false,
+        value,
+        error: null,
+      }));
+    } catch (error) {
+      setState((currentState) => ({
+        ...currentState,
+        isLoading: false,
+        error,
+      }));
+    }
+  }, [provider]);
+
+  const value: GlobalCatalogContextType = useMemo(
+    () => ({
+      state,
+      updateCatalog,
+    }),
+    [state, updateCatalog]
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      updateCatalog();
+    }, updateFrequency);
+    updateCatalog();
+    return () => {
+      clearInterval(interval);
+    };
+  }, [updateFrequency, updateCatalog]);
+
+  return (
+    <globalCatalogContext.Provider value={value}>
+      {children}
+    </globalCatalogContext.Provider>
+  );
+}

--- a/src/platform/providers/GlobalCatalogProvider/types.ts
+++ b/src/platform/providers/GlobalCatalogProvider/types.ts
@@ -1,0 +1,38 @@
+export type Loadable<T> = {
+  error: any | null;
+  isLoading: boolean;
+  value: T | null;
+};
+
+interface GenericGlobalCatalogEntry {
+  platform: string;
+  branch: string;
+  currencies: string[];
+  tags: string[];
+  categories: string[];
+}
+
+interface GlobalLiveAppCatalogEntry extends GenericGlobalCatalogEntry {
+  type: "LIVE_APP";
+  appId: string;
+}
+
+interface GlobalNativeCatalogEntry extends GenericGlobalCatalogEntry {
+  type: "NATIVE";
+  path: string;
+}
+
+export type GlobalCatalogEntry =
+  | GlobalLiveAppCatalogEntry
+  | GlobalNativeCatalogEntry;
+
+type PromotedApp = {
+  id: string;
+  thumbnailUrl: string;
+};
+
+export type GlobalCatalog = {
+  orderedCategories: string[];
+  promotedApps: PromotedApp[];
+  appsMetadata: GlobalCatalogEntry[];
+};

--- a/src/platform/providers/LiveAppProvider/api/index.ts
+++ b/src/platform/providers/LiveAppProvider/api/index.ts
@@ -1,0 +1,50 @@
+import network from "../../../../network";
+import { getEnv } from "../../../../env";
+import type { LiveAppManifest } from "../types";
+import mockData from "./mock.json";
+
+type RemotePlatformAppProvider = {
+  value: string;
+  url: string;
+  label: string;
+};
+
+export const providers = [
+  {
+    value: "production",
+    url: getEnv("PLATFORM_MANIFEST_API_URL"),
+  },
+  {
+    value: "staging",
+    url: getEnv("PLATFORM_MANIFEST_STAGING_API_URL"),
+  },
+];
+
+export function getProviderURL(value: string): RemotePlatformAppProvider {
+  const provider = providers.find((provider) => provider.value === value);
+
+  if (!provider) {
+    throw new Error(`remote live app provider "${value}" not found`);
+  }
+  return provider.url;
+}
+
+const api = {
+  fetchLiveAppManifests: async (
+    provider: string
+  ): Promise<LiveAppManifest[]> => {
+    if (getEnv("MOCK")) {
+      return mockData as LiveAppManifest[];
+    }
+
+    const { data } = await network({
+      method: "GET",
+      headers: {
+        Origin: "http://localhost:3000",
+      },
+      url: getProviderURL(provider),
+    });
+    return data as LiveAppManifest[];
+  },
+};
+export default api;

--- a/src/platform/providers/LiveAppProvider/api/mock.json
+++ b/src/platform/providers/LiveAppProvider/api/mock.json
@@ -1,0 +1,827 @@
+[
+    {
+      "id": "Card",
+      "name": "Card",
+      "url": "https://cl-cards.com/waiting-list/",
+      "homepageUrl": "https://baanx.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/card2.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["card"],
+      "currencies": "*",
+      "content": {
+        "shortDescription": {
+          "en": "Coming soon: spend your crypto globally with the crypto debit CL Card, powered by Ledger. Built to be compatible with your Ledger wallet. Join the waitlist"
+        },
+        "description": {
+          "en": "Coming soon: spend your crypto globally with the crypto debit CL Card, powered by Ledger. Built to be compatible with your Ledger wallet. Join the waitlist"
+        }
+      },
+      "permissions": [
+        {
+          "method": "*"
+        }
+      ],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "cl-card",
+      "name": "Card",
+      "url": "https://cl-cards.com/waiting-list/",
+      "homepageUrl": "https://baanx.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/card2.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "private": true,
+      "branch": "stable",
+      "categories": ["card"],
+      "currencies": "*",
+      "content": {
+        "shortDescription": {
+          "en": "Coming soon: spend your crypto globally with the crypto debit CL Card, powered by Ledger. Built to be compatible with your Ledger wallet. Join the waitlist"
+        },
+        "description": {
+          "en": "Coming soon: spend your crypto globally with the crypto debit CL Card, powered by Ledger. Built to be compatible with your Ledger wallet. Join the waitlist"
+        }
+      },
+      "permissions": [
+        {
+          "method": "*"
+        }
+      ],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "moonpay",
+      "name": "MoonPay",
+      "url": "https://buy.moonpay.com/?apiKey=pk_live_j5CLt1qxbqGtYhkxUxyk6VQnSd5CBXI&ledgerlive",
+      "homepageUrl": "https://www.moonpay.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/moonpay.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["buy"],
+      "currencies": [
+        "bitcoin",
+        "bitcoin_cash",
+        "bsc",
+        "digibyte",
+        "dogecoin",
+        "ethereum",
+        "litecoin",
+        "polkadot",
+        "ripple",
+        "stellar",
+        "tron"
+      ],
+      "content": {
+        "shortDescription": {
+          "en": "A fast, simple, and secure way to buy crypto."
+        },
+        "description": {
+          "en": "MoonPay accepts all major payment methods and over 30 fiat currencies, enabling people from all over the world to buy crypto."
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+    "id": "ramp",
+    "name": "Ramp",
+    "url": "https://integrations.ramp.network/ledger/",
+    "homepageUrl": "https://ramp.network/buy",
+    "icon": "https://cdn.live.ledger.com/icons/platform/ramp.png",
+    "platform": "all",
+    "apiVersion": "0.0.1",
+    "manifestVersion": "1",
+    "branch": "stable",
+    "categories": [
+      "buy"
+    ],
+    "currencies": [
+      "ethereum",
+      "bitcoin",
+      "bsc",
+      "polkadot",
+      "ripple",
+      "litecoin",
+      "polygon",
+      "bitcoin_cash",
+      "stellar",
+      "dogecoin",
+      "tezos",
+      "elrond"
+    ],
+    "content": {
+      "shortDescription": {
+        "en": "An easy, low-fee and secure way to buy your favorite crypto assets."
+      },
+      "description": {
+        "en": "Ramp - Use instant payment methods to buy crypto from anywhere on the globe."
+      }
+    },
+    "permissions": [],
+    "domains": [
+      "https://*"
+    ]
+    },
+    {
+      "id": "paraswap",
+      "name": "ParaSwap",
+      "url": "https://dapp-browser.apps.ledger.com/?params=%7B%22dappUrl%22%3A%22https%3A%2F%2Fv5.paraswap.io%2Fledger-live%22%2C%22nanoApp%22%3A%22Paraswap%22%2C%22dappName%22%3A%22ParaSwap%22%2C%22networks%22%3A%5B%7B%22currency%22%3A%22ethereum%22%2C%22chainID%22%3A1%2C%22nodeURL%22%3A%22wss%3A%2F%2Feth-mainnet.ws.alchemyapi.io%2Fv2%2F0fyudoTG94QWC0tEtfJViM9v2ZXJuij2%22%7D%2C%7B%22currency%22%3A%22bsc%22%2C%22chainID%22%3A56%2C%22nodeURL%22%3A%22https%3A%2F%2Fbsc-dataseed.binance.org%2F%22%7D%2C%7B%22currency%22%3A%20%22polygon%22%2C%22chainID%22%3A%20137%2C%22nodeURL%22%3A%20%22https%3A%2F%2Fpolygon-mainnet.g.alchemy.com%2Fv2%2FoPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE%22%7D%5D%7D",
+      "params": {
+        "dappUrl": "https://v5.paraswap.io/?referrer=ledger2&embed=true&enableStaking=false&displayMenu=false&enableNetworkSwitch=false",
+        "nanoApp": "Paraswap",
+        "dappName": "ParaSwap",
+        "networks": [
+          {
+            "currency": "ethereum",
+            "chainID": 1,
+            "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+          },
+          {
+            "currency": "bsc",
+            "chainID": 56,
+            "nodeURL": "https://bsc-dataseed.binance.org/"
+          },
+          {
+            "currency": "polygon",
+            "chainID": 137,
+            "nodeURL": "https://polygon-mainnet.g.alchemy.com/v2/oPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE"
+          }
+        ]
+      },
+      "homepageUrl": "https://paraswap.io",
+      "supportUrl": "https://paraswap.io",
+      "icon": "https://cdn.live.ledger.com/icons/platform/paraswap.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["swap", "defi"],
+      "currencies": ["ethereum", "bsc"],
+      "content": {
+        "shortDescription": {
+          "en": "Swap your crypto with ParaSwap that aggregates and provides the best quotes decentralised exchanges."
+        },
+        "description": {
+          "en": "Swap your crypto with ParaSwap that aggregates and provides the best quotes decentralised exchanges."
+        }
+      },
+      "permissions": [
+        {
+          "method": "account.list",
+          "params": {
+            "currencies": ["ethereum", "bsc"]
+          }
+        },
+        {
+          "method": "account.request",
+          "params": {
+            "currencies": ["ethereum", "bsc"]
+          }
+        },
+        {
+          "method": "transaction.sign",
+          "params": {
+            "nanoApp": ["paraswap"]
+          }
+        },
+        {
+          "method": "transaction.broadcast"
+        }
+      ],
+      "domains": ["https://*"]
+    },
+      {
+      "id": "paraswap v5",
+      "name": "ParaSwap v5",
+      "url": "https://dapp-browser.apps.ledger.com/?params=%7B%22dappUrl%22%3A%22https%3A%2F%2Fv5.paraswap.io%2Fledger-live%22%2C%22nanoApp%22%3A%22Paraswap%22%2C%22dappName%22%3A%22ParaSwap%22%2C%22networks%22%3A%5B%7B%22currency%22%3A%22ethereum%22%2C%22chainID%22%3A1%2C%22nodeURL%22%3A%22wss%3A%2F%2Feth-mainnet.ws.alchemyapi.io%2Fv2%2F0fyudoTG94QWC0tEtfJViM9v2ZXJuij2%22%7D%2C%7B%22currency%22%3A%22bsc%22%2C%22chainID%22%3A56%2C%22nodeURL%22%3A%22https%3A%2F%2Fbsc-dataseed.binance.org%2F%22%7D%2C%7B%22currency%22%3A%20%22polygon%22%2C%22chainID%22%3A%20137%2C%22nodeURL%22%3A%20%22https%3A%2F%2Fpolygon-mainnet.g.alchemy.com%2Fv2%2FoPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE%22%7D%5D%7D",
+      "params": {
+        "dappUrl": "https://v5.paraswap.io/?referrer=ledger2&embed=true&enableStaking=false&displayMenu=false",
+        "nanoApp": "Paraswap",
+        "dappName": "ParaSwap",
+        "networks": [
+          {
+            "currency": "ethereum",
+            "chainID": 1,
+            "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+          },
+          {
+            "currency": "bsc",
+            "chainID": 56,
+            "nodeURL": "https://bsc-dataseed.binance.org/"
+          },
+          {
+            "currency": "polygon",
+            "chainID": 137,
+            "nodeURL": "https://polygon-mainnet.g.alchemy.com/v2/oPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE"
+          }
+        ]
+      },
+      "homepageUrl": "https://paraswap.io",
+      "supportUrl": "https://paraswap.io",
+      "icon": "https://cdn.live.ledger.com/icons/platform/paraswap.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "experimental",
+      "categories": ["swap", "defi"],
+      "currencies": ["ethereum", "bsc"],
+      "content": {
+        "shortDescription": {
+          "en": "Swap your crypto with ParaSwap that aggregates and provides the best quotes decentralised exchanges."
+        },
+        "description": {
+          "en": "Swap your crypto with ParaSwap that aggregates and provides the best quotes decentralised exchanges."
+        }
+      },
+      "permissions": [
+        {
+          "method": "account.list",
+          "params": {
+            "currencies": ["ethereum", "bsc"]
+          }
+        },
+        {
+          "method": "account.request",
+          "params": {
+            "currencies": ["ethereum", "bsc"]
+          }
+        },
+        {
+          "method": "transaction.sign",
+          "params": {
+            "nanoApp": ["paraswap"]
+          }
+        },
+        {
+          "method": "transaction.broadcast"
+        }
+      ],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "lido",
+      "name": "Lido",
+      "url": "https://dapp-browser.apps.ledger.com/?params=%7B%22dappUrl%22%3A%22https%3A%2F%2Fstake.lido.fi%2F%3Fref%3D0x558247e365be655f9144e1a0140D793984372Ef3%26embed%3Dtrue%22%2C%22nanoApp%22%3A%22Lido%22%2C%22dappName%22%3A%22Lido%22%2C%22networks%22%3A%5B%7B%22currency%22%3A%22ethereum%22%2C%22chainID%22%3A1%2C%22nodeURL%22%3A%22wss%3A%2F%2Feth-mainnet.ws.alchemyapi.io%2Fv2%2F0fyudoTG94QWC0tEtfJViM9v2ZXJuij2%22%7D%5D%7D",
+      "params": {
+        "dappUrl": "https://stake.lido.fi/?ref=0x558247e365be655f9144e1a0140D793984372Ef3&embed=true",
+        "nanoApp": "Lido",
+        "dappName": "Lido",
+        "networks": [
+          {
+            "currency": "ethereum",
+            "chainID": 1,
+            "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+          }
+        ]
+      },
+      "homepageUrl": "https://lido.fi/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/lido.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["staking", "defi"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Stake your ETH with Lido to earn daily staking rewards."
+        },
+        "description": {
+          "en": "Stake your ETH with Lido to earn daily staking rewards."
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "1inch",
+      "name": "1inch",
+      "url": "https://dapp-browser.apps.ledger.com/?params=%7B%22dappUrl%22%3A%22https%3A%2F%2Fapp.1inch.io%2F%3FledgerLive%3Dtrue%22%2C%22nanoApp%22%3A%221inch%22%2C%22dappName%22%3A%221inch%22%2C%22networks%22%3A%5B%7B%22currency%22%3A%22ethereum%22%2C%22chainID%22%3A1%2C%22nodeURL%22%3A%22wss%3A%2F%2Feth-mainnet.ws.alchemyapi.io%2Fv2%2F0fyudoTG94QWC0tEtfJViM9v2ZXJuij2%22%7D%2C%7B%22currency%22%3A%22bsc%22%2C%22chainID%22%3A56%2C%22nodeURL%22%3A%22https%3A%2F%2Fbsc-dataseed.binance.org%2F%22%7D%2C%7B%22currency%22%3A%20%22polygon%22%2C%22chainID%22%3A%20137%2C%22nodeURL%22%3A%20%22https%3A%2F%2Fpolygon-mainnet.g.alchemy.com%2Fv2%2FoPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE%22%7D%5D%7D",
+      "params": {
+        "dappUrl": "https://app.1inch.io/?ledgerLive=true",
+        "nanoApp": "1inch",
+        "dappName": "1inch",
+        "networks": [
+          {
+            "currency": "ethereum",
+            "chainID": 1,
+            "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+          },
+          {
+            "currency": "bsc",
+            "chainID": 56,
+            "nodeURL": "https://bsc-dataseed.binance.org/"
+          },
+          {
+            "currency": "polygon",
+            "chainID": 137,
+            "nodeURL": "https://polygon-mainnet.g.alchemy.com/v2/oPIxZM7kXsPVVY1Sk0kOQwkoIOpSu8PE"
+          }
+        ]
+      },
+      "homepageUrl": "https://1inch.io/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/1inch.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["swap", "defi"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Exchange crypto via a Defi/DEX aggregator on Ethereum mainnet, BSC or Polygon"
+        },
+        "description": {
+          "en": "Exchange crypto via a Defi/DEX aggregator on Ethereum mainnet, BSC or Polygon"
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "btcdirect",
+      "name": "BTC Direct",
+      "url": "https://ledger.btcdirect.eu/",
+      "homepageUrl": "https://btcdirect.eu/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/btcdirect.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["buy"],
+      "currencies": ["bitcoin", "bitcoin_cash", "ethereum", "litecoin", "ripple"],
+      "content": {
+        "shortDescription": {
+          "en": "Buy crypto easily and quickly from your Ledger Live via BTC Direct."
+        },
+        "description": {
+          "en": "Buy crypto easily and quickly from your Ledger Live via BTC Direct."
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "banxa",
+      "name": "Banxa",
+      "url": "https://ledger.banxa.com/",
+      "homepageUrl": "https://banxa.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/banxa.png",
+      "platform": "desktop",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["buy"],
+      "currencies": ["ethereum", "bitcoin", "litecoin", "ripple", "tether"],
+      "content": {
+        "shortDescription": {
+          "en": "Banxa supports the widest choice of payment options locally and globally, enabling people to purchase crypto"
+        },
+        "description": {
+          "en": "Banxa supports the widest choice of payment options locally and globally, enabling people to purchase crypto"
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "bitrefill",
+      "name": "Bitrefill",
+      "url": "https://embed.bitrefill.com/buy/?utm_source=ledger_live&paymentMethods=bitcoin,ethereum,litecoin,dogecoin&ref=ftbYHzmt",
+      "homepageUrl": "https://bitrefill.com",
+      "icon": "https://cdn.live.ledger.com/icons/platform/bitrefill.png",
+      "platform": "desktop",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["gift cards"],
+      "currencies": ["bitcoin", "ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Buy gift cards and top up airtime"
+        },
+        "description": {
+          "en": "Buy gift cards and top up airtime with Bitcoin and Ethereum"
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "mercuryo",
+      "name": "Mercuryo",
+      "url": "https://exchange.mercuryo.io/?widget_id=13806834-fd92-460c-b8a4-14b58a09b2a6&fix_currency=true&ledger=true&type=buy&hide_address=true",
+      "homepageUrl": "https://www.mercuryo.io/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/mercuryo.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["buy", "sell"],
+      "currencies": [
+        "bitcoin",
+        "ethereum",
+        "algorand",
+        "bitcoin cash",
+        "binance coin",
+        "tron",
+        "tether"
+      ],
+      "content": {
+        "shortDescription": {
+          "en": "Buy and sell crypto in a heartbeat."
+        },
+        "description": {
+          "en": "Mercuryo widget allows you to seamlessly buy crypto, supporting dozens of local payment methods and currencies. Liquidity, chargebacks, support, anti-fraud, and KYC checks included."
+        }
+      },
+      "permissions": [],
+      "domains": []
+    },
+    {
+      "id": "wyre_buy",
+      "name": "Wyre",
+      "url": "https://platform.apps.ledger.com/app/wyre",
+      "homepageUrl": "https://www.sendwyre.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/wyre.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["exchange", "buy"],
+      "currencies": ["ethereum", "bitcoin", "algorand"],
+      "content": {
+        "shortDescription": {
+          "en": "Purchase Bitcoin, Ethereum and more crypto with Wyre, only available to our US customers."
+        },
+        "description": {
+          "en": "Purchase Bitcoin, Ethereum and more crypto with Wyre, only available to our US customers."
+        }
+      },
+      "permissions": [
+        {
+          "method": "account.request",
+          "params": {
+            "currencies": ["ethereum", "bitcoin", "algorand"]
+          }
+        }
+      ],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "zerion",
+      "name": "Zerion",
+      "url": "https://dapp-browser.apps.ledger.com/?params=%7B%22dappUrl%22%3A%22https%3A%2F%2Fapp.zerion.io%2F%3Fembed%3Dledgerdappbrowser%22%2C%22nanoApp%22%3A%22Paraswap%22%2C%22dappName%22%3A%22Zerion%22%2C%22networks%22%3A%5B%7B%22currency%22%3A%22ethereum%22%2C%22chainID%22%3A1%2C%22nodeURL%22%3A%22wss%3A%2F%2Feth-mainnet.ws.alchemyapi.io%2Fv2%2F0fyudoTG94QWC0tEtfJViM9v2ZXJuij2%22%7D%5D%7D",
+      "params": {
+        "dappUrl": "https://app.zerion.io/?embed=ledgerdappbrowser",
+        "nanoApp": "Paraswap",
+        "dappName": "Zerion",
+        "networks": [
+          {
+            "currency": "ethereum",
+            "chainID": 1,
+            "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+          }
+        ]
+      },
+      "homepageUrl": "https://zerion.io/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/zerion.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["portfolio", "defi"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "The smart way to manage your DeFi portfolio."
+        },
+        "description": {
+          "en": "The smart way to manage your DeFi portfolio."
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "rainbow",
+      "name": "Rainbow.me",
+      "url": "https://platform.apps.ledger.com/app/web-browser?url=https%3A%2F%2Frainbow.me%2F%7Baccount.address%7D&currencies=ethereum&webAppName=Rainbow.me",
+      "homepageUrl": "https://rainbow.me",
+      "icon": "https://cdn.live.ledger.com/icons/platform/rainbow.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["nft"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "An easy way to visualize the NFT secured by your hardware wallet."
+        },
+        "description": {
+          "en": "An easy way to visualize the NFT secured by your hardware wallet."
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "poap",
+      "name": "POAP",
+      "url": "https://platform.apps.ledger.com/app/web-browser?url=https%3A%2F%2Fapp.poap.xyz%2Fscan%2F%7Baccount.address%7D&currencies=ethereum&webAppName=Poap",
+      "homepageUrl": "https://app.poap.xyz/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/poap.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "stable",
+      "categories": ["nft", "defi"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Proof of Attendance Protocol"
+        },
+        "description": {
+          "en": "The Proof of attendance protocol (POAP) reminds you of the cool places you’ve been to."
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "aave",
+      "name": "Aave",
+      "url": "",
+      "homepageUrl": "https://aave.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/aave.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "soon",
+      "categories": ["lend"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Lend or Borrow your crypto through a liquidity market protocol and stay in control of your funds."
+        },
+        "description": {
+          "en": "Lend or Borrow your crypto through a liquidity market protocol and stay in control of your funds."
+        }
+      },
+      "permissions": [],
+      "domains": []
+    },
+    {
+      "id": "compound",
+      "name": "Compound",
+      "url": "",
+      "homepageUrl": "https://compound.finance/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/compound.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "soon",
+      "categories": ["lend", "compound"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Lend or Borrow your crypto via a completely decentralized and open-source protocol."
+        },
+        "description": {
+          "en": "Lend or Borrow your crypto via a completely decentralized and open-source protocol."
+        }
+      },
+      "permissions": [],
+      "domains": []
+    },
+    {
+      "id": "alkemi",
+      "name": "Alkemi",
+      "url": "",
+      "homepageUrl": "https://alkemi.network/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/alkemi.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "soon",
+      "categories": ["lend"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Earn high yields on your assets with our professional DeFi borrowing and lending platform."
+        },
+        "description": {
+          "en": "Earn high yields on your assets with our professional DeFi borrowing and lending platform."
+        }
+      },
+      "permissions": [],
+      "domains": []
+    },
+    {
+      "id": "deversifi",
+      "name": "DeversiFi",
+      "url": "",
+      "homepageUrl": "https://www.deversifi.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/deversifi.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "soon",
+      "categories": ["dex"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Trade through a self-custody decentralized exchange on Ethereum layer-2."
+        },
+        "description": {
+          "en": "Trade through a self-custody decentralized exchange on Ethereum layer-2."
+        }
+      },
+      "permissions": [],
+      "domains": []
+    },
+    {
+      "id": "yearn",
+      "name": "Yearn",
+      "url": "https://dapp-browser.apps.ledger.com",
+      "params": {
+        "dappUrl": "https://beta.yearn.finance?embed=true",
+        "nanoApp": "Yearn",
+        "dappName": "Yearn",
+        "networks": [
+          {
+            "currency": "ethereum",
+            "chainID": 1,
+            "nodeURL": "wss://eth-mainnet.ws.alchemyapi.io/v2/0fyudoTG94QWC0tEtfJViM9v2ZXJuij2"
+          }
+        ]
+      },
+      "homepageUrl": "https://beta.yearn.finance",
+      "icon": "https://cdn.live.ledger.com/icons/platform/yearn.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "experimental",
+      "categories": ["staking", "defi"],
+      "currencies": ["ethereum"],
+      "content": {
+        "shortDescription": {
+          "en": "Generate yield automatically with Yearn products"
+        },
+        "description": {
+          "en": "Generate yield automatically with Yearn products"
+        }
+      },
+      "permissions": [],
+      "domains": ["https://*"]
+    },
+    {
+    "id": "changenow",
+    "name": "ChangeNOW",
+    "url": "https://changenow.io/ledger",
+    "homepageUrl": "https://changenow.io/",
+    "icon": "https://content-api.changenow.io/uploads/changenow_3fec68652e.png",
+    "platform": "all",
+    "apiVersion": "0.0.1",
+    "manifestVersion": "1",
+    "branch": "experimental",
+    "categories": ["swap"],
+    "currencies": [
+      "bitcoin",
+      "ethereum"
+    ],
+    "content": {
+      "shortDescription": {
+        "en": "Exchange 300+ coins and tokens free of limits",
+        "fr": "Échangez plus de 300 pièces et jetons sans limites",
+        "es": "Intercambia más de 300 monedas y tokens sin límites",
+        "ru": "Обменивайте 300+ монет и токенов без ограничений",
+        "zh": "无限制地兑换 300 多个硬币和代币",
+        "de": "Tauschen Sie über 300 Münzen und Token ohne Limits ein",
+        "tr": "300'den fazla jeton ve jetonu sınırsız olarak değiştirin",
+        "jp": "300以上のコインとトークンを制限なしで交換します",
+        "kr": "300개 이상의 코인과 토큰을 무제한으로 교환"
+      },
+      "description": {
+        "en": "ChangeNOW is a limitless crypto exchange and processing service offering fast crypto swaps with no hidden fees. It supports a wide range of assets including over 300 cryptocurrencies. The transactions start from $2, have no upper limit, and take about 5 minutes to complete.",
+        "fr": "ChangeNOW est un service d’échange et de traitement de crypto-monnaies illimité offrant des échanges de crypto-monnaies rapides sans frais cachés. Il prend en charge un large éventail d’actifs, notamment plus de 300 devises cryptographiques. Les transactions commencent à partir de 2 $, n’ont pas de limite supérieure et prennent environ 5 minutes.",
+        "es": "ChangeNOW es un servicio ilimitado de procesamiento y intercambio de cifrado que ofrece intercambios de cifrado rápidos sin tarifas ocultas. Admite una amplia gama de activos que incluyen más de 300 criptomonedas y más. Las transacciones comienzan desde $ 2 dólares, no tienen límite superior y tardan unos 5 minutos en completarse.",
+        "ru": "ChangeNOW - это безграничный сервис обмена и обработки криптовалют, предлагающий быстрые обмены криптовалют без скрытых комиссий. Он поддерживает широкий спектр активов из более чем более 300 криптовалют. Транзакции начинаются с 2 долларов, не имеют верхнего предела и занимают около 5 минут.",
+        "zh": "ChangeNOW 是一种无限的加密交换和处理服务，提供快速的加密交换，没有隐藏费用。 它支持广泛的资产，包括 300 多种加密货币。 交易从 2 美元起，没有上限，大约需要 5 分钟才能完成。",
+        "de": "ChangeNOW ist ein grenzenloser Krypto-Austausch- und Verarbeitungsservice, der schnelle Krypto-Swaps ohne versteckte Gebühren anbietet. Es unterstützt eine breite Palette von über 300 Kryptowährungen. Die Transaktionen beginnen bei 2 $, haben keine Obergrenze und dauern etwa 5 Minuten.",
+        "tr": "ChangeNOW, gizli ücretler olmadan hızlı kripto takasları sunan sınırsız bir kripto değişimi ve işleme hizmetidir. 300'den fazla kripto para birimi dahil olmak üzere çok çeşitli varlıkları destekler. İşlemler 2 dolardan başlar, üst limiti yoktur ve tamamlanması yaklaşık 5 dakika sürer.",
+        "jp": "ChangeNOWは、隠れた料金なしで高速暗号スワップを提供する無制限の暗号交換および処理サービスです。 300以上の暗号通貨を含む幅広い資産をサポートします。 トランザクションは$ 2から始まり、上限はなく、完了するまでに約5分かかります。",
+        "kr": "ChangeNOW는 숨겨진 수수료 없이 빠른 암호화 스왑을 제공하는 무제한 암호화 교환 및 처리 서비스입니다. 300개 이상의 암호화폐를 포함한 광범위한 자산을 지원합니다. 거래는 $2부터 시작하며 상한선이 없으며 완료하는 데 약 5분이 걸립니다."
+      }
+    },
+    "permissions": [
+      {
+        "method": "*"
+      }
+    ],
+    "domains": ["https://*"]
+    },
+    {
+      "id": "mercuryo",
+      "name": "Mercuryo",
+      "url": "https://exchange.mercuryo.io/?widget_id=13806834-fd92-460c-b8a4-14b58a09b2a6&fix_currency=true&ledger=true&type=buy&hide_address=true",
+      "homepageUrl": "https://www.mercuryo.io/",
+      "icon": "https://inlnk.ru/84PnYo",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "experimental",
+      "categories": ["buy", "sell"],
+      "currencies": [
+        "bitcoin",
+        "ethereum",
+        "algorand",
+        "bitcoin cash",
+        "binance coin",
+        "tron",
+        "tether"
+      ],
+      "content": {
+        "shortDescription": {
+          "en": "Buy and sell crypto in a heartbeat."
+        },
+        "description": {
+          "en": "Mercuryo widget allows you to seamlessly buy and sell crypto, supporting dozens of local payment methods and currencies. Liquidity, chargebacks, support, anti-fraud, and KYC checks included."
+        }
+      },
+      "permissions": [],
+      "domains": []
+    },
+    {
+      "id": "transak",
+      "name": "Transak",
+      "url": "https://global.transak.com?apiKey=e95c1914-e525-4d85-870e-0e7297baedf9&isFeeCalculationHidden=true",
+      "homepageUrl": "https://transak.com",
+      "icon": "https://d1wvnwyfte65eg.cloudfront.net/logo_main.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "experimental",
+      "categories": ["tools"],
+      "currencies": [
+        "bitcoin",
+        "ethereum",
+        "algorand",
+        "ripple",
+        "cosmos",
+        "tezos",
+        "polkadot",
+        "stellar",
+        "tron"
+      ],
+      "content": {
+        "shortDescription": {
+          "en": "Buy 80+ different cryptocurrencies easily by card or bank transfer. Transak accepts over 45 fiat currencies from 115 countries and territories."
+        },
+        "description": {
+          "en": "Buy 80+ different cryptocurrencies easily by card or bank transfer. Transak accepts over 45 fiat currencies from 115 countries and territories."
+        }
+      },
+      "permissions": [
+        {
+          "method": "*"
+        }
+      ],
+      "domains": ["https://*"]
+    },
+    {
+      "id": "debug",
+      "name": "Debugger",
+      "url": "https://debug.apps.ledger.com/",
+      "homepageUrl": "https://developers.ledger.com/",
+      "icon": "https://cdn.live.ledger.com/icons/platform/debugger.png",
+      "platform": "all",
+      "apiVersion": "0.0.1",
+      "manifestVersion": "1",
+      "branch": "debug",
+      "categories": ["tools"],
+      "currencies": "*",
+      "content": {
+        "shortDescription": {
+          "en": "Try out the Ledger Live API to test capabilities of our platform integration solution. Use at your own risk."
+        },
+        "description": {
+          "en": "Try out the Ledger Live API to test capabilities of our platform integration solution. Use at your own risk."
+        }
+      },
+      "permissions": [
+        {
+          "method": "*"
+        }
+      ],
+      "domains": ["https://*"]
+    }
+]

--- a/src/platform/providers/LiveAppProvider/index.tsx
+++ b/src/platform/providers/LiveAppProvider/index.tsx
@@ -1,0 +1,104 @@
+import { access } from "fs";
+import React, {
+  useContext,
+  useEffect,
+  createContext,
+  useMemo,
+  useState,
+  useCallback,
+} from "react";
+import { Loadable, LiveAppManifest, LiveAppRegistry } from "./types";
+
+import api from "./api";
+
+const initialState: Loadable<LiveAppRegistry> = {
+  isLoading: false,
+  value: null,
+  error: null,
+};
+
+type LiveAppContextType = {
+  state: Loadable<LiveAppRegistry>;
+  updateManifests: () => Promise<void>;
+};
+
+export const liveAppContext = createContext<LiveAppContextType>({
+  state: initialState,
+  updateManifests: () => Promise.resolve(),
+});
+
+type LiveAppProviderProps = {
+  children: React.ReactNode;
+  provider: string;
+  updateFrequency: number;
+};
+
+export function useLiveAppManifest(appId: string): LiveAppManifest | undefined {
+  const liveAppRegistry = useContext(liveAppContext).state;
+
+  if (!liveAppRegistry.value) {
+    return undefined;
+  }
+
+  return liveAppRegistry.value.liveAppById[appId];
+}
+
+export function LiveAppProvider({
+  children,
+  provider,
+  updateFrequency,
+}: LiveAppProviderProps): JSX.Element {
+  const [state, setState] = useState<Loadable<LiveAppRegistry>>(initialState);
+
+  console.log("LiveAppProvider", { state });
+  const updateManifests = useCallback(async () => {
+    setState((currentState) => ({
+      ...currentState,
+      isLoading: true,
+      error: null,
+    }));
+
+    try {
+      const allManifests = await api.fetchLiveAppManifests(provider);
+      setState(() => ({
+        isLoading: false,
+        value: {
+          liveAppByIndex: allManifests,
+          liveAppById: allManifests.reduce((acc, liveAppManifest) => {
+            acc[liveAppManifest.id] = liveAppManifest;
+            return access;
+          }, {}),
+        },
+        error: null,
+      }));
+    } catch (error) {
+      setState((currentState) => ({
+        ...currentState,
+        isLoading: false,
+        error,
+      }));
+    }
+  }, [provider]);
+
+  const value: LiveAppContextType = useMemo(
+    () => ({
+      state,
+      updateManifests,
+    }),
+    [state, updateManifests]
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      updateManifests();
+    }, updateFrequency);
+    updateManifests();
+    return () => {
+      clearInterval(interval);
+    };
+  }, [updateFrequency, updateManifests]);
+
+  return (
+    <liveAppContext.Provider value={value}>{children}</liveAppContext.Provider>
+  );
+}

--- a/src/platform/providers/LiveAppProvider/index.tsx
+++ b/src/platform/providers/LiveAppProvider/index.tsx
@@ -50,7 +50,6 @@ export function LiveAppProvider({
 }: LiveAppProviderProps): JSX.Element {
   const [state, setState] = useState<Loadable<LiveAppRegistry>>(initialState);
 
-  console.log("LiveAppProvider", { state });
   const updateManifests = useCallback(async () => {
     setState((currentState) => ({
       ...currentState,

--- a/src/platform/providers/LiveAppProvider/types.ts
+++ b/src/platform/providers/LiveAppProvider/types.ts
@@ -1,0 +1,43 @@
+export type Loadable<T> = {
+  error: any | null;
+  isLoading: boolean;
+  value: T | null;
+};
+
+export type AppPlatform =
+  | "desktop" // == windows || mac || linux
+  | "mobile" // == android || ios
+  | "all";
+
+export type AppBranch = "stable" | "experimental" | "soon" | "debug";
+
+export type LiveAppPermission = {
+  method: string;
+  params?: any;
+};
+
+export type LiveAppManifest = {
+  id: string;
+  private?: boolean;
+  name: string;
+  url: string;
+  params?: string[];
+  homepageUrl: string;
+  supportUrl?: string;
+  icon?: string | null;
+  platform: AppPlatform;
+  apiVersion: string;
+  manifestVersion: string;
+  branch: AppBranch;
+  permissions: LiveAppPermission[];
+  domains: string[];
+};
+
+export type LiveAppRegistry = {
+  liveAppById: { [appId: string]: LiveAppManifest };
+  liveAppByIndex: LiveAppManifest[];
+};
+
+export type LiveAppDataAPI = {
+  fetchLiveAppManifests: (url: string) => Promise<LiveAppManifest[]>;
+};

--- a/src/platform/providers/RampCatalogProvider/api/index.ts
+++ b/src/platform/providers/RampCatalogProvider/api/index.ts
@@ -1,0 +1,42 @@
+import network from "../../../../network";
+import { getEnv } from "../../../../env";
+import type { RampCatalog } from "../types";
+import mockData from "./mock.json";
+
+export const providers = [
+  {
+    value: "production",
+    url: getEnv("PLATFORM_RAMP_CATALOG_API_URL"),
+  },
+  {
+    value: "staging",
+    url: getEnv("PLATFORM_RAMP_CATALOG_STAGING_API_URL"),
+  },
+];
+
+export function getProviderURL(value: string): string {
+  const provider = providers.find((provider) => provider.value === value);
+
+  if (!provider) {
+    throw new Error(`remote ramp catalog provider "${value}" not found`);
+  }
+  return provider.url;
+}
+
+const api = {
+  fetchRampCatalog: async (provider: string): Promise<RampCatalog> => {
+    if (getEnv("MOCK")) {
+      return mockData as RampCatalog;
+    }
+
+    const { data } = await network({
+      method: "GET",
+      headers: {
+        Origin: "http://localhost:3000",
+      },
+      url: getProviderURL(provider),
+    });
+    return data as RampCatalog;
+  },
+};
+export default api;

--- a/src/platform/providers/RampCatalogProvider/api/mock.json
+++ b/src/platform/providers/RampCatalogProvider/api/mock.json
@@ -1,0 +1,41 @@
+{
+  "onRamp": [
+    {
+      "appId": "coinify",
+      "name": "Coinify",
+      "paymentProviders": ["visa", "mastercard", "maestro", "paypal", "sepa"],
+      "cryptoCurrencies": ["bitcoin", "ethereum"],
+      "fiatCurrencies": ["euro", "usd"]
+    },
+    {
+      "appId": "btcdirect",
+      "name": "BTC Direct",
+      "paymentProviders": ["visa", "mastercard", "maestro", "paypal"],
+      "cryptoCurrencies": ["bitcoin", "ethereum"],
+      "fiatCurrencies": ["euro", "usd"]
+    },
+    {
+      "appId": "moonpay",
+      "name": "MoonPay",
+      "paymentProviders": ["visa", "mastercard", "maestro", "applepay", "googlepay"],
+      "cryptoCurrencies": ["bitcoin", "ethereum"],
+      "fiatCurrencies": ["euro", "usd"]
+    },
+    {
+      "appId": "wyre",
+      "name": "Wyre",
+      "paymentProviders": ["visa", "mastercard", "maestro", "applepay", "googlepay"],
+      "cryptoCurrencies": ["bitcoin", "ethereum"],
+      "fiatCurrencies": ["euro", "usd"]
+    }
+  ],
+  "offRamp": [
+    {
+      "appId": "coinify",
+      "name": "Coinify",
+      "paymentProviders": ["sepa"],
+      "cryptoCurrencies": ["bitcoin", "ethereum"],
+      "fiatCurrencies": ["euro", "usd"]
+    }
+  ] 
+}

--- a/src/platform/providers/RampCatalogProvider/helpers.ts
+++ b/src/platform/providers/RampCatalogProvider/helpers.ts
@@ -1,0 +1,47 @@
+import _ from "lodash";
+import { RampCatalogEntry } from "./types";
+
+export type RampFilters = {
+  fiatCurrencies?: string[];
+  cryptoCurrencies?: string[];
+  paymentProviders?: string[];
+};
+
+function filterArray(array: string[], filters: string[]) {
+  return filters.every((filter) => array.includes(filter));
+}
+
+export function filterRampCatalogEntries(
+  entries: RampCatalogEntry[],
+  filters: RampFilters
+): RampCatalogEntry[] {
+  return entries.filter((entry) => {
+    if (
+      filters.cryptoCurrencies &&
+      !filterArray(entry.cryptoCurrencies, filters.cryptoCurrencies)
+    ) {
+      return false;
+    }
+
+    if (
+      filters.fiatCurrencies &&
+      !filterArray(entry.fiatCurrencies, filters.fiatCurrencies)
+    ) {
+      return false;
+    }
+
+    if (
+      filters.paymentProviders &&
+      !filterArray(entry.paymentProviders, filters.paymentProviders)
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+export function getAllSupportedCryptoCurrencies(
+  entries: RampCatalogEntry[]
+): string[] {
+  return _.uniq(_.flatten(entries.map((entry) => entry.cryptoCurrencies)));
+}

--- a/src/platform/providers/RampCatalogProvider/index.tsx
+++ b/src/platform/providers/RampCatalogProvider/index.tsx
@@ -1,0 +1,95 @@
+import React, {
+  useContext,
+  useEffect,
+  createContext,
+  useMemo,
+  useState,
+  useCallback,
+} from "react";
+import { Loadable, RampCatalog } from "./types";
+import api from "./api";
+
+const initialState: Loadable<RampCatalog> = {
+  isLoading: false,
+  value: null,
+  error: null,
+};
+
+export type RampCatalogDataAPI = {
+  fetchRampCatalog: () => Promise<RampCatalog>;
+};
+
+type RampCatalogContextType = {
+  state: Loadable<RampCatalog>;
+  updateCatalog: () => Promise<void>;
+};
+
+export const rampCatalogContext = createContext<RampCatalogContextType>({
+  state: initialState,
+  updateCatalog: () => Promise.resolve(),
+});
+
+type RampCatalogProviderProps = {
+  children: React.ReactNode;
+  provider: string;
+  updateFrequency: number;
+};
+
+export function useRampCatalog(): Loadable<RampCatalog> {
+  return useContext(rampCatalogContext).state;
+}
+
+export function RampCatalogProvider({
+  children,
+  provider,
+  updateFrequency,
+}: RampCatalogProviderProps): JSX.Element {
+  const [state, setState] = useState<Loadable<RampCatalog>>(initialState);
+
+  const updateCatalog = useCallback(async () => {
+    setState((currentState) => ({
+      ...currentState,
+      isLoading: true,
+      error: null,
+    }));
+
+    try {
+      const value = await api.fetchRampCatalog(provider);
+      setState(() => ({
+        isLoading: false,
+        value,
+        error: null,
+      }));
+    } catch (error) {
+      setState((currentState) => ({
+        ...currentState,
+        isLoading: false,
+        error,
+      }));
+    }
+  }, [provider]);
+
+  const value: RampCatalogContextType = useMemo(
+    () => ({
+      state,
+      updateCatalog,
+    }),
+    [state, updateCatalog]
+  );
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      updateCatalog();
+    }, updateFrequency);
+    updateCatalog();
+    return () => {
+      clearInterval(interval);
+    };
+  }, [updateFrequency, updateCatalog]);
+
+  return (
+    <rampCatalogContext.Provider value={value}>
+      {children}
+    </rampCatalogContext.Provider>
+  );
+}

--- a/src/platform/providers/RampCatalogProvider/types.ts
+++ b/src/platform/providers/RampCatalogProvider/types.ts
@@ -1,0 +1,29 @@
+export type Loadable<T> = {
+  error: any | null;
+  isLoading: boolean;
+  value: T | null;
+};
+
+export interface GenericRampCatalogEntry {
+  name: string;
+  paymentProviders: string[];
+  cryptoCurrencies: string[];
+  fiatCurrencies: string[];
+}
+
+export interface RampLiveAppCatalogEntry extends GenericRampCatalogEntry {
+  type: "LIVE_APP";
+  appId: string;
+}
+
+export interface RampNativeCatalogEntry extends GenericRampCatalogEntry {
+  type: "NATIVE";
+  path: string;
+}
+
+export type RampCatalogEntry = RampLiveAppCatalogEntry | RampNativeCatalogEntry;
+
+export type RampCatalog = {
+  onRamp: RampCatalogEntry[];
+  offRamp: RampCatalogEntry[];
+};

--- a/src/types/manager.ts
+++ b/src/types/manager.ts
@@ -30,6 +30,7 @@ export type DeviceInfo = {
   mcuBlVersion?: string;
   mcuTargetId?: number;
   seTargetId?: number;
+  onboarded?: boolean;
 };
 export type DeviceModelInfo = {
   modelId: DeviceModelId;


### PR DESCRIPTION
## Context (issues, jira)

Added three new data providers to be used for live apps:
- Live App Provider: Provide data about live apps and their manifests
- Discover Provider: Provide data about the discover section (catalog)
- Ramp Provider: Provide data about the multibuy catalog

## Description / Usage

This is non-breaking because the old all-in-one provider is still available. Clients are expected to migrate to this new system with the multibuy and discover v2 implementations.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
