### PR TITLE
Add a workaround that prevent 2 last operations to be same id

### DIFF
--- a/src/families/cosmos/js-synchronisation.ts
+++ b/src/families/cosmos/js-synchronisation.ts
@@ -177,6 +177,14 @@ export const getAccountShape: GetAccountShape = async (info) => {
   const oldOperations = initialAccount?.operations || [];
   const newOperations = txToOps(info, accountId, txs);
   const operations = mergeOps(oldOperations, newOperations);
+  // Workaround on duplicated operation just after a broadcast
+  if (
+    operations !== oldOperations &&
+    operations.length > 1 &&
+    operations[0].id === operations[1].id
+  ) {
+    operations.splice(0, 1); // remove last operation [0] because it's already present in [1]
+  }
 
   let balance = balances;
   let delegatedBalance = new BigNumber(0);


### PR DESCRIPTION

workaround of a flawky behavior of COSMOS JS
