### PR TITLE
LIVE-1292 Cover Polkadot existential deposit edge case

### DIFF
--- a/src/families/polkadot/js-getTransactionStatus.ts
+++ b/src/families/polkadot/js-getTransactionStatus.ts
@@ -36,6 +36,7 @@ import {
   calculateAmount,
   getMinimumAmountToBond,
   getMinimumBalance,
+  EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN,
 } from "./logic";
 import { isValidAddress } from "./address";
 import { getCurrentPolkadotPreloadData } from "./preload";
@@ -77,7 +78,11 @@ const getSendTransactionStatus = async (
   const minimumBalanceExistential = getMinimumBalance(a);
   const leftover = a.spendableBalance.minus(totalSpent);
 
-  if (a.spendableBalance.lte(EXISTENTIAL_DEPOSIT)) {
+  if (
+    a.spendableBalance.lte(
+      EXISTENTIAL_DEPOSIT.plus(EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN)
+    )
+  ) {
     errors.amount = new NotEnoughBalance();
   } else if (
     minimumBalanceExistential.gt(0) &&

--- a/src/families/polkadot/js-getTransactionStatus.ts
+++ b/src/families/polkadot/js-getTransactionStatus.ts
@@ -77,7 +77,9 @@ const getSendTransactionStatus = async (
   const minimumBalanceExistential = getMinimumBalance(a);
   const leftover = a.spendableBalance.minus(totalSpent);
 
-  if (
+  if (a.spendableBalance.lte(EXISTENTIAL_DEPOSIT)) {
+    errors.amount = new NotEnoughBalance();
+  } else if (
     minimumBalanceExistential.gt(0) &&
     leftover.lt(minimumBalanceExistential) &&
     leftover.gt(0)

--- a/src/families/polkadot/js-signOperation.ts
+++ b/src/families/polkadot/js-signOperation.ts
@@ -42,19 +42,14 @@ const MODE_TO_PALLET_METHOD = {
 };
 
 const getExtra = (type: string, account: Account, transaction: Transaction) => {
-  const extra = MODE_TO_PALLET_METHOD[transaction.mode]
-    ? {
-        palletMethod:
-          MODE_TO_PALLET_METHOD[
-            transaction.mode === "bond" && !isFirstBond(account)
-              ? "bondExtra"
-              : transaction.mode
-          ],
-      }
-    : {};
+  const extra = {
+    palletMethod: MODE_TO_PALLET_METHOD[transaction.mode],
+  };
 
   if (transaction.mode == "send" && transaction.useAllAmount) {
     extra.palletMethod = MODE_TO_PALLET_METHOD["sendMax"];
+  } else if (transaction.mode === "bond" && !isFirstBond(account)) {
+    extra.palletMethod = MODE_TO_PALLET_METHOD["bondExtra"];
   }
 
   switch (type) {

--- a/src/families/polkadot/js-signOperation.ts
+++ b/src/families/polkadot/js-signOperation.ts
@@ -29,6 +29,7 @@ const MODE_TO_TYPE = {
 };
 const MODE_TO_PALLET_METHOD = {
   send: "balances.transferKeepAlive",
+  sendMax: "balances.transfer",
   bond: "staking.bond",
   bondExtra: "staking.bondExtra",
   unbond: "staking.unbond",
@@ -51,6 +52,10 @@ const getExtra = (type: string, account: Account, transaction: Transaction) => {
           ],
       }
     : {};
+
+  if (transaction.mode == "send" && transaction.useAllAmount) {
+    extra.palletMethod = MODE_TO_PALLET_METHOD["sendMax"];
+  }
 
   switch (type) {
     case "OUT":

--- a/src/families/polkadot/logic.ts
+++ b/src/families/polkadot/logic.ts
@@ -3,7 +3,7 @@ import type { Account, OperationType } from "../../types";
 import type { Transaction } from "./types";
 import { getCurrentPolkadotPreloadData } from "./preload";
 
-export const EXISTENTIAL_DEPOSIT = new BigNumber(10000000000);
+export const EXISTENTIAL_DEPOSIT = new BigNumber(11000000000);
 export const MAX_NOMINATIONS = 16;
 export const MAX_UNLOCKINGS = 32;
 export const PRELOAD_MAX_AGE = 60 * 1000;

--- a/src/families/polkadot/logic.ts
+++ b/src/families/polkadot/logic.ts
@@ -3,7 +3,8 @@ import type { Account, OperationType } from "../../types";
 import type { Transaction } from "./types";
 import { getCurrentPolkadotPreloadData } from "./preload";
 
-export const EXISTENTIAL_DEPOSIT = new BigNumber(11000000000);
+export const EXISTENTIAL_DEPOSIT = new BigNumber(10000000000);
+export const EXISTENTIAL_DEPOSIT_RECOMMENDED_MARGIN = new BigNumber(1000000000); // Polkadot recommended Existential Deposit error margin
 export const MAX_NOMINATIONS = 16;
 export const MAX_UNLOCKINGS = 32;
 export const PRELOAD_MAX_AGE = 60 * 1000;


### PR DESCRIPTION
## Context (issues, jira)

https://ledgerhq.atlassian.net/browse/LIVE-1292

## Description / Usage

When trying to emptied an account, it doesn't work.
This happens when the balance is at ~1 DOT, this is a limitation of the Polkadot blockchain.
The logic of Ledger Live Common was not adapted, this PR fix this.

This PR also contains a fix on the optimistic operation which does not contain the correct type when it is a send max.

<!-- please share a sample of code that uses your new code (if features were added) -->
<!-- please document quickly what would the "user land" need to do to use the feature -->

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
