### PR TITLE
[FEAT][FTX] LIVE-1947 forward swap state

### DIFF
--- a/src/exchange/swap/index.ts
+++ b/src/exchange/swap/index.ts
@@ -7,6 +7,7 @@ import getKYCStatus from "./getKYCStatus";
 import submitKYC from "./submitKYC";
 import initSwap from "./initSwap";
 import checkQuote from "./checkQuote";
+import { postSwapAccepted, postSwapCancelled } from "./postSwapState";
 import { getEnv } from "../../env";
 import {
   JSONRPCResponseError,
@@ -181,6 +182,8 @@ export {
   getStatus,
   getExchangeRates,
   getCompleteSwapHistory,
+  postSwapAccepted,
+  postSwapCancelled,
   initSwap,
   getKYCStatus,
   submitKYC,

--- a/src/exchange/swap/initSwap.ts
+++ b/src/exchange/swap/initSwap.ts
@@ -32,6 +32,7 @@ const withDevicePromise = (deviceId, fn) =>
 // throw if TransactionStatus have errors
 // you get at the end a final Transaction to be done (it's not yet signed, nor broadcasted!) and a swapId
 const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
+  let swapId;
   let { transaction } = input;
   const { exchange, exchangeRate, deviceId, userId } = input;
 
@@ -40,7 +41,6 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
     let unsubscribed = false;
 
     const confirmSwap = async () => {
-      let swapId;
       let ignoreTransportError;
       log("swap", `attempt to connect to ${deviceId}`);
       await withDevicePromise(deviceId, async (transport) => {
@@ -109,6 +109,7 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
           o.next({
             type: "init-swap-error",
             error: new SwapGenericAPIError(),
+            swapId,
           });
           o.complete();
           return;
@@ -315,6 +316,7 @@ const initSwap = (input: InitSwapInput): Observable<SwapRequestEvent> => {
         o.next({
           type: "init-swap-error",
           error: e,
+          swapId,
         });
         o.complete();
         unsubscribed = true;

--- a/src/exchange/swap/mock.ts
+++ b/src/exchange/swap/mock.ts
@@ -8,6 +8,8 @@ import type {
   KYCStatus,
   SwapRequestEvent,
   ValidKYCStatus,
+  PostSwapAccepted,
+  PostSwapCancelled,
 } from "./types";
 import { getAccountUnit } from "../../account";
 import type { Transaction, TokenCurrency, CryptoCurrency } from "../../types";
@@ -253,4 +255,25 @@ export const mockCheckQuote: CheckQuote = async ({
         description: "Something unexpected happened",
       };
   }
+};
+
+export const mockPostSwapAccepted: PostSwapAccepted = async ({
+  provider,
+  swapId,
+  transactionId,
+}) => {
+  //Fake delay to simulate network
+  await new Promise((r) => setTimeout(r, 800));
+
+  return null;
+};
+
+export const mockPostSwapCancelled: PostSwapCancelled = async ({
+  provider,
+  swapId,
+}) => {
+  //Fake delay to simulate network
+  await new Promise((r) => setTimeout(r, 800));
+
+  return null;
 };

--- a/src/exchange/swap/postSwapState.ts
+++ b/src/exchange/swap/postSwapState.ts
@@ -1,0 +1,37 @@
+import network from "../../network";
+import { getSwapAPIBaseURL } from "./";
+import type { PostSwapAccepted, PostSwapCancelled } from "./types";
+import { getEnv } from "../../env";
+import { mockPostSwapAccepted, mockPostSwapCancelled } from "./mock";
+
+export const postSwapAccepted: PostSwapAccepted = async ({
+  provider,
+  swapId,
+  transactionId,
+}) => {
+  if (getEnv("MOCK"))
+    return mockPostSwapAccepted({ provider, swapId, transactionId });
+
+  await network({
+    method: "POST",
+    url: `${getSwapAPIBaseURL()}/swap/accepted`,
+    data: { provider, swapId, transactionId },
+  });
+
+  return null;
+};
+
+export const postSwapCancelled: PostSwapCancelled = async ({
+  provider,
+  swapId,
+}) => {
+  if (getEnv("MOCK")) return mockPostSwapCancelled({ provider, swapId });
+
+  await network({
+    method: "POST",
+    url: `${getSwapAPIBaseURL()}/swap/cancelled`,
+    data: { provider, swapId },
+  });
+
+  return null;
+};

--- a/src/exchange/swap/types.ts
+++ b/src/exchange/swap/types.ts
@@ -143,6 +143,31 @@ export type SwapStatus = {
   status: ValidSwapStatus;
 };
 export type GetStatus = (arg0: SwapStatusRequest) => Promise<SwapStatus>;
+
+// -----
+// Related to Swap state API call (accepted or cancelled)
+
+type SwapStateRequest = {
+  provider: string;
+  swapId: string;
+};
+
+export type SwapStateAcceptedRequest = SwapStateRequest & {
+  transactionId: string;
+};
+
+export type SwapStateCancelledRequest = SwapStateRequest;
+
+export type PostSwapAccepted = (
+  arg0: SwapStateAcceptedRequest
+) => Promise<null>;
+
+export type PostSwapCancelled = (
+  arg0: SwapStateCancelledRequest
+) => Promise<null>;
+
+// -----
+
 export type UpdateAccountSwapStatus = (
   arg0: Account
 ) => Promise<Account | null | undefined>;

--- a/src/exchange/swap/types.ts
+++ b/src/exchange/swap/types.ts
@@ -123,6 +123,10 @@ export type InitSwapResult = {
   transaction: Transaction;
   swapId: string;
 };
+export type InitSwapErrorResult = {
+  error: Error;
+  swapId: string;
+};
 type ValidSwapStatus =
   | "pending"
   | "onhold"
@@ -155,6 +159,7 @@ export type SwapRequestEvent =
   | {
       type: "init-swap-error";
       error: Error;
+      swapId: string;
     }
   | {
       type: "init-swap-result";

--- a/src/hw/actions/initSwap.ts
+++ b/src/hw/actions/initSwap.ts
@@ -12,13 +12,14 @@ import type {
   Exchange,
   ExchangeRate,
   InitSwapResult,
+  InitSwapErrorResult,
   SwapRequestEvent,
 } from "../../exchange/swap/types";
 
 type State = {
   initSwapResult: InitSwapResult | null | undefined;
   initSwapRequested: boolean;
-  initSwapError: Error | null | undefined;
+  initSwapErrorResult: InitSwapErrorResult | null | undefined;
   error?: Error;
   isLoading: boolean;
   freezeReduxDevice: boolean;
@@ -39,28 +40,28 @@ type Result =
       initSwapResult: InitSwapResult;
     }
   | {
-      initSwapError: Error;
+      initSwapErrorResult: InitSwapErrorResult;
     };
 
 type InitSwapAction = Action<InitSwapRequest, InitSwapState, Result>;
 
 const mapResult = ({
   initSwapResult,
-  initSwapError,
+  initSwapErrorResult,
 }: InitSwapState): Result | null | undefined =>
   initSwapResult
     ? {
         initSwapResult,
       }
-    : initSwapError
+    : initSwapErrorResult
     ? {
-        initSwapError,
+        initSwapErrorResult,
       }
     : null;
 
 const initialState: State = {
   initSwapResult: null,
-  initSwapError: null,
+  initSwapErrorResult: null,
   initSwapRequested: false,
   isLoading: true,
   freezeReduxDevice: false,
@@ -72,7 +73,11 @@ const reducer = (state: State, e: SwapRequestEvent) => {
       return { ...state, freezeReduxDevice: true };
 
     case "init-swap-error":
-      return { ...state, initSwapError: e.error, isLoading: false };
+      return {
+        ...state,
+        initSwapErrorResult: { error: e.error, swapId: e.swapId },
+        isLoading: false,
+      };
 
     case "init-swap-requested":
       return {


### PR DESCRIPTION
## Context (issues, jira)

https://ledgerhq.atlassian.net/browse/LIVE-1947

Add endpoints used by LLD and LLM to provide swap state (accepted or declined) to our backend to be forwarded to partner

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
