### PR TITLE
useCurrenciesByMarketcapWithStatus

### DIFF
--- a/src/currencies/index.ts
+++ b/src/currencies/index.ts
@@ -7,6 +7,7 @@ import {
   useMarketcapTickers,
   currenciesByMarketcap,
   useCurrenciesByMarketcap,
+  useCurrenciesByMarketcapWithStatus,
 } from "./sortByMarketcap";
 import {
   listFiatCurrencies,
@@ -54,6 +55,7 @@ export {
   useMarketcapTickers,
   currenciesByMarketcap,
   useCurrenciesByMarketcap,
+  useCurrenciesByMarketcapWithStatus,
   listFiatCurrencies,
   listCryptoCurrencies,
   getFiatCurrencyByTicker,

--- a/src/currencies/sortByMarketcap.ts
+++ b/src/currencies/sortByMarketcap.ts
@@ -107,3 +107,36 @@ export const useCurrenciesByMarketcap = <C extends Currency>(
   const tickers = useMarketcapTickers();
   return tickers ? sortByMarketcap(currencies, tickers) : currencies;
 };
+
+type CurrenciesByMarketcapResult = {
+  loading: boolean;
+  error?: Error;
+  currencies?: any[];
+};
+
+export const useCurrenciesByMarketcapWithStatus = <C extends Currency>(
+  currencies: C[]
+): CurrenciesByMarketcapResult => {
+  const [status, setStatus] = useState<CurrenciesByMarketcapResult>({
+    loading: false,
+  });
+
+  useEffect(() => {
+    function getCurrenciesByMarketcap() {
+      setStatus({ loading: true });
+      getMarketcapTickers()
+        .then((tickers) => {
+          setStatus({
+            loading: false,
+            currencies: sortByMarketcap(currencies, tickers),
+          });
+        })
+        .catch((error: Error) => {
+          setStatus({ loading: false, error, currencies });
+        });
+    }
+    getCurrenciesByMarketcap();
+  }, []);
+
+  return status;
+};


### PR DESCRIPTION
## Context (issues, jira)

Current hook to get data by marketcap was async and missing some info.
I created this new one to get loading status and errors to handle those informations on UI.
Here is the issue [LIVE-1982].

Using this one I will be able to get an empty state until the loading or error state switch.

## Description / Usage

```tsx
const { loading, error, currencies } = useCurrenciesByMarketcapWithStatus(
    cryptoCurrencies,
);
```

## Expectations

- [ ] **Test coverage: The changes of this PR are covered by test.** Unit test were added with mocks when depending on a backend/device.
- [*] **No impact: The changes of this PR have ZERO impact on the userland.** Meaning, we can use these changes without modifying LLD/LLM at all. It will be a "noop" and the maintainers will be able to bump it without changing anything.


[LIVE-1982]: https://ledgerhq.atlassian.net/browse/LIVE-1982?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ