### PR TITLE
hotfix(walletconnect): make the walletconnect compatible with all EIP-712 implementations

### DIFF
--- a/src/walletconnect/index.ts
+++ b/src/walletconnect/index.ts
@@ -48,7 +48,9 @@ export const parseCallRequest: Parser = async (account, payload) => {
         data: payload.params[0],
       };
 
-    case "eth_signTypedData":
+    // @dev: Today, `eth_signTypedData` is versionned. We can't only check `eth_signTypedData`
+    //       This regex matches `eth_signTypedData` and `eth_signTypedData_v[0-9]`
+    case payload.method.match(/eth_signTypedData(_v.)?$/)?.input:
       message = JSON.parse(payload.params[1]);
       hashes = {
         // $FlowFixMe


### PR DESCRIPTION
## Context (issues, jira)

The 712 specification has evolved over time. Each time the implementation changed, the community incremented the paylaod_method by 1. At the moment, the current version of the implementation is `eth_signTypedData_v4`. That's why we have to check any method called `eth_signTypedData` with an optional version parameter. Walletconnect is using this method right now when dealing with a signed message.

Without this fix, our implementation of Walletconnect isn't compatible with all implementations of the EIP712.

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
