### PR TITLE
LIVE-1994 [BTC family] fix account index undefined

### DIFF
--- a/src/families/bitcoin/wallet-btc/storage/index.ts
+++ b/src/families/bitcoin/wallet-btc/storage/index.ts
@@ -216,10 +216,7 @@ class BitcoinLikeStorage implements IStorage {
     this.unspentUtxos = data.unspentUtxos;
     this.addressCache = data.addressCache;
     Base.addressCache = { ...Base.addressCache, ...this.addressCache };
-    if (
-      (!this.accountIndex || isEmpty(this.accountIndex)) &&
-      this.txs.length > 0
-    ) {
+    if (!this.accountIndex || isEmpty(this.accountIndex)) {
       this.accountIndex = {};
       this.createAccountIndex();
     }


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LIVE-1994

A bug detected by QA
when an account doesn't have any transaction, and accountIndex doesn't exist in app.json.
then this account receives funds and need to use accountIndex to sync
it causes this.accountIndex is undefined

So the fix should make sure this.accountIndex is not undefined even if there is no transaction