### PR TITLE
Tezos: Fixes UI issue that would not make the error appear

### DIFF
--- a/src/families/tezos/bridge/js.ts
+++ b/src/families/tezos/bridge/js.ts
@@ -76,7 +76,7 @@ const getTransactionStatus = async (
     feeTooHigh?: Error;
     recipient?: Error;
   } = {};
-  let amountMustReset = false;
+  let resetTotalSpent = false;
 
   // Recipient validation logic
   if (t.mode !== "undelegate") {
@@ -100,7 +100,7 @@ const getTransactionStatus = async (
   const estimatedFees = t.estimatedFees || new BigNumber(0);
   if (t.mode === "send") {
     if (!errors.amount && t.amount.eq(0) && !t.useAllAmount) {
-      amountMustReset = true;
+      resetTotalSpent = true;
       errors.amount = new AmountRequired();
     } else if (t.amount.gt(0) && estimatedFees.times(10).gt(t.amount)) {
       warnings.feeTooHigh = new FeeTooHigh();
@@ -128,7 +128,7 @@ const getTransactionStatus = async (
     // remap taquito errors
     if (t.taquitoError.endsWith("balance_too_low")) {
       if (t.mode === "send") {
-        amountMustReset = true;
+        resetTotalSpent = true;
         errors.amount = new NotEnoughBalance();
       } else {
         errors.amount = new NotEnoughBalanceToDelegate();
@@ -138,12 +138,12 @@ const getTransactionStatus = async (
     } else if (!errors.amount) {
       // unidentified error case
       errors.amount = new Error(t.taquitoError);
-      amountMustReset = true;
+      resetTotalSpent = true;
     }
   }
 
   if (!errors.amount && account.balance.lte(0)) {
-    amountMustReset = true;
+    resetTotalSpent = true;
     errors.amount = new NotEnoughBalance();
   }
 
@@ -154,20 +154,20 @@ const getTransactionStatus = async (
     t.amount.lt(EXISTENTIAL_DEPOSIT) &&
     (await api.getAccountByAddress(t.recipient)).type === "empty"
   ) {
-    amountMustReset = true;
+    resetTotalSpent = true;
     errors.amount = new NotEnoughBalanceBecauseDestinationNotCreated("", {
       minimalAmount: "0.275 XTZ",
     });
   }
 
-  const amount = amountMustReset ? new BigNumber(0) : t.amount;
-
   const result = {
     errors,
     warnings,
     estimatedFees,
-    amount,
-    totalSpent: amount.plus(estimatedFees),
+    amount: t.amount,
+    totalSpent: resetTotalSpent
+      ? new BigNumber(0)
+      : t.amount.plus(estimatedFees),
   };
   return Promise.resolve(result);
 };


### PR DESCRIPTION
`status.amount` must not be set back to 0 even when there is an error, because the UI side (LLD/LLM) **wrongly** use this information as a way to know if user have set or not the field ( https://github.com/LedgerHQ/ledger-live-desktop/blob/develop/src/renderer/modals/Send/fields/AmountField.js#L75 ). Logically, the UI should instead use `transaction.amount`,

but meanwhile here is a fix for Tezos to still set `status.amount` to value `transaction.amount` even if the value is way beyond the account boundaries.
