### PR TITLE
Bugfix: Nfts ops treated in the wrong order to infer balance

### DIFF
--- a/src/families/ethereum/nft.unit.test.ts
+++ b/src/families/ethereum/nft.unit.test.ts
@@ -83,7 +83,11 @@ describe("nft merging", () => {
 
 describe("OpenSea lazy minting bs", () => {
   test("should have a correct on-chain nft amount even with OpenSea lazy minting", () => {
-    const makeNftOperation = (type: Operation["type"], value): Operation => {
+    const makeNftOperation = (
+      type: Operation["type"],
+      value: string | number,
+      dateOrder: number
+    ): Operation => {
       if (!["NFT_IN", "NFT_OUT"].includes(type)) {
         return {} as Operation;
       }
@@ -101,6 +105,7 @@ describe("OpenSea lazy minting bs", () => {
       const fee = new BigNumber(0);
       const tokenId = "42069";
       const hash = "FaKeHasH";
+      const date = new Date(Date.now() + dateOrder ?? 0);
 
       return {
         id,
@@ -114,17 +119,18 @@ describe("OpenSea lazy minting bs", () => {
         value: new BigNumber(value),
         type,
         accountId: id,
+        date,
       } as Operation;
     };
 
     // scenario with bob lazy minting 10 NFTs
     const ops = [
-      makeNftOperation("NFT_OUT", 5), // lazy mint sending 5 NFT
-      makeNftOperation("NFT_IN", 1), // receiving 1 of them back
-      makeNftOperation("NFT_IN", 2), // receiving 2 of them back
-      makeNftOperation("NFT_OUT", 2), // lazy mint sending 5 NFT (transformed by OpenSea in 2 txs) 1/2 (off-chain)
-      makeNftOperation("NFT_OUT", 3), // lazy mint sending 5 NFT (transformed by OpenSea in 2 txs) 2/2 (on-chain)
-      makeNftOperation("NFT_IN", 1), // receiving 1 back
+      makeNftOperation("NFT_OUT", 5, 0), // lazy mint sending 5 NFT
+      makeNftOperation("NFT_IN", 1, 1), // receiving 1 of them back
+      makeNftOperation("NFT_IN", 2, 2), // receiving 2 of them back
+      makeNftOperation("NFT_OUT", 2, 3), // lazy mint sending 5 NFT (transformed by OpenSea in 2 txs) 1/2 (off-chain)
+      makeNftOperation("NFT_OUT", 3, 4), // lazy mint sending 5 NFT (transformed by OpenSea in 2 txs) 2/2 (on-chain)
+      makeNftOperation("NFT_IN", 1, 5), // receiving 1 back
     ];
 
     // What happened for bob:

--- a/src/nft/helpers.ts
+++ b/src/nft/helpers.ts
@@ -15,6 +15,8 @@ import { API, apiForCurrency } from "../api/Ethereum";
 
 export const nftsFromOperations = (ops: Operation[]): ProtoNFT[] => {
   const nftsMap = ops
+    // make sure we have the operation in chronological order (older first)
+    .sort((a, b) => a.date.getTime() - b.date.getTime())
     // if ops are Operations get the prop nftOperations, else ops are considered nftOperations already
     .flatMap((op) => (op?.nftOperations?.length ? op.nftOperations : op))
     .reduce((acc: Record<string, ProtoNFT>, nftOp: Operation) => {


### PR DESCRIPTION
## Context (issues, jira)

Since #1862, where we decided to not follow blindly the value of each operation because of OpenSea lazy minting feature breaking our quantities, we introduced a bug by making the order of each operation important. 

Our operations need to be in chronological order to infer the balance with our new conditions for lazy minting. 

## Description / Usage
<img width="592" alt="Screenshot 2022-04-07 at 17 19 58" src="https://user-images.githubusercontent.com/44363395/162234228-2ae5eda5-3155-4a4c-b1c4-1f51e2da031e.png">

Operations are now sorted by date before anything else.

## Expectations

- [x] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
