### PR TITLE
feat: add amount display to Send—'Transfer All' flow's confirmation step

### DIFF
--- a/src/families/hedera/deviceTransactionConfig.ts
+++ b/src/families/hedera/deviceTransactionConfig.ts
@@ -25,11 +25,12 @@ function getDeviceTransactionConfig({
       label: "Method",
       value: "Transfer",
     });
-    fields.push({
-      type: "amount",
-      label: "Amount",
-    });
   }
+
+  fields.push({
+    type: "amount",
+    label: "Amount",
+  });
 
   if (!estimatedFees.isZero()) {
     fields.push({


### PR DESCRIPTION
## Description:
- Add `Amount` display to confirmation step for transferring a specific amount of hbars and transferring all hbars. It was missing for the latter; this PR will fix that!

<img width="505" alt="Screen Shot 2022-04-14 at 09 52 00" src="https://user-images.githubusercontent.com/22848332/163487661-6341f423-2241-49e2-9575-c89c26389fb0.png">

