### PR TITLE
Fixes on max spendable balance function

### DIFF
--- a/src/families/filecoin/bridge/utils/types.ts
+++ b/src/families/filecoin/bridge/utils/types.ts
@@ -1,5 +1,5 @@
 export interface EstimatedFeesRequest {
-  to: string;
+  to?: string;
   from: string;
 }
 


### PR DESCRIPTION
## Context (issues, jira)
Filecoin integration


## Description / Usage

- estimate fees when there is not recipient address
- avoid to generate spendable balance as negative


## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [ ] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.

<!--
If one of these can't be checked, please document it carefully (on the reason you can't check it).
NB: We want to avoid as much as possible such breaking changes to make a bump very easy.
-->
