### PR TITLE
Support: Changing NFT link provider matching backend response

### DIFF
--- a/src/types/nft.ts
+++ b/src/types/nft.ts
@@ -36,7 +36,7 @@ export type NFT = Omit<ProtoNFT, "metadata"> & {
   metadata: NFTMetadata;
 };
 
-export type NFTMetadataLinksProviders = "opensea" | "rarible" | "etherscan";
+export type NFTMetadataLinksProviders = "opensea" | "rarible" | "explorer";
 
 export type NFTMetadataResponse = {
   status: 200 | 404 | 500;


### PR DESCRIPTION
## Context (issues, jira)

Changing NFT Type to match the new chain agnostic response for nft links.
<img width="622" alt="Screenshot 2022-05-04 at 20 20 29" src="https://user-images.githubusercontent.com/44363395/166800744-df9f4ab1-21d5-4062-833e-80e7dfdcbe96.png">

## Description / Usage

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [x] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
