### PR TITLE
LIVE-1940 : Change Cosmos validators limit from 130 to 175

### DIFF
--- a/src/families/cosmos/__snapshots__/bridge.test.ts.snap
+++ b/src/families/cosmos/__snapshots__/bridge.test.ts.snap
@@ -63,9 +63,9 @@ Array [
     "xpub": "cosmos108uy5q9jt59gwugq5yrdhkzcd9jryslmpcstk5",
   },
   Object {
-    "balance": "478443",
+    "balance": "470724",
     "cosmosResources": Object {
-      "delegatedBalance": "1000",
+      "delegatedBalance": "0",
       "withdrawAddress": "cosmos1cgc696ay2pg6d4gcejek2y8la66j7e5y3c7kyw",
     },
     "currencyId": "cosmos",
@@ -82,7 +82,7 @@ Array [
     "index": 2,
     "name": "Cosmos 3",
     "nfts": undefined,
-    "operationsCount": 8,
+    "operationsCount": 9,
     "pendingOperations": Array [],
     "seedIdentifier": "0388459b2653519948b12492f1a0b464720110c147a8155d23d423a5cc3c21d89a",
     "starred": false,
@@ -1120,6 +1120,31 @@ Array [
       "transactionSequenceNumber": 0,
       "type": "OUT",
       "value": "6565",
+    },
+    Object {
+      "accountId": "js:2:cosmos:cosmos1cgc696ay2pg6d4gcejek2y8la66j7e5y3c7kyw:",
+      "blockHash": null,
+      "blockHeight": "10337853",
+      "contract": undefined,
+      "extra": Object {
+        "validators": Array [
+          Object {
+            "address": "cosmosvaloper17zcpywlhgcpk7ff505vr8mnc4wwpv5fcta6enz",
+            "amount": "1000",
+          },
+        ],
+      },
+      "fee": "7719",
+      "hash": "DD5085AF922A2BAD032131A2F9168EB1498E615063ECBC6C86CE31D5B9981E2A",
+      "id": "js:2:cosmos:cosmos1cgc696ay2pg6d4gcejek2y8la66j7e5y3c7kyw:-DD5085AF922A2BAD032131A2F9168EB1498E615063ECBC6C86CE31D5B9981E2A-UNDELEGATE",
+      "operator": undefined,
+      "recipients": Array [],
+      "senders": Array [],
+      "standard": undefined,
+      "tokenId": undefined,
+      "transactionSequenceNumber": 27,
+      "type": "UNDELEGATE",
+      "value": "7719",
     },
     Object {
       "accountId": "js:2:cosmos:cosmos1cgc696ay2pg6d4gcejek2y8la66j7e5y3c7kyw:",

--- a/src/families/cosmos/validators.ts
+++ b/src/families/cosmos/validators.ts
@@ -31,7 +31,7 @@ const cacheValidators = makeLRUCache(
     if (isStargate(currency)) {
       const url = `${getBaseApiUrl(
         currency
-      )}/${namespace}/staking/${version}/validators?status=BOND_STATUS_BONDED&pagination.limit=130`;
+      )}/${namespace}/staking/${version}/validators?status=BOND_STATUS_BONDED&pagination.limit=175`;
       const { data } = await network({
         url,
         method: "GET",


### PR DESCRIPTION
## Context (issues, jira)
 
I changed the cosmos validators limit from 130 to 175

## Description / Usage

https://ledgerhq.atlassian.net/browse/LIVE-1940

ledger-live-common/src/families/cosmos/validators.ts : 
/${namespace}/staking/${version}/validators?status=BOND_STATUS_BONDED&pagination.limit=175`

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
