### PR TITLE
getCompleteSwapHistory modified to avoid returning the same swap operations multiple times

### DIFF
--- a/src/exchange/swap/getCompleteSwapHistory.ts
+++ b/src/exchange/swap/getCompleteSwapHistory.ts
@@ -113,7 +113,7 @@ const getCompleteSwapHistory = (
       day = startOfDay(swap.operation.date);
       data = [swap];
       continue;
-    } else if (!skip) {
+    } else if (!skip && !data.find((d) => d.swapId === swap.swapId)) {
       data.push(swap);
     }
 


### PR DESCRIPTION
getCompleteSwapHistory was returning a section with the same swap operation twice

## Context (issues, jira)



## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
