### PR TITLE
fixing an odd crash caused by the getProviders function

### DIFF
--- a/src/exchange/swap/getProviders.ts
+++ b/src/exchange/swap/getProviders.ts
@@ -13,7 +13,7 @@ const getProviders: GetProviders = async () => {
   });
 
   if (!res.data.length) {
-    return new SwapNoAvailableProviders();
+    throw new SwapNoAvailableProviders();
   }
 
   return res.data;


### PR DESCRIPTION
## Context (issues, jira)

[LIVE-2126](https://ledgerhq.atlassian.net/browse/LIVE-2126)

## Description / Usage

Fixed an odd bug where the Error() what returned instead of being throw.

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
