### PR TITLE
Fix bch bot and change hash into txid from explorer response

### DIFF
--- a/src/__tests__/families/bitcoin/wallet-btc/xpub.pickingStrategies.integration.test.ts
+++ b/src/__tests__/families/bitcoin/wallet-btc/xpub.pickingStrategies.integration.test.ts
@@ -60,7 +60,7 @@ describe("testing xpub legacy transactions", () => {
     // Initialize the xpub with 2 txs. So that it has 2 utxo
     dataset.xpub.storage.appendTxs([
       {
-        hash: "9e1b337875c21f751e70ee2c2c6ee93d8a6733d0f3ba6d139ae6a0479ebcefb0",
+        id: "9e1b337875c21f751e70ee2c2c6ee93d8a6733d0f3ba6d139ae6a0479ebcefb0",
         inputs: [],
         outputs: [
           {
@@ -93,7 +93,7 @@ describe("testing xpub legacy transactions", () => {
         received_at: "2021-07-28T13:34:17Z",
       },
       {
-        hash: "0b9f98d07eb418fa20573112d3cba6b871d429a06c724a7888ff0886be5213d1",
+        id: "0b9f98d07eb418fa20573112d3cba6b871d429a06c724a7888ff0886be5213d1",
         inputs: [
           {
             output_hash:
@@ -188,7 +188,7 @@ describe("testing xpub legacy transactions", () => {
     // Add 3 txs for the xpub. So that it has 5 utxo
     dataset.xpub.storage.appendTxs([
       {
-        hash: "8f30fe84da5a5846d668b4bad260730f2b0125fa66fb2633fa1cee23c6b11053",
+        id: "8f30fe84da5a5846d668b4bad260730f2b0125fa66fb2633fa1cee23c6b11053",
         inputs: [
           {
             output_hash:
@@ -230,7 +230,7 @@ describe("testing xpub legacy transactions", () => {
         received_at: "2021-07-28T14:46:51Z",
       },
       {
-        hash: "2f90f3312ffd4dce490cb2f7429c586a43ef68c99fc2f8e549127b72af7b4209",
+        id: "2f90f3312ffd4dce490cb2f7429c586a43ef68c99fc2f8e549127b72af7b4209",
         inputs: [
           {
             output_hash:
@@ -272,7 +272,7 @@ describe("testing xpub legacy transactions", () => {
         received_at: "2021-07-28T14:46:51Z",
       },
       {
-        hash: "2fee0c4b55e08583aa5bc565d7e428f7cdcbd2b73262f62208a6a72a74e2c945",
+        id: "2fee0c4b55e08583aa5bc565d7e428f7cdcbd2b73262f62208a6a72a74e2c945",
         inputs: [
           {
             output_hash:

--- a/src/families/bitcoin/js-synchronisation.ts
+++ b/src/families/bitcoin/js-synchronisation.ts
@@ -94,7 +94,7 @@ const mapTxToOperations = (
   changeAddresses: Set<string>
 ): $Shape<Operation[]> => {
   const operations: Operation[] = [];
-  const hash = tx.hash;
+  const txId = tx.id;
   const fee = new BigNumber(tx.fees);
   const blockHeight = tx.block?.height;
   const blockHash = tx.block?.hash;
@@ -189,8 +189,8 @@ const mapTxToOperations = (
 
     type = "OUT";
     operations.push({
-      id: encodeOperationId(accountId, hash, type),
-      hash,
+      id: encodeOperationId(accountId, txId, type),
+      hash: txId,
       type,
       value,
       fee,
@@ -223,8 +223,8 @@ const mapTxToOperations = (
       value = finalAmount;
       type = "IN";
       operations.push({
-        id: encodeOperationId(accountId, hash, type),
-        hash,
+        id: encodeOperationId(accountId, txId, type),
+        hash: txId,
         type,
         value,
         fee,

--- a/src/families/bitcoin/specs.ts
+++ b/src/families/bitcoin/specs.ts
@@ -10,7 +10,11 @@ import { pickSiblings } from "../../bot/specs";
 import { bitcoinPickingStrategy } from "./types";
 import type { MutationSpec, AppSpec } from "../../bot/types";
 import { LowerThanMinimumRelayFee } from "../../errors";
-import { getMinRelayFee, getUTXOStatus } from "./logic";
+import {
+  getMinRelayFee,
+  getUTXOStatus,
+  bchToCashaddrAddressWithoutPrefix,
+} from "./logic";
 import { DeviceModelId } from "@ledgerhq/devices";
 type Arg = Partial<{
   minimalAmount: BigNumber;
@@ -81,7 +85,11 @@ const genericTest = ({
         : txInputs.map((t) => t.address).filter(Boolean),
       recipients: txOutputs
         .filter((o) => o.address && !o.isChange)
-        .map((o) => o.address)
+        .map((o) =>
+          account.currency.id === "bitcoin_cash"
+            ? bchToCashaddrAddressWithoutPrefix(o.address)
+            : o.address
+        )
         .filter(Boolean),
     })
   );
@@ -307,9 +315,6 @@ const bitcoinGold: AppSpec<Transaction> = {
   test: genericTest,
   mutations: bitcoinLikeMutations(),
 };
-
-const bchToCashaddrAddressWithoutPrefix = (recipient) =>
-  bchaddrjs.toCashAddress(recipient).split(":")[1];
 
 const bitcoinCash: AppSpec<Transaction> = {
   name: "Bitcoin Cash",

--- a/src/families/bitcoin/wallet-btc/explorer/index.ts
+++ b/src/families/bitcoin/wallet-btc/explorer/index.ts
@@ -242,7 +242,7 @@ class BitcoinLikeExplorer extends EventEmitter implements IExplorer {
     delete tx.confirmations;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
-    delete tx.id;
+    delete tx.hash;
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore
     delete tx.lock_time;
@@ -269,7 +269,7 @@ class BitcoinLikeExplorer extends EventEmitter implements IExplorer {
       // @ts-ignore
       delete output.script_hex;
       // eslint-disable-next-line no-param-reassign
-      output.output_hash = tx.hash;
+      output.output_hash = tx.id;
       // eslint-disable-next-line no-param-reassign
       output.block_height = tx.block ? tx.block.height : null;
       // Definition of replaceable, per the standard: https://github.com/bitcoin/bips/blob/61ccc84930051e5b4a99926510d0db4a8475a4e6/bip-0125.mediawiki#summary

--- a/src/families/bitcoin/wallet-btc/storage/index.ts
+++ b/src/families/bitcoin/wallet-btc/storage/index.ts
@@ -56,8 +56,8 @@ class BitcoinLikeStorage implements IStorage {
     return tx;
   }
 
-  getTx(address: string, hash: string) {
-    const index = `${address}-${hash}`;
+  getTx(address: string, txId: string) {
+    const index = `${address}-${txId}`;
     return this.txs[this.primaryIndex[index]];
   }
 
@@ -72,7 +72,7 @@ class BitcoinLikeStorage implements IStorage {
 
     txs.forEach((tx) => {
       const indexAddress = tx.address;
-      const index = `${indexAddress}-${tx.hash}`;
+      const index = `${indexAddress}-${tx.id}`;
 
       // we reject already seen tx
       if (this.txs[this.primaryIndex[index]]) {
@@ -142,7 +142,7 @@ class BitcoinLikeStorage implements IStorage {
     this.txs.forEach((tx: TX) => {
       // clean
       const indexAddress = tx.address;
-      const index = `${indexAddress}-${tx.hash}`;
+      const index = `${indexAddress}-${tx.id}`;
 
       if (tx.account !== txsFilter.account || tx.index !== txsFilter.index) {
         this.primaryIndex[index] = newTxs.push(tx) - 1;
@@ -166,7 +166,7 @@ class BitcoinLikeStorage implements IStorage {
     this.txs.forEach((tx: TX) => {
       // clean
       const indexAddress = tx.address;
-      const index = `${indexAddress}-${tx.hash}`;
+      const index = `${indexAddress}-${tx.id}`;
 
       if (tx.account !== txsFilter.account || tx.index !== txsFilter.index) {
         this.primaryIndex[index] = newTxs.push(tx) - 1;

--- a/src/families/bitcoin/wallet-btc/storage/types.ts
+++ b/src/families/bitcoin/wallet-btc/storage/types.ts
@@ -1,5 +1,5 @@
 export interface TX {
-  hash: string;
+  id: string;
   account: number;
   index: number;
   received_at: string;
@@ -50,7 +50,7 @@ export interface IStorage {
     confirmed?: boolean;
   }): TX | undefined;
   getLastUnconfirmedTx(): TX | undefined;
-  getTx(address: string, hash: string): TX | undefined;
+  getTx(address: string, txId: string): TX | undefined;
   getUniquesAddresses(addressesFilter: {
     account?: number;
     index?: number;


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LIVE-1931
1. we read the "hash" field from explorer for each transaction, now we use id field instead.
2. fix bch bot