### PR TITLE
[Celo integration] Fix amount calculation in send max when fees exceed spendable amount

### DIFF
--- a/src/families/celo/js-getTransactionStatus.ts
+++ b/src/families/celo/js-getTransactionStatus.ts
@@ -29,9 +29,11 @@ const getTransactionStatus = async (
 
   const estimatedFees = transaction.fees || new BigNumber(0);
 
-  const amount = useAllAmount
+  let amount = useAllAmount
     ? account.spendableBalance.minus(estimatedFees)
     : new BigNumber(transaction.amount);
+
+  if (amount.lt(0)) amount = new BigNumber(0);
 
   if (amount.lte(0) && !transaction.useAllAmount) {
     errors.amount = new AmountRequired();


### PR DESCRIPTION
## Context (issues, jira)
This fixes amount calculation in send max when fees exceed spendable amount. In this case we just set amount to 0.

### Before:
![CleanShot 2022-04-19 at 12 07 31](https://user-images.githubusercontent.com/1530318/163982161-00843246-77ad-49cc-9678-484ce7e96c9f.jpeg)

### After:
![CleanShot 2022-04-19 at 12 10 03](https://user-images.githubusercontent.com/1530318/163982194-940ceb34-4d4d-4c9b-a172-c0b15d171aa9.jpeg)



## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
