### PR TITLE
Uses balance from backend even if no txs

### DIFF
--- a/src/families/ethereum/synchronisation.ts
+++ b/src/families/ethereum/synchronisation.ts
@@ -59,20 +59,23 @@ export const getAccountShape: GetAccountShape = async (
   const txsP = fetchAllTransactions(api, address, pullFromBlockHash);
   const currentBlockP = fetchCurrentBlock(currency);
   const balanceP = api.getAccountBalance(address);
-  const [txs, currentBlock] = await Promise.all([txsP, currentBlockP]);
+  const [txs, currentBlock, balance] = await Promise.all([
+    txsP,
+    currentBlockP,
+    balanceP,
+  ]);
   const blockHeight = currentBlock.height.toNumber();
 
   if (!pullFromBlockHash && txs.length === 0) {
     log("ethereum", "no ops on " + address);
     return {
       id: accountId,
-      balance: new BigNumber(0),
+      balance,
       subAccounts: [],
       blockHeight,
     };
   }
 
-  const balance = await balanceP;
   // transform transactions into operations
   let newOps = flatMap(txs, txToOps({ address, id: accountId, currency }));
   // extracting out the sub operations by token account


### PR DESCRIPTION
e.g. receive by unsupported internal tx

## Context (issues, jira)

Fixes LIVE-1102

## Description / Usage

Polygon explorers may not index all kind of internal transactions so this is a workaround to still discover accounts while there are no transactions in explorers.
