### PR TITLE
LIVE-1716 async fixes

### DIFF
--- a/src/families/bitcoin/wallet-btc/crypto/bip32.ts
+++ b/src/families/bitcoin/wallet-btc/crypto/bip32.ts
@@ -1,5 +1,6 @@
+import invariant from "invariant";
 import createHmac from "create-hmac";
-import { publicKeyTweakAdd } from "./secp256k1";
+import { getSecp256k1Instance } from "./secp256k1";
 
 // the BIP32 class is inspired from https://github.com/bitcoinjs/bip32/blob/master/src/bip32.js
 class BIP32 {
@@ -15,6 +16,8 @@ class BIP32 {
     depth = 0,
     index = 0
   ) {
+    invariant(publicKey && publicKey.length > 0, "publicKey must not be empty");
+    invariant(chainCode && chainCode.length > 0, "chainCode must not be empty");
     this.publicKey = publicKey;
     this.chainCode = chainCode;
     this.network = network;
@@ -28,7 +31,9 @@ class BIP32 {
     const I = createHmac("sha512", this.chainCode).update(data).digest();
     const IL = I.slice(0, 32);
     const IR = I.slice(32);
-    const Ki = Buffer.from(await publicKeyTweakAdd(this.publicKey, IL));
+    const Ki = Buffer.from(
+      await getSecp256k1Instance().publicKeyTweakAdd(this.publicKey, IL)
+    );
     return new BIP32(Ki, IR, this.network, this.depth + 1, index);
   }
 }

--- a/src/families/bitcoin/wallet-btc/crypto/bitcoin.ts
+++ b/src/families/bitcoin/wallet-btc/crypto/bitcoin.ts
@@ -3,7 +3,7 @@
 import * as bech32 from "bech32";
 import { bech32m } from "../../bech32m";
 import * as bjs from "bitcoinjs-lib";
-import { publicKeyTweakAdd } from "./secp256k1";
+import { getSecp256k1Instance } from "./secp256k1";
 import { InvalidAddress } from "@ledgerhq/errors";
 import { DerivationModes } from "../types";
 import Base from "./base";
@@ -196,7 +196,7 @@ class Bitcoin extends Base {
 
     // Q = P + int(hash_TapTweak(bytes(P)))G
     const outputEcdsaKey = Buffer.from(
-      await publicKeyTweakAdd(evenEcdsaPubkey, tweak)
+      await getSecp256k1Instance().publicKeyTweakAdd(evenEcdsaPubkey, tweak)
     );
     // Convert to schnorr.
     const outputSchnorrKey = outputEcdsaKey.slice(1);

--- a/src/families/bitcoin/wallet-btc/crypto/index.ts
+++ b/src/families/bitcoin/wallet-btc/crypto/index.ts
@@ -16,4 +16,4 @@ export { default as Qtum } from "./qtum";
 export { default as Vertcoin } from "./vtc";
 export { default as ViaCoin } from "./via";
 export { default as Decred } from "./decred";
-export { setSecp256k1Instance, publicKeyTweakAdd } from "./secp256k1";
+export { setSecp256k1Instance, getSecp256k1Instance } from "./secp256k1";

--- a/src/families/bitcoin/wallet-btc/crypto/secp256k1.ts
+++ b/src/families/bitcoin/wallet-btc/crypto/secp256k1.ts
@@ -1,13 +1,32 @@
 import secp256k1 from "secp256k1";
-let secp256k1Instance = secp256k1;
 
-export function setSecp256k1Instance(secp256k1: any): void {
-  secp256k1Instance = secp256k1;
+/**
+ * Implement the subset of secp256k1 that wallet-btc needs to work.
+ * The interface is made asynchronous to be more efficient to run in a renderer thread and defer the cryptography
+ */
+export type Secp256k1Instance = {
+  publicKeyTweakAdd(
+    publicKey: Uint8Array,
+    tweak: Uint8Array
+  ): Promise<Uint8Array>;
+};
+
+// default uses node.js's secp256k1
+let impl: Secp256k1Instance = {
+  publicKeyTweakAdd: (publicKey, tweak) =>
+    Promise.resolve(secp256k1.publicKeyTweakAdd(publicKey, tweak)),
+};
+
+/**
+ * allows to override the default Secp256k1Instance
+ */
+export function setSecp256k1Instance(override: Secp256k1Instance): void {
+  impl = override;
 }
 
-export async function publicKeyTweakAdd(
-  publicKey: Uint8Array,
-  tweak: Uint8Array
-): Promise<number[]> {
-  return Array.from(secp256k1Instance.publicKeyTweakAdd(publicKey, tweak));
+/**
+ * get the current Secp256k1Instance
+ */
+export function getSecp256k1Instance(): Secp256k1Instance {
+  return impl;
 }


### PR DESCRIPTION
- improve typing of secp256k1. contract changed: setSecp256k1Instance + getSecp256k1Instance
- This rework also fixes a bug we had on mobile. LIVE-1716
- improve logic of getPubkeyAt caches. the promises are cached and not their result. this ensure concurrency of calls will wait for the same calculation and avoid some congestion of calls. documented it a bit more.
- add some invariant() to prevent future case of empty publicKey
