### PR TITLE
Fixes LIVE-2166: nftsFromOperations was mutating account.operations

### DIFF
--- a/src/families/ethereum/nft.unit.test.ts
+++ b/src/families/ethereum/nft.unit.test.ts
@@ -141,7 +141,9 @@ describe("OpenSea lazy minting bs", () => {
     // -2 off-chain & -3 on-chain -> 0 on-chain (3 off-chain)
     // +1 on-chain -> 1 on-chain (and 3 off-chain)
 
+    const prevOperations = ops.slice(0);
     const nfts = nftsFromOperations(ops);
+    expect(prevOperations).toEqual(ops); // ensure preserved order of operations
     expect(nfts[0].amount.toNumber()).toBe(1);
   });
 });

--- a/src/nft/helpers.ts
+++ b/src/nft/helpers.ts
@@ -16,6 +16,7 @@ import { API, apiForCurrency } from "../api/Ethereum";
 
 export const nftsFromOperations = (ops: Operation[]): ProtoNFT[] => {
   const nftsMap = ops
+    .slice(0)
     // make sure we have the operation in chronological order (older first)
     .sort((a, b) => a.date.getTime() - b.date.getTime())
     // if ops are Operations get the prop nftOperations, else ops are considered nftOperations already


### PR DESCRIPTION
ops.sort()  is mutating ops, so we must protect this to happen.

It was the cause of a bad reordering operations issue on Ethereum.

A test was brought to also ensure we don't regress.